### PR TITLE
Dynamically set the asm version

### DIFF
--- a/pkgs/build-support/mkTextileLoader.nix
+++ b/pkgs/build-support/mkTextileLoader.nix
@@ -16,6 +16,9 @@
 let
   lib_lock = lib.importJSON ./libraries.json;
   fetchedLibraries = lib.forEach libraries (l: fetchurl lib_lock.${l});
+  asmVersion = builtins.head (builtins.head (
+    builtins.filter (v: v!=null) (builtins.map (builtins.match "org\\.ow2\\.asm:asm:([\.0-9]+)") libraries)
+  ));
 in
 stdenvNoCC.mkDerivation {
   pname = "${loaderName}-server-launch.jar";
@@ -33,7 +36,7 @@ stdenvNoCC.mkDerivation {
     Manifest-Version: 1.0
     Main-Class: ${serverLaunch}
     Name: org/objectweb/asm/
-    Implementation-Version: 9.2
+    Implementation-Version: ${asmVersion}
     EOF
 
     ${

--- a/pkgs/build-support/mkTextileLoader.nix
+++ b/pkgs/build-support/mkTextileLoader.nix
@@ -17,7 +17,7 @@ let
   lib_lock = lib.importJSON ./libraries.json;
   fetchedLibraries = lib.forEach libraries (l: fetchurl lib_lock.${l});
   asmVersion = builtins.head (builtins.head (
-    builtins.filter (v: v!=null) (builtins.map (builtins.match "org\\.ow2\\.asm:asm:([\.0-9]+)") libraries)
+    builtins.filter (v: v!=null) (builtins.map (builtins.match "org\\.ow2\\.asm:asm:([\\.0-9]+)") libraries)
   ));
 in
 stdenvNoCC.mkDerivation {


### PR DESCRIPTION
Added the small workaround to extract the asm version from list of libaries to the [mkTextileLoader.nix](https://github.com/mechan1sm/nix-minecraft/blob/master/pkgs/build-support/mkTextileLoader.nix#L19).

The list of libraries must contain exactly one string matching the following regular expression:
```regex
org\.ow2\.asm:asm:([\.0-9]+)
```
This should fix those errors for fabric/legacy-fabric/quilt servers, cause they are only ones using mkTextileLoader.