### PR TITLE
Option for copying files (instead of symlinking)

### DIFF
--- a/modules/minecraft-servers.nix
+++ b/modules/minecraft-servers.nix
@@ -300,10 +300,10 @@ in
               symlinks = {
                 "eula.txt" = eulaFile;
               } // conf.symlinks;
-              files = {
-                "whitelist.json" = mkIf (conf.whitelist != { }) whitelistFile;
-                "server.properties" = mkIf (conf.serverProperties != { }) serverPropertiesFile;
-              } // conf.files;
+              files =
+                (optionalAttrs (conf.whitelist != { }) { "whitelist.json" = whitelistFile; }) //
+                (optionalAttrs (conf.serverProperties != { }) { "server.properties" = serverPropertiesFile; }) //
+                conf.files;
 
               startScript = pkgs.writeScript "minecraft-start-${name}" ''
                 #!${pkgs.runtimeShell}

--- a/modules/minecraft-servers.nix
+++ b/modules/minecraft-servers.nix
@@ -377,6 +377,23 @@ in
                 postStart = ''
                   ${pkgs.coreutils}/bin/chmod 660 ${tmuxSock}
                 '';
+
+                postStop =
+                  let
+                    rmSymlinks = pkgs.writeShellScript "minecraft-server-${name}-rm-symlinks"
+                      (concatStringsSep "\n"
+                        (mapAttrsToList (n: v: "unlink ${n}") symlinks)
+                      );
+                    rmFiles = pkgs.writeShellScript "minecraft-server-${name}-rm-files"
+                      (concatStringsSep "\n"
+                        (mapAttrsToList (n: v: "rm -f ${n}") files)
+                      );
+                  in
+                  ''
+                    cd ${serverDir}
+                    ${rmSymlinks}
+                    ${rmFiles}
+                  '';
               };
             })
           servers;

--- a/modules/minecraft-servers.nix
+++ b/modules/minecraft-servers.nix
@@ -361,6 +361,7 @@ in
                               echo "${n} already exists, moving"
                               mv "${n}" "${n}.bak"
                             fi
+                            mkdir -p $(dirname ${n})
                             cp -L --no-preserve all ${v} ${n}
                           '')
                           files));


### PR DESCRIPTION
Hello!

First of all, thanks a lot for this awesome module!

I've been trying to get a full minecraft server network going, and it's been going great! I've made a couple of changes for my own use, so here's one of them, in case you're interested.

The ideia is that a lot of configuration files (specially plugins) behave terribly when faced with the read-only fs link destinations. Paper, for example, completely crashes if `config/paper.yml` is read-only.
A solution I've come up with is adding a `files` option that behaves similarly to `symlinks`, but it dereferences the file, making it mutable. That way, the plugin/mod/server can behave as expected, while keeping reproducibility (as the files are copied again each time the service starts).

An existing file with the same name is only backed up if: 1) it's not a symlink 2) it's different to the one being copied (that way a useless `.bak` won't replace a potentially useful one).

I've also went ahead and added a `mkdir` command, so that any parent directories are created (both for files and for symlinks).