### PR TITLE
tests: init

### DIFF
--- a/tests/files-symlinks.nix
+++ b/tests/files-symlinks.nix
@@ -1,0 +1,53 @@
+{ nixosTest, outputs }:
+
+nixosTest {
+  name = "files-symlinks";
+  nodes.server = { config, pkgs, lib, ...}: {
+    nixpkgs = {
+      overlays = [ outputs.overlays.default ];
+      config.allowUnfree = true;
+    };
+    imports = [ outputs.nixosModules.minecraft-servers ];
+
+    services.minecraft-servers = {
+      enable = true;
+      eula = true;
+      servers.paper = {
+        enable = true;
+        jvmOpts = "-Xmx512M"; # Avoid OOM
+        package = pkgs.paperServers.paper-1_19_4;
+        serverProperties = {
+          server-port = 25565;
+          level-type = "flat"; # Make the test lighter
+          online-mode = false;
+        };
+        symlinks = {
+          # To avoid internet access
+          "cache/mojang_1.19.4.jar" = "${pkgs.vanillaServers.vanilla-1_19_4}/lib/minecraft/server.jar";
+        };
+        files = {
+          # A mutable file
+          "ops.json".value = [{
+            name = "Misterio7x";
+            # Offline mode UUID that is derived from the username
+            # Does not need internet to resolve, and never changes.
+            uuid = "b094c46b-90d6-385a-96d9-5e740ed98070";
+            level = 4;
+          }];
+          "spigot.yml".value = {
+            messages.unknown-command = "Unknown command, dummy!";
+          };
+        };
+      };
+    };
+  };
+
+  testScript = { nodes, ... }: ''
+    name = "paper"
+    grep_logs = lambda expr: f"grep '{expr}' /srv/minecraft/{name}/logs/latest.log"
+
+    server.wait_for_unit(f"minecraft-server-{name}.service")
+    server.wait_for_open_port(25565)
+    server.wait_until_succeeds(grep_logs("Done ([0-9.]\+s)! For help, type \"help\""), timeout=30)
+  '';
+}

--- a/tests/simple.nix
+++ b/tests/simple.nix
@@ -1,0 +1,36 @@
+{ nixosTest, outputs }:
+
+nixosTest {
+  name = "simple";
+  nodes.server = { config, pkgs, lib, ...}: {
+    nixpkgs = {
+      overlays = [ outputs.overlays.default ];
+      config.allowUnfree = true;
+    };
+    imports = [ outputs.nixosModules.minecraft-servers ];
+
+    services.minecraft-servers = {
+      enable = true;
+      eula = true;
+      servers.vanilla = {
+        enable = true;
+        jvmOpts = "-Xmx512M"; # Avoid OOM
+        package = pkgs.vanilla-server;
+        serverProperties = {
+          server-port = 25565;
+          level-type = "flat"; # Make the test lighter
+          max-players = 10;
+        };
+      };
+    };
+  };
+
+  testScript = { nodes, ... }: ''
+    name = "vanilla"
+    grep_logs = lambda expr: f"grep '{expr}' /srv/minecraft/{name}/logs/latest.log"
+
+    server.wait_for_unit(f"minecraft-server-{name}.service")
+    server.wait_for_open_port(25565)
+    server.wait_until_succeeds(grep_logs("Done ([0-9.]\+s)! For help, type \"help\""), timeout=30)
+  '';
+}


### PR DESCRIPTION
Hi! This is me again, with the first of 4 PRs this time xD

This PR adds simple NixOS integration tests, which can be run with `nix flake check` (or individually with `nix build .#checks.x86_64-linux.simple`).

For now, there's two:
- Simple: runs the vanilla server and check that it actually started
- Files & Symlinks: runs the paper server, with two nix expression-generated files (ops.json and paper.yml), as well as symlink (a vanilla jar that is nescessary to avoid paper trying to download it at runtime).
    - In a follow-up PR (will open it in a few minutes), I will use this to test command execution:
        - I de-op `Misterio7x`, this mutates the ops.json, so validates that `files` are mutable.
        - I run a unknown command and grep the output, validating that the `paper.yml` `unknown-command` is actually used.
        
     