### PR TITLE
fix: replace stdenv with stdenvNoCC to remove gcc dependency

### DIFF
--- a/pkgs/fabric-servers/loader.nix
+++ b/pkgs/fabric-servers/loader.nix
@@ -1,6 +1,6 @@
 { lib
 , fetchurl
-, stdenv
+, stdenvNoCC
 , unzip
 , zip
 , jre_headless
@@ -10,7 +10,7 @@ let
   lib_lock = lib.importJSON ./libraries.json;
   libraries = lib.forEach lock.libraries (l: fetchurl lib_lock.${l});
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   name = "fabric-server-launch.jar";
   nativeBuildInputs = [ unzip zip jre_headless ];
 

--- a/pkgs/helpers/fetchModrinthMod.nix
+++ b/pkgs/helpers/fetchModrinthMod.nix
@@ -1,5 +1,4 @@
-{ stdenv
-, fetchurl
+{ fetchurl
 , jq
 , id
 , hash

--- a/pkgs/legacy-fabric-servers/loader.nix
+++ b/pkgs/legacy-fabric-servers/loader.nix
@@ -1,6 +1,6 @@
 { lib
 , fetchurl
-, stdenv
+, stdenvNoCC
 , unzip
 , zip
 , jre_headless
@@ -10,7 +10,7 @@ let
   lib_lock = lib.importJSON ./libraries.json;
   libraries = lib.forEach lock.libraries (l: fetchurl lib_lock.${l});
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   name = "fabric-server-launch.jar";
   nativeBuildInputs = [ unzip zip jre_headless ];
 

--- a/pkgs/minecraft-servers/derivation.nix
+++ b/pkgs/minecraft-servers/derivation.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchurl, nixosTests, jre_headless, version, url, sha1 }:
-stdenv.mkDerivation {
+{ lib, stdenvNoCC, fetchurl, nixosTests, jre_headless, version, url, sha1 }:
+stdenvNoCC.mkDerivation {
   pname = "minecraft-server";
   inherit version;
 

--- a/pkgs/paper-servers/derivation.nix
+++ b/pkgs/paper-servers/derivation.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchurl, nixosTests, jre, version, url, sha256 }:
-stdenv.mkDerivation {
+{ lib, stdenvNoCC, fetchurl, nixosTests, jre, version, url, sha256 }:
+stdenvNoCC.mkDerivation {
   pname = "paper";
   inherit version;
 

--- a/pkgs/quilt-servers/loader.nix
+++ b/pkgs/quilt-servers/loader.nix
@@ -1,6 +1,6 @@
 { lib
 , fetchurl
-, stdenv
+, stdenvNoCC
 , unzip
 , zip
 , jre_headless
@@ -10,7 +10,7 @@ let
   lib_lock = lib.importJSON ./libraries.json;
   libraries = lib.forEach lock.libraries (l: fetchurl lib_lock.${l});
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   name = "quilt-server-launch.jar";
   nativeBuildInputs = [ unzip zip jre_headless ];
 

--- a/pkgs/velocity-servers/derivation.nix
+++ b/pkgs/velocity-servers/derivation.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchurl, nixosTests, jre_headless, version, url, sha256, channel ? "default" }:
-stdenv.mkDerivation {
+{ lib, stdenvNoCC, fetchurl, nixosTests, jre_headless, version, url, sha256, channel ? "default" }:
+stdenvNoCC.mkDerivation {
   pname = "velocity";
   inherit version;
 


### PR DESCRIPTION
Now that I think of it it's actually weird for nixpkgs to include a C compiler by default instead of the other way round :thinking: 
Anyway, here's the PR
