### PR TITLE
refactor file & symlink

### DIFF
--- a/modules/minecraft-servers.nix
+++ b/modules/minecraft-servers.nix
@@ -475,9 +475,15 @@ in
             arbitrary files in the server's data directory.
           '';
           files = with types; mkOpt' (attrsOf (either path configType)) { } ''
-            Things to copy into this server's data directory. Similar to
-            symlinks, but these are actual files. Useful for configuration
-            files that don't behave well when read-only.
+            Things to copy into this server's data directory. Similar to symlinks,
+            but these are actual, writable, files. Useful for configuration files
+            that don't behave well when read-only. Directories are copied recursively and
+            dereferenced. They will be deleted after the server stops, so any modification
+            is discarded.
+
+            These files may include placeholders to substitute with values from
+            <option>services.minecraft-servers.environmentFile</option>
+            (i.e. @variable_name@).
           '';
 
           managementSystem = mkOption {

--- a/tests/files-symlinks.nix
+++ b/tests/files-symlinks.nix
@@ -51,5 +51,10 @@ nixosTest {
     # Check that de-opping works (ops.json is mutable as expected)
     server.succeed(server_cmd("deop Misterio7x"))
     server.wait_until_succeeds(grep_logs("Made Misterio7x no longer a server operator"), timeout=3)
+
+    # Check that cleanup works
+    server.wait_until_succeeds(f"systemctl stop minecraft-server-{name}.service")
+    server.fail(f"test -e /srv/minecraft/{name}/cache/mojang_1.19.4.jar")
+    server.fail(f"test -e /srv/minecraft/{name}/ops.json")
   '';
 }


### PR DESCRIPTION
Hi there! I was still bothered by the fact that symlinks/files aren't cleaned up when removed from the config (and stopWhenChanged prevents us from using stuff such as reload), so I decided to try a different approach.

The new system works by adding a file (.nix-minecraft-managed) to track managed files and symlinks. This makes it possible to correctly cleanup managed files (when stopping, restarting, reloading).

I've also added support for directories (https://github.com/Infinidoge/nix-minecraft/issues/73), and ensured only non-binary files are substituted with env vars (https://github.com/Infinidoge/nix-minecraft/issues/70)

Marked as draft as I'm still testing it.

Fixes #73
Fixes #70 