### PR TITLE
velocity: fix latest

### DIFF
--- a/pkgs/velocity-servers/default.nix
+++ b/pkgs/velocity-servers/default.nix
@@ -21,7 +21,7 @@ let
             })
           builds))
       versions;
-  stablePackages = map (filter (x: x.meta.branch != "experimental")) packages;
+  stablePackages = filter (x: x != [ ]) (map (filter (x: x.meta.branch != "experimental")) packages);
 in
 recurseIntoAttrs (listToAttrs (
   (map (x: nameValuePair (escapeVersion x.name) x) (flatten packages))


### PR DESCRIPTION
stablePackages previously filtered the experimental builds, but did not account for a possibility where every single build within a version was experimental (the empty list would be kept, thus breaking `last`).

This just happened now with 3.3.0 (where every single build is currently experimental).
```
$ nix build github:infinidoge/nix-minecraft#velocity-server
error:
       … while evaluating the attribute 'velocity-server'

         at /nix/store/63yr5rbdg9wkzbzrz7ww29pyzil33hk2-source/flake.nix:41:11:

           40|           paper-server = paperServers.paper;
           41|           velocity-server = velocityServers.velocity;
             |           ^
           42|           minecraft-server = vanilla-server;

       … while evaluating the attribute 'velocity'

         at /nix/store/35dcag44a0ymww0vy0s4jjgxwpv9g62d-source/lib/attrsets.nix:488:14:

          487|     value:
          488|     { inherit name value; };
             |              ^
          489|

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: lists.last: list must not be empty!
```


This PR makes sure we remove the empty lists.
