### PR TITLE
Harden module, use systemd.tmpfiles to create dirs

### DIFF
--- a/modules/minecraft-servers.nix
+++ b/modules/minecraft-servers.nix
@@ -266,6 +266,7 @@ in
             description = "Minecraft server service user";
             home = cfg.dataDir;
             createHome = true;
+            homeMode = "770";
             isSystemUser = true;
             group = "minecraft";
           };
@@ -315,7 +316,7 @@ in
           };
 
         systemd.tmpfiles.rules = mapAttrsToList (name: _:
-          "d '${cfg.dataDir}/${name}' 0700 ${cfg.user} - - -"
+          "d '${cfg.dataDir}/${name}' 0770 ${cfg.user} - - -"
         ) servers;
 
         systemd.services = mapAttrs'

--- a/modules/minecraft-servers.nix
+++ b/modules/minecraft-servers.nix
@@ -265,6 +265,7 @@ in
           users.minecraft = {
             description = "Minecraft server service user";
             home = cfg.dataDir;
+            createHome = true;
             isSystemUser = true;
             group = "minecraft";
           };
@@ -313,16 +314,13 @@ in
             allowedTCPPorts = flatten (mapAttrsToList getTCPPorts toOpen);
           };
 
-        system.activationScripts.minecraft-server-data-dir.text = ''
-          mkdir -p ${cfg.dataDir}
-          chown minecraft:minecraft ${cfg.dataDir}
-          chmod -R 775 ${cfg.dataDir}
-        '';
+        systemd.tmpfiles.rules = mapAttrsToList (name: _:
+          "d '${cfg.dataDir}/${name}' 0700 ${cfg.user} - - -"
+        ) servers;
 
         systemd.services = mapAttrs'
           (name: conf:
             let
-              serverDir = "${cfg.dataDir}/${name}";
               tmux = "${getBin pkgs.tmux}/bin/tmux";
               tmuxSock = "${cfg.runDir}/${name}.sock";
 
@@ -337,9 +335,6 @@ in
 
               startScript = pkgs.writeScript "minecraft-start-${name}" ''
                 #!${pkgs.runtimeShell}
-
-                umask u=rwx,g=rwx,o=rx
-                cd ${serverDir}
                 ${tmux} -S ${tmuxSock} new -d ${getExe conf.package} ${conf.jvmOpts}
               '';
 
@@ -366,6 +361,7 @@ in
                   ExecStart = "${startScript}";
                   ExecStop = "${stopScript} $MAINPID";
                   Restart = conf.restart;
+                  WorkingDirectory = "${cfg.dataDir}/${name}";
                   User = "minecraft";
                   Type = "forking";
                   GuessMainPID = true;
@@ -373,6 +369,27 @@ in
                   RuntimeDirectoryPreserve = "yes";
                   EnvironmentFile = mkIf (cfg.environmentFile != null)
                     (toString cfg.environmentFile);
+
+                  # Hardening
+                  CapabilityBoundingSet = [ "" ];
+                  DeviceAllow = [ "" ];
+                  LockPersonality = true;
+                  PrivateDevices = true;
+                  PrivateTmp = true;
+                  PrivateUsers = true;
+                  ProtectClock = true;
+                  ProtectControlGroups = true;
+                  ProtectHome = true;
+                  ProtectHostname = true;
+                  ProtectKernelLogs = true;
+                  ProtectKernelModules = true;
+                  ProtectKernelTunables = true;
+                  ProtectProc = "invisible";
+                  RestrictNamespaces = true;
+                  RestrictRealtime = true;
+                  RestrictSUIDSGID = true;
+                  SystemCallArchitectures = "native";
+                  UMask = "0007";
                 };
 
                 preStart =
@@ -414,9 +431,6 @@ in
                           files));
                   in
                   ''
-                    umask u=rwx,g=rwx,o=rx
-                    mkdir -p ${serverDir}
-                    cd ${serverDir}
                     ${mkSymlinks}
                     ${mkFiles}
                   '';
@@ -437,7 +451,6 @@ in
                       );
                   in
                   ''
-                    cd ${serverDir}
                     ${rmSymlinks}
                     ${rmFiles}
                   '';


### PR DESCRIPTION
This PR hardens the minecraft service, and in that process uses systemd to create directories (and set permissions), instead of relying on scripts.

Try running `systemd-analyze security`, and you'll see that the current score is < 1. With this PR, it increases to 3.

I also changed the umask from `002` to `007`, this means new files will be `770` and not `775`. I think this is better, as other users (that are not in the group) should not have any access to the files whatsoever.