### PR TITLE
meta: document overriding custom server jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ All of these packages are also available under `packages`, not just `legacyPacka
 - `velocity-server`: Same as `velocityServers.velocity`
 - `minecraft-server`: Same as `vanilla-server`
 
-Server versions not found above can be manually added via an override.
+Server versions not found above can be manually via an override.
+This override changes the path the launch script to your provided jar file, and does not modify the vanilla jar.
 In this example, uberbukkit.jar exists next to this configuration:
 
 ```nix

--- a/README.md
+++ b/README.md
@@ -208,9 +208,8 @@ All of these packages are also available under `packages`, not just `legacyPacka
 - `velocity-server`: Same as `velocityServers.velocity`
 - `minecraft-server`: Same as `vanilla-server`
 
-Server versions not found above can be manually via an override.
-This override changes the path the launch script uses to your provided jar file, and does not modify the vanilla jar.
-In this example, uberbukkit.jar exists next to this configuration:
+Server versions not found above can be setup manually via an override.
+For example, this override changes the path the launch script uses to your provided jar file, and does not modify the vanilla jar:
 
 ```nix
 let

--- a/README.md
+++ b/README.md
@@ -208,6 +208,23 @@ All of these packages are also available under `packages`, not just `legacyPacka
 - `velocity-server`: Same as `velocityServers.velocity`
 - `minecraft-server`: Same as `vanilla-server`
 
+Server versions not found above can be manually overriden. 
+In this example, uberbukkit.jar exists next to this configuration:
+
+```nix
+let
+  uberBukkit = pkgs.vanillaServers.vanilla.overrideAttrs (oldAttrs: {
+    src = ./uberbukkit.jar;
+  });
+in
+{
+  services.minecraft-servers.servers.beta-server = {
+    enable = true;
+    package = uberBukkit;
+  };
+}
+```
+
 #### `nix-modrinth-prefetch`
 
 [Source](./pkgs/tools/nix-modrinth-prefetch.nix)

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ All of these packages are also available under `packages`, not just `legacyPacka
 - `velocity-server`: Same as `velocityServers.velocity`
 - `minecraft-server`: Same as `vanilla-server`
 
-Server versions not found above can be manually overriden. 
+Server versions not found above can be manually added via an override.
 In this example, uberbukkit.jar exists next to this configuration:
 
 ```nix

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ All of these packages are also available under `packages`, not just `legacyPacka
 - `minecraft-server`: Same as `vanilla-server`
 
 Server versions not found above can be manually via an override.
-This override changes the path the launch script to your provided jar file, and does not modify the vanilla jar.
+This override changes the path the launch script uses to your provided jar file, and does not modify the vanilla jar.
 In this example, uberbukkit.jar exists next to this configuration:
 
 ```nix


### PR DESCRIPTION
Some server jar files are either too niche to be merged into the project, or make my head spin on even attempting to get officially merged with the Python scripting involved to do so. However, I've found it's very easy to override the src of the vanilla server's package to support custom jar files. My small contribution is documenting how to do so and letting people know it's possible :)