### PR TITLE
 module: allow management via systemd socket

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+	"[nix]": {
+		"editor.insertSpaces": true,
+		"editor.tabSize": 2
+	},
+	"nix.serverSettings": {
+		"nil": {
+			"formatting": { "command": ["nixpkgs-fmt"] }
+		}
+	},
+	"nix.formatterPath": "nixpkgs-fmt"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Documentation of major changes, newest first.
 
+## 2024-06-07: Addition of systemd-sockets & deprecation of `runDir`
+
+With the addition systemd-socket server management, the `runDir` option has been deprecated.
+Plase configure servers' tmux socket paths via `managementSystem.tmux.socketPath` instead.
+
 ## 2024-05-27: Removal of loader version packages
 
 As per the previous deprecation notice, the old `loader-mcversion-loaderversion` packages have been removed.
@@ -13,7 +18,7 @@ For Fabric, Quilt, and Legacy Fabric servers, the old way of specifying the load
 Instead of using `minecraftServers.fabric-1_19_2-0_14_20` to use loader version `0.14.20`,
 Use `minecraftServers.fabric-1_19_2.override { loaderVersion = "0.14.20"; }`
 
-## 2023-05-13: Removal of attrsets from `packages`.
+## 2023-05-13: Removal of attrsets from `packages`
 
 As per the previous deprecation notice, all of the attrsets in `packages` have been removed, and are instead available under `legacyPackages`.
 

--- a/modules/minecraft-servers.nix
+++ b/modules/minecraft-servers.nix
@@ -176,7 +176,7 @@ let
 
               # Wait for the PID of the minecraft server to disappear before
               # returning, so systemd doesn't attempt to SIGKILL it.
-              tries=3
+              tries=15
               while kill -0 "$1" 2> /dev/null; do
                 if [[ $tries -gt 0 ]]; then
                   sleep 1s

--- a/tests/simple-systemd-socket.nix
+++ b/tests/simple-systemd-socket.nix
@@ -1,0 +1,48 @@
+{ nixosTest, outputs }:
+
+nixosTest {
+  name = "simple-systemd-socket";
+  nodes.server = { config, pkgs, lib, ... }: {
+    imports = [ outputs.nixosModules.minecraft-servers ];
+
+    services.minecraft-servers = {
+      enable = true;
+      eula = true;
+
+      managementSystem.tmux.enable = false;
+
+      servers.vanilla = {
+        managementSystem.systemd-socket = {
+          enable = true;
+          stdinSocket.path = server: "/run/minecraft/my_unusual_socket_path.sock";
+        };
+
+        enable = true;
+        jvmOpts = "-Xmx512M"; # Avoid OOM
+        package = pkgs.vanilla-server;
+        serverProperties = {
+          server-port = 25565;
+          level-type = "flat"; # Make the test lighter
+          max-players = 10;
+        };
+      };
+    };
+  };
+
+  testScript = { nodes, ... }: ''
+    name = "vanilla"
+    grep_logs = lambda expr: f"grep '{expr}' /srv/minecraft/{name}/logs/latest.log"
+    server_cmd = lambda cmd: f"echo '{cmd}' > /run/minecraft/my_unusual_socket_path.sock"
+
+    server.wait_for_unit(f"minecraft-server-{name}.service")
+    server.wait_for_open_port(25565)
+    server.wait_until_succeeds(grep_logs("Done ([0-9.]\+s)! For help, type \"help\""), timeout=30)
+
+    server.succeed(server_cmd("list"))
+    server.wait_until_succeeds(grep_logs("There are 0 of a max of 10 players online"), timeout=3)
+
+    # Trigger unknown-command message, check it works
+    server.succeed(server_cmd("foobar"))
+    server.wait_until_succeeds(grep_logs("Unknown or incomplete command"), timeout=3)
+  '';
+}


### PR DESCRIPTION
Supersedes #52. Partially fixes #63 (per-server user & group configuration missing).

This PR adds a way to make servers managed via a systemd stdin socket and the journal, allowing for a better integrated experience with the rest of the system.

This PR largely builds on top of @Misterio77's excellent #52 and retains the nice additions:
* expanded tests verifying automated command execution
* extra lifecycle hooks for the server services

I did change the default systemd socket path from #52 to be aligned with the current tmux socket path and renamed the lifecycle hooks to preserve the systemd naming convention, though.

I've added a few extras, not all of which I'm sure want to be kept. Feedback welcome. :slightly_smiling_face:
* `docsAsciiDoc` and `docsCommonMark` package outputs (not present in the overlay) to make sure that `nix flake check` verifies that the docs can be built. there was a trivial issue previously, which prevented them from building.
* VS Code config for [nix-ide] specifying the formatter to be `nixpkgs-fmt`, along with the proper indentation.
* per-server management of the socket (both tmux & systemd) paths.

I'm not too sure I like the way server overrides of the global management system config works, but it was all I could conjure with my limited knowledge of advanced usage of the module system.

This PR should be backwards compatible, although some field-testing would be much appreciated as I don't have any real setup to test it on (and frankly no time either :)).