### PR TITLE
Add mutable whitelist and server.properties options

### DIFF
--- a/modules/minecraft-servers.nix
+++ b/modules/minecraft-servers.nix
@@ -242,7 +242,8 @@ in
             description = ''
               Minecraft server properties for the server.properties file of this server. See
               <link xlink:href="https://minecraft.gamepedia.com/Server.properties#Java_Edition_3"/>
-              for documentation on these values.
+              for documentation on these values. Leave <literal>null</iteral> to use a mutable
+              properties file.
             '';
           };
 


### PR DESCRIPTION
As a server owner I want to be able to manage my whitelist imperatively, as it often changes. I allowed specifying null for `whitelist` and `serverProperties` to leave the files mutable when not specified, preventing overwriting with empty files. This is mainly intended for whitelists, but I also implemented it for serverProperties for completeness' sake.
- Whitelist tested and confirmed that changes are not overridden on service restart (when whitelist option is `null`)
- serverProperties I assume works but I haven't tested it, the logic is exactly the same as whitelist.