### PR TITLE
module: getExe instead of /bin/minecraft-server

### DIFF
--- a/modules/minecraft-servers.nix
+++ b/modules/minecraft-servers.nix
@@ -265,7 +265,7 @@ in
 
                 umask u=rwx,g=rwx,o=rx
                 cd ${serverDir}
-                ${tmux} -S ${tmuxSock} new -d ${conf.package}/bin/minecraft-server ${conf.jvmOpts}
+                ${tmux} -S ${tmuxSock} new -d ${getExe conf.package} ${conf.jvmOpts}
               '';
 
               stopScript = pkgs.writeScript "minecraft-stop-${name}" ''


### PR DESCRIPTION
Use `lib.getExe` instead of assuming the executable is named `minecraft-server`.