### PR TITLE
build-support: Update asm to version 9.5

### DIFF
--- a/pkgs/build-support/mkTextileLoader.nix
+++ b/pkgs/build-support/mkTextileLoader.nix
@@ -33,7 +33,7 @@ stdenvNoCC.mkDerivation {
     Manifest-Version: 1.0
     Main-Class: ${serverLaunch}
     Name: org/objectweb/asm/
-    Implementation-Version: 9.3
+    Implementation-Version: 9.4
     EOF
 
     ${

--- a/pkgs/build-support/mkTextileLoader.nix
+++ b/pkgs/build-support/mkTextileLoader.nix
@@ -33,7 +33,7 @@ stdenvNoCC.mkDerivation {
     Manifest-Version: 1.0
     Main-Class: ${serverLaunch}
     Name: org/objectweb/asm/
-    Implementation-Version: 9.2
+    Implementation-Version: 9.3
     EOF
 
     ${

--- a/pkgs/build-support/mkTextileLoader.nix
+++ b/pkgs/build-support/mkTextileLoader.nix
@@ -33,7 +33,7 @@ stdenvNoCC.mkDerivation {
     Manifest-Version: 1.0
     Main-Class: ${serverLaunch}
     Name: org/objectweb/asm/
-    Implementation-Version: 9.4
+    Implementation-Version: 9.5
     EOF
 
     ${


### PR DESCRIPTION
Compatibility level "JAVA_21" can't be applied with asm older than 9.5