### PR TITLE
module: replace tmux with systemd socket

### DIFF
--- a/tests/simple.nix
+++ b/tests/simple.nix
@@ -24,9 +24,13 @@ nixosTest {
   testScript = { nodes, ... }: ''
     name = "vanilla"
     grep_logs = lambda expr: f"grep '{expr}' /srv/minecraft/{name}/logs/latest.log"
+    server_cmd = lambda cmd: f"echo '{cmd}' > /run/minecraft-server/{name}.stdin"
 
     server.wait_for_unit(f"minecraft-server-{name}.service")
     server.wait_for_open_port(25565)
     server.wait_until_succeeds(grep_logs("Done ([0-9.]\+s)! For help, type \"help\""), timeout=30)
+
+    server.succeed(server_cmd("list"))
+    server.wait_until_succeeds(grep_logs("There are 0 of a max of 10 players online"), timeout=3)
   '';
 }


### PR DESCRIPTION
Supersedes #41.

---

This PR replaces tmux with a systemd stdin socket. With it, you can easily run commands like so:
```
echo "say Hi" > /run/minecraft/foobar.stdin
```
We now use this to run "stop" (or any custom command) on ExecStop, for a cleaner shutdown.

To complement extraReload, I've added more extra* options for different parts of the lifecycle: extra{Post,Pre}{Start,Stop} (preStop and postStart can run game commands, awesome!).

The tests are also expanded:
- In the simple test: I run `list` and check the output is good.
- In the file/symlinks test:
  - I de-op `Misterio7x` to verify `ops.json` is both mutable and has the correct declaratively-set value
  - I run an unknown command and check the message matches `unknown-command`. As paper mutates `paper.yml` (to fill it up with missing entries) on startup, this verifies that values set through nix-minecraft are kept by it.