### PR TITLE
Add mainProgram to velocity-server derivation

### DIFF
--- a/pkgs/velocity-servers/derivation.nix
+++ b/pkgs/velocity-servers/derivation.nix
@@ -31,5 +31,6 @@ stdenvNoCC.mkDerivation {
     platforms = platforms.unix;
     maintainers = with maintainers; [ misterio77 ];
     branch = channel;
+    mainProgram = "velocity";
   };
 }


### PR DESCRIPTION
Removes the warning when using the velocity-server derivation with the nixos module:
```
trace: warning: getExe: Package "velocity-3.3.0-SNAPSHOT-build.316" does not have the meta.mainProgram attribute.
We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold.
If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away.
Otherwise, if the package does not have a main program, or if you don't control its definition, use getExe' to specify the name to the program, such as lib.getExe' foo "bar".
```