### PR TITLE
module: fix assertion for clashing `dataDir`s

### DIFF
--- a/modules/minecraft-servers.nix
+++ b/modules/minecraft-servers.nix
@@ -296,7 +296,7 @@ in
               + " set `services.minecraft-servers.eula` to `true` if you agree.";
           }
           {
-            assertion = !config.services.minecraft-server.enable && cfg.dataDir != config.services.minecraft-server.dataDir;
+            assertion = config.services.minecraft-server.enable -> cfg.dataDir != config.services.minecraft-server.dataDir;
             message = "`services.minecraft-servers.dataDir` and `services.minecraft-server.dataDir` conflict."
               + " Set one to use a different data directory.";
           }


### PR DESCRIPTION
This assertion triggers when `minecraft-server` is not enabled and the `dataDir`s are equal. I'm assuming this is a bug, and the `!` was meant to negate the whole expression (and also swapping the `!=` for an `==`), but I think the implication arrow makes the intent more clear.