### PR TITLE
fix: un-break nix flake show by moving packages into legacyPackages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Documentation of major changes, newest first.
 
+## 2023-04-05: Deprecation of `packages` flake output
+Since the packages are currently wrapped inside of attrsets, the flake is more or less "broken". According to the specs, the `packages` outputs may only contain derivations, no sets.
+Nixpkgs doesn't follow that structure either, that's why it uses the `legacyPackages` output instead. Doing the same thing with this flake "un-breaks" things like `nix flake show`
+
 ## 2023-02-27: Deprecation of `fetchModrinthMod` and `nix-prefetch-modrinth`
 
 `fetchModrinthMod` and `nix-prefetch-modrinth` have been kinda just... bad from the beginning.

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
       overlay = final: prev: packages prev;
       nixosModules = self.lib.rakeLeaves ./modules;
     } // flake-utils.lib.eachDefaultSystem (system: {
-      packages = packages (import nixpkgs {
+      legacyPackages = packages (import nixpkgs {
         inherit system;
         config = { allowUnfree = true; };
       });

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
     , ...
     }@inputs:
     let
-      packages = pkgs:
+      myPackages = pkgs:
         let
           callPackage = pkgs.newScope {
             inherit inputs;
@@ -44,12 +44,13 @@
     {
       lib = import ./lib { lib = flake-utils.lib // nixpkgs.lib; };
 
-      overlay = final: prev: packages prev;
+      overlay = final: prev: myPackages prev;
       nixosModules = self.lib.rakeLeaves ./modules;
-    } // flake-utils.lib.eachDefaultSystem (system: {
-      legacyPackages = packages (import nixpkgs {
+    } // flake-utils.lib.eachDefaultSystem (system: rec {
+      legacyPackages = myPackages (import nixpkgs {
         inherit system;
         config = { allowUnfree = true; };
       });
+      packages = nixpkgs.lib.warn "`packages` is deprecated; use `legacyPackages` instead. see CHANGELOG.md for more information" legacyPackages;
     });
 }


### PR DESCRIPTION
The legacyPackages output was created for nixpkgs which has it's derivations inside of nested attribute sets instead of a single top-level set.
Since this flake also uses nested sets for its packages we can simply make use of this to unbreak it.

Temporary fix until #11 is done
(or welp perhaps even a permanent fix in case #11 doesn't get picked up again)