### PR TITLE
fix: create parent directories for symlinks with nested paths

### DIFF
--- a/modules/minecraft-servers.nix
+++ b/modules/minecraft-servers.nix
@@ -328,6 +328,7 @@ in
                               echo "${n} already exists, moving"
                               mv "${n}" "${n}.bak"
                             fi
+                            mkdir -p $(dirname ${n})
                             ln -sf ${v} ${n}
                           '')
                           conf.symlinks));

--- a/modules/minecraft-servers.nix
+++ b/modules/minecraft-servers.nix
@@ -328,8 +328,8 @@ in
                               echo "${n} already exists, moving"
                               mv "${n}" "${n}.bak"
                             fi
-                            mkdir -p $(dirname ${n})
-                            ln -sf ${v} ${n}
+                            mkdir -p "$(dirname "${n}")"
+                            ln -sf "${v}" "${n}"
                           '')
                           conf.symlinks));
                   in


### PR DESCRIPTION
If the parent directory doesn't exist `ln` will fail, so i `mkdir -p` the parent. My usecase was 
```nix
{
  services.minecraft-servers = {
      enable = true;
      eula = true;
  
      servers = {
        "test" = {
          enable = true;
          openFirewall = true;
  
          package = mcPkgs.paperServers.paper-1_19_3;
  
          symlinks = {
            mods = pkgs.linkFarmFromDrvs "mods" (map mcPkgs.fetchModrinthMod (builtins.attrValues {
              UnifiedMetrics = {
                id = "YREl7q0o";
                hash = "sha256-3/MjbjBI+FkDOiTeHftZuARGIrgexXdAPsrcTfLFih8=";
              };
            }));
  
            "config/unifiedmetrics/config.yml" = pkgs.writeText "unifiedmetrics-config.yml" (builtins.toJSON {
              server.name = "global";
  
              metrics = {
                enabled = true;
                driver = "prometheus";
                collectors = {
                  systemGc = true;
                  systemMemory = true;
                  systemProcess = true;
                  systemThread = true;
                  server = true;
                  world = true;
                  tick = true;
                  events = true;
                };
              };
            });
          };
        };
      };
    };
}
```
failing because `config/unifiedmetrics` didnt get created