### PR TITLE
fix(minecraft-servers): don't clear runtime dir

### DIFF
--- a/modules/minecraft-servers.nix
+++ b/modules/minecraft-servers.nix
@@ -295,6 +295,7 @@ in
                   Type = "forking";
                   GuessMainPID = true;
                   RuntimeDirectory = "minecraft";
+                  RuntimeDirectoryPreserve = "yes";
                 };
 
                 preStart =


### PR DESCRIPTION
Fixes #14

For some reason I just didn't read that RuntimeDirectory was explicitly cleared by systemd with the service stops/restarts.
This led to all of the other tmux sockets becoming lost whenever a server restarted or was stopped.