### PR TITLE
feat: remove deprecated outputs.packages attribute

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,32 +49,5 @@
         inherit system;
         config = { allowUnfree = true; };
       });
-
-      packages = {
-        inherit (legacyPackages)
-          vanilla-server
-          fabric-server
-          quilt-server
-          paper-server
-          velocity-server
-          minecraft-server
-          nix-modrinth-prefetch;
-      } // (
-        nixpkgs.lib.mapAttrs
-          (name: set: nixpkgs.lib.warn
-            "`${name}` from the `packages` flake output is deprecated. Please use the `legacyPackages` flake output instead."
-            set
-          )
-          {
-            inherit (legacyPackages)
-              vanillaServers
-              fabricServers
-              quiltServers
-              legacyFabricServers
-              paperServers
-              velocityServers
-              minecraftServers;
-          }
-      );
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,8 @@
       lib = import ./lib { lib = flake-utils.lib // nixpkgs.lib; };
 
       overlay = final: prev: mkPackages prev;
+      overlays.default = self.overlay;
+
       nixosModules = self.lib.rakeLeaves ./modules;
     } // flake-utils.lib.eachDefaultSystem (system: rec {
       legacyPackages = mkPackages (import nixpkgs {


### PR DESCRIPTION
Due to the nature of how the packages are exposed in nix-minecraft currently, they do not fit the pattern as required by flakes. This PR removes the packages attribute so to fully rely on legacyPackages instead.

This is done due to all nix tooling that supports flakes complain about the attributes of nix-minecraft (nil_ls, nix flake, etc).

This also closes #11 simply because this repository has grown too much to be able to upkeep such a huge PR. It will likely get repurposed into a hard fork with a smaller scale, current plan being making it fabric only.