### PR TITLE
Purpur init

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ As of currently, it packages:
   - Legacy Fabric
   - Quilt
   - Paper
+  - Purpur
 - All supported versions of the following:
   - Velocity proxy
 - Various tools
@@ -116,6 +117,12 @@ Since Legacy Fabric does not have a defined newest version to target, it lacks a
 
 If you plan on running paper without internet, you'll have to link the vanilla jar to `cache/mojang_{version}.jar`. The relevant jar is available at the package's `vanillaJar` attribute.
 
+### `purpurServers.*`
+
+[Source](./pkgs/paper-servers)
+
+`purpurServers` functions the same as `paperServers`.
+
 ### `velocityServers.*`
 
 [Source](./pkgs/velocity-servers)
@@ -126,7 +133,7 @@ For convenience, `velocityServers.velocity` is equivalent to the latest version.
 
 ### `minecraftServers.*`
 
-`vanillaServers // fabricServers // quiltServers // legacyFabricServers // paperServers`. Will be used most often as it contains all of the different server versions across each mod loader. When using the overlay, this will replace the Nixpkgs `minecraftServers`.
+`vanillaServers // fabricServers // quiltServers // legacyFabricServers // paperServers // purpurServers`. Will be used most often as it contains all of the different server versions across each mod loader. When using the overlay, this will replace the Nixpkgs `minecraftServers`.
 
 ### `fetchPackwizModpack`
 
@@ -232,6 +239,7 @@ All of these packages are also available under `packages`, not just `legacyPacka
 - `fabric-server`: Same as `fabricServers.fabric`
 - `quilt-server`: Same as `quiltServers.quilt`
 - `paper-server`: Same as `paperServers.paper`
+- `purpur-server`: Same as `purpurServers.purpur`
 - `velocity-server`: Same as `velocityServers.velocity`
 - `minecraft-server`: Same as `vanilla-server`
 

--- a/examples/single-server-with-mods/flake.nix
+++ b/examples/single-server-with-mods/flake.nix
@@ -1,22 +1,22 @@
 {
-   description = "Homelab running Minecraft";
+  description = "Homelab running Minecraft";
 
-   inputs = {
-      nixpkgs.url = "github:NixOS/nixpkgs/release-24.11";
-      nix-minecraft.url = "github:Infinidoge/nix-minecraft";
-   };
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-24.11";
+    nix-minecraft.url = "github:Infinidoge/nix-minecraft";
+  };
 
-   outputs = inputs@{ self, nixpkgs, nix-minecraft, ... }: {
-      nixosConfigurations."edi" = nixpkgs.lib.nixosSystem {
-         system = "x86_64-linux";
-         modules = [
-            ./configuration.nix
-            ./minecraft.nix
-            nix-minecraft.nixosModules.minecraft-servers
-            {
-               nixpkgs.overlays = [ inputs.nix-minecraft.overlay ];
-            }
-         ];
-      };
-   };
+  outputs = inputs@{ self, nixpkgs, nix-minecraft, ... }: {
+    nixosConfigurations."edi" = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        ./configuration.nix
+        ./minecraft.nix
+        nix-minecraft.nixosModules.minecraft-servers
+        {
+          nixpkgs.overlays = [ inputs.nix-minecraft.overlay ];
+        }
+      ];
+    };
+  };
 }

--- a/examples/single-server/configuration.nix
+++ b/examples/single-server/configuration.nix
@@ -7,11 +7,11 @@
     eula = true;
     openFirewall = true;
     servers.vanilla = {
-       enable = true;
-       jvmOpts = "-Xmx4G -Xms2G";
+      enable = true;
+      jvmOpts = "-Xmx4G -Xms2G";
 
-       # Specify the custom minecraft server package
-       package = pkgs.minecraftServers.vanilla-server;
-     };
+      # Specify the custom minecraft server package
+      package = pkgs.minecraftServers.vanilla-server;
+    };
   };
 }

--- a/examples/single-server/flake.nix
+++ b/examples/single-server/flake.nix
@@ -1,22 +1,22 @@
 {
-   description = "Homelab running Minecraft";
+  description = "Homelab running Minecraft";
 
-   inputs = {
-      nixpkgs.url = "github:NixOS/nixpkgs/release-24.11";
-      nix-minecraft.url = "github:Infinidoge/nix-minecraft";
-   };
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-24.11";
+    nix-minecraft.url = "github:Infinidoge/nix-minecraft";
+  };
 
-   outputs = inputs@{ self, nixpkgs, nix-minecraft, ... }: {
-      nixosConfigurations."edi" = nixpkgs.lib.nixosSystem {
-         system = "x86_64-linux";
-         modules = [
-            ./configuration.nix
-            ./minecraft.nix
-            nix-minecraft.nixosModules.minecraft-servers
-            {
-               nixpkgs.overlays = [ inputs.nix-minecraft.overlay ];
-            }
-         ];
-      };
-   };
+  outputs = inputs@{ self, nixpkgs, nix-minecraft, ... }: {
+    nixosConfigurations."edi" = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        ./configuration.nix
+        ./minecraft.nix
+        nix-minecraft.nixosModules.minecraft-servers
+        {
+          nixpkgs.overlays = [ inputs.nix-minecraft.overlay ];
+        }
+      ];
+    };
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,10 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    flake-compat = { url = "github:edolstra/flake-compat"; flake = false; };
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
   };
 
   outputs =
@@ -16,11 +19,18 @@
     let
       mkLib = pkgs: pkgs.lib.extend (_: _: { our = self.lib; });
 
-      mkPackages = pkgs:
+      mkPackages =
+        pkgs:
         let
           # Include build support functions in callPackage,
           # and include callPackage in itself so it passes to children
-          callPackage = pkgs.newScope ({ lib = mkLib pkgs; inherit callPackage; } // buildSupport);
+          callPackage = pkgs.newScope (
+            {
+              lib = mkLib pkgs;
+              inherit callPackage;
+            }
+            // buildSupport
+          );
           buildSupport = builtins.mapAttrs (n: v: callPackage v) (self.lib.rakeLeaves ./pkgs/build-support);
         in
         rec {
@@ -31,20 +41,28 @@
           quiltServers = callPackage ./pkgs/quilt-servers { inherit vanillaServers; };
           legacyFabricServers = callPackage ./pkgs/legacy-fabric-servers { inherit vanillaServers; };
           paperServers = callPackage ./pkgs/paper-servers { inherit vanillaServers; };
+          purpurServers = callPackage ./pkgs/purpur-servers { inherit vanillaServers; };
           velocityServers = callPackage ./pkgs/velocity-servers { };
-          minecraftServers = vanillaServers // fabricServers // quiltServers // legacyFabricServers // paperServers;
+          minecraftServers =
+            vanillaServers
+            // fabricServers
+            // quiltServers
+            // legacyFabricServers
+            // paperServers
+            // purpurServers;
 
           vanilla-server = vanillaServers.vanilla;
           fabric-server = fabricServers.fabric;
           quilt-server = quiltServers.quilt;
           paper-server = paperServers.paper;
+          purpur-server = purpurServers.purpur;
           velocity-server = velocityServers.velocity;
           minecraft-server = vanilla-server;
-        } // (
-          builtins.mapAttrs (n: v: callPackage v { }) (self.lib.rakeLeaves ./pkgs/tools)
-        );
+        }
+        // (builtins.mapAttrs (n: v: callPackage v { }) (self.lib.rakeLeaves ./pkgs/tools));
 
-      mkTests = pkgs:
+      mkTests =
+        pkgs:
         let
           inherit (pkgs.stdenv) isLinux;
           inherit (pkgs.lib) optionalAttrs mapAttrs;
@@ -69,37 +87,50 @@
         checks = { inherit (self.checks) x86_64-linux; };
         packages = { inherit (self.packages) x86_64-linux; };
       };
-    } // flake-utils.lib.eachDefaultSystem (system:
-    let
-      pkgs = import nixpkgs {
-        inherit system;
-        config = { allowUnfree = true; };
-      };
-      docs = pkgs.nixosOptionsDoc {
-        inherit (pkgs.lib.evalModules {
-          modules = [{ _module.check = false; } nixosModules.minecraft-servers];
-        }) options;
-      };
-    in
-    rec {
-      legacyPackages = mkPackages pkgs;
+    }
+    // flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          config = {
+            allowUnfree = true;
+          };
+        };
+        docs = pkgs.nixosOptionsDoc {
+          inherit
+            (pkgs.lib.evalModules {
+              modules = [
+                { _module.check = false; }
+                nixosModules.minecraft-servers
+              ];
+            })
+            options
+            ;
+        };
+      in
+      rec {
+        legacyPackages = mkPackages pkgs;
 
-      packages = {
-        inherit (legacyPackages)
-          vanilla-server
-          fabric-server
-          quilt-server
-          paper-server
-          velocity-server
-          minecraft-server
-          nix-modrinth-prefetch;
+        packages = {
+          inherit (legacyPackages)
+            vanilla-server
+            fabric-server
+            quilt-server
+            paper-server
+            purpur-server
+            velocity-server
+            minecraft-server
+            nix-modrinth-prefetch
+            ;
 
-        docsAsciiDoc = docs.optionsAsciiDoc;
-        docsCommonMark = docs.optionsCommonMark;
-      };
+          docsAsciiDoc = docs.optionsAsciiDoc;
+          docsCommonMark = docs.optionsCommonMark;
+        };
 
-      checks = mkTests (pkgs.extend self.outputs.overlays.default) // packages;
+        checks = mkTests (pkgs.extend self.outputs.overlays.default) // packages;
 
-      formatter = pkgs.nixpkgs-fmt;
-    });
+        formatter = pkgs.nixpkgs-fmt;
+      }
+    );
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -84,11 +84,14 @@ rec {
 
   # Get all files from a path (e.g. a modpack derivation) and return them in the
   # format expected by the files/symlinks module options.
-  collectFiles = let
-    mapListToAttrs = fn: fv: list:
-      lib.listToAttrs (map (x: nameValuePair (fn x) (fv x)) list);
-  in path:
+  collectFiles =
+    let
+      mapListToAttrs = fn: fv: list:
+        lib.listToAttrs (map (x: nameValuePair (fn x) (fv x)) list);
+    in
+    path:
     mapListToAttrs
-    (x: builtins.unsafeDiscardStringContext (lib.removePrefix "${path}/" x))
-    (lib.id) (lib.filesystem.listFilesRecursive "${path}");
+      (x: builtins.unsafeDiscardStringContext (lib.removePrefix "${path}/" x))
+      (lib.id)
+      (lib.filesystem.listFilesRecursive "${path}");
 })

--- a/modules/minecraft-servers.nix
+++ b/modules/minecraft-servers.nix
@@ -43,7 +43,7 @@ let
     else error;
 
   txtList =
-    { }:
+    {}:
     {
       type = with lib.types; listOf str;
       generate = name: value: pkgs.writeText name (lib.concatStringsSep "\n" value);

--- a/pkgs/purpur-servers/default.nix
+++ b/pkgs/purpur-servers/default.nix
@@ -1,0 +1,63 @@
+{ callPackage
+, lib
+, jdk8
+, jdk11
+, jdk
+, vanillaServers
+,
+}:
+let
+  inherit (lib.our) escapeVersion;
+  inherit (lib)
+    nameValuePair
+    flatten
+    last
+    versionOlder
+    mapAttrsToList
+    ;
+  versions = lib.importJSON ./lock.json;
+
+  # Remove -build... suffix
+  stripBuild = v: builtins.head (builtins.match "(.*)-build.*" v);
+  # Sort by attribute 'attr' using 'f' function
+  sortBy = attr: f: builtins.sort (a: b: f a.${attr} b.${attr});
+
+  # https://docs.papermc.io/paper/getting-started#requirements
+  getRecommendedJavaVersion =
+    v:
+    if versionOlder v "1.11.2" then
+      jdk8
+    else if versionOlder v "1.16.5" then
+      jdk11
+    else
+      jdk;
+
+  packages = mapAttrsToList
+    (
+      mcVersion: builds:
+        sortBy "version" versionOlder (
+          mapAttrsToList
+            (
+              buildNumber: value:
+                callPackage ./derivation.nix {
+                  inherit (value) url sha256;
+                  version = "${mcVersion}-build.${buildNumber}";
+                  jre = getRecommendedJavaVersion mcVersion;
+                  minecraft-server = vanillaServers."vanilla-${escapeVersion mcVersion}";
+                }
+            )
+            builds
+        )
+    )
+    versions;
+
+  # Latest build for each MC version
+  latestBuilds = sortBy "version" versionOlder (map last packages);
+in
+lib.recurseIntoAttrs (
+  builtins.listToAttrs (
+    (map (x: nameValuePair (escapeVersion x.name) x) (flatten packages))
+    ++ (map (x: nameValuePair (escapeVersion (stripBuild x.name)) x) latestBuilds)
+    ++ [ (nameValuePair "purpur" (last latestBuilds)) ]
+  )
+)

--- a/pkgs/purpur-servers/derivation.nix
+++ b/pkgs/purpur-servers/derivation.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, nixosTests
+, jre
+, version
+, url
+, sha256
+, minecraft-server
+,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "purpur";
+  inherit version;
+
+  src = fetchurl { inherit url sha256; };
+
+  preferLocalBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib/minecraft
+    cp -v $src $out/lib/minecraft/server.jar
+
+    cat > $out/bin/minecraft-server << EOF
+    #!/bin/sh
+    exec ${jre}/bin/java \$@ -jar $out/lib/minecraft/server.jar nogui
+    EOF
+
+    chmod +x $out/bin/minecraft-server
+  '';
+
+  dontUnpack = true;
+
+  passthru = {
+    updateScript = ./update.py;
+    # If you plan on running paper without internet, be sure to link this jar
+    # to `cache/mojang_{version}.jar`.
+    vanillaJar = "${minecraft-server}/lib/minecraft/server.jar";
+  };
+
+  meta = with lib; {
+    description = "A high performance spigot fork";
+    homepage = "https://papermc.io";
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ misterio77 ];
+    mainProgram = "minecraft-server";
+  };
+}

--- a/pkgs/purpur-servers/lock.json
+++ b/pkgs/purpur-servers/lock.json
@@ -1,0 +1,8956 @@
+{
+  "1.14.1": {
+    "63": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/63/download",
+      "sha256": "d5813af64b5a05df6857d101b047347d312dcc1c15d9349c41e237cf91a1ce3e"
+    },
+    "2": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/2/download",
+      "sha256": "4dee7f68bab636aeea1d0adf008bc5a4e70970082515be25a9afc18c73759ab4"
+    },
+    "8": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/8/download",
+      "sha256": "34527aa2df03770f6b8ecb2b71cecb7237184d417cad2422f3e1ae3b9a756df8"
+    },
+    "11": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/11/download",
+      "sha256": "61a5fb76452b027f5904f2d1becb5c87d3320bab01f033921fbdd1674b2dbf7f"
+    },
+    "10": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/10/download",
+      "sha256": "bd9ed0b2ee04396dd104367b764dd046837216d7c0e282a9639c42ab1e7b2760"
+    },
+    "3": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/3/download",
+      "sha256": "85b886d6ad44231e7cedcd80340f5dd0c99f8ccd3cb66d0a4c15a8c9e99f2797"
+    },
+    "4": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/4/download",
+      "sha256": "423e33e06ef99846c65c9f4ad1437007023ade8755baf9086c478cf08ec26390"
+    },
+    "12": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/12/download",
+      "sha256": "b34d8f62e71aec5bf7f0fb01d8a17098ffc9d44cbf811849bcbd5911677f5575"
+    },
+    "9": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/9/download",
+      "sha256": "a5d9675e2018c1af3db95267bddc612df5b4e9dda6d9397643f155deeffaefad"
+    },
+    "5": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/5/download",
+      "sha256": "358089a401709d569d4d47011e0aac11058a826abef278e77a47526f1dcc0f23"
+    },
+    "13": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/13/download",
+      "sha256": "acc29abe4ace6d52b659a3e834f7e70b5742a821509ee5905450fa84afe5cfa6"
+    },
+    "14": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/14/download",
+      "sha256": "65817f18bd2ace018297047503ee461402b82f65dcc99f3f1886d8c44fca7222"
+    },
+    "15": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/15/download",
+      "sha256": "8e4f8044f8ecf88eb1a76f4feeedf1881af7c9683b02af13bc11e5b5c21b548f"
+    },
+    "22": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/22/download",
+      "sha256": "4760c4038665df0441237b5bc44e8602dcebee92481dffdb2ff884717b4dcc89"
+    },
+    "17": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/17/download",
+      "sha256": "f8102ff57c736d191bb27a57eff0d4f85929d7ff31e196dce4a9e324aa947227"
+    },
+    "16": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/16/download",
+      "sha256": "d46c968b2cf4030c13b670ca1b59bb6ef8f8eb4da461c0586658f19802b4c722"
+    },
+    "20": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/20/download",
+      "sha256": "1a186d60d11da03154bc52b91cbce9bdcc80d671a134d249111ecff2c07aab5c"
+    },
+    "24": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/24/download",
+      "sha256": "908639954ad0f8f28f7ba5b073a91ff0fe088096ca8482a0926314dfc08183fd"
+    },
+    "19": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/19/download",
+      "sha256": "6504395c410520ad7beb70d1372567e8d68009e8ff16ebc3722d884aabcaebdb"
+    },
+    "23": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/23/download",
+      "sha256": "bfef8b54e1cccfd0ba344be885edf5e4070d78ae860f95aa9a12b44c370e08f5"
+    },
+    "18": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/18/download",
+      "sha256": "9cf6d824c9a7f75aef923859c75fdf13af824b7d254d0ca49e62dba904e9c49c"
+    },
+    "29": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/29/download",
+      "sha256": "239ea2c46b71a7fa1852e6fb89cc22809ac0c02845bc7a93a9f284bd2ffb0ce8"
+    },
+    "27": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/27/download",
+      "sha256": "6317c50d8945a2304849c0420a310d6c4ca36460e8aea4e435eeb77cd328910a"
+    },
+    "28": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/28/download",
+      "sha256": "254e47e3ab4414423679f69963548a8a058510241f4dabd8d2f7bd909ade1508"
+    },
+    "36": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/36/download",
+      "sha256": "cd6d2be42ef81781841bb6d310843547c5be256cd23dc695c0bdfd9dc9f8b3fe"
+    },
+    "33": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/33/download",
+      "sha256": "629989626d3a2749822111017ea3c9240f314425d47fa932aabc04e7e305aef6"
+    },
+    "35": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/35/download",
+      "sha256": "af261b9d2207298b4e719e7c364dc53e68f8824052f157016960cdc5bb1f506c"
+    },
+    "34": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/34/download",
+      "sha256": "71fc23c8029250958584a2922662b22bf87321f230d9397eac23a3c2f33a04b5"
+    },
+    "30": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/30/download",
+      "sha256": "c48656744732ddf84ba8e576a78e8bf12bc6003135f4bd1277d63e459d42617a"
+    },
+    "38": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/38/download",
+      "sha256": "ddeda7d6bdd04ae0c8ee1a324b937453de17257efe84bb9ec46e3674cf19d553"
+    },
+    "37": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/37/download",
+      "sha256": "c60e6643ece25d19e3e0af3e460547d3b213de8cf40403ae376b32fe438c8301"
+    },
+    "39": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/39/download",
+      "sha256": "bb2fc8e3b481fbf8043a4f223c1f7b61933ad948b5c574200cb4c3add1970c0b"
+    },
+    "45": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/45/download",
+      "sha256": "244333ad77b61cd43b5980c3dae783ac986450fcda44abac20e8298130b7f866"
+    },
+    "43": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/43/download",
+      "sha256": "809ba692060204bb88423c01d52526a62eddd5d59902bb43294479b1bb7d07b8"
+    },
+    "41": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/41/download",
+      "sha256": "e77709537411a3553a02d0e2db730b55fd9fd7c17ed1ab7fd78992b8e5963b22"
+    },
+    "44": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/44/download",
+      "sha256": "ea503244203c7ca3159ba8d2a912cddf24dc7843a6f06b4f74d7adff9fc5562c"
+    },
+    "40": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/40/download",
+      "sha256": "e91746abe92bf6ca585d3baa2e46879cf4a3d81cd0bc2fdda5bc851ea5142edb"
+    },
+    "32": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/32/download",
+      "sha256": "ff815ca6b5f624bc7537c02aa1f486d5911b1f353952dc26075c91f1f7b4ce8d"
+    },
+    "31": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/31/download",
+      "sha256": "ac165c589a0175b1ed7c7bb94eada3f3b9cc77ba78717ea0a9e4092258c293f3"
+    },
+    "46": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/46/download",
+      "sha256": "a48e6a74f965ee160ad6b82b5559f7c8d6edb1e33f249404f919a4ed6bcb9d05"
+    },
+    "50": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/50/download",
+      "sha256": "1aa70bf4dcce869871342a9b7449ff0add173199d6f8d20672f57e405a601de7"
+    },
+    "48": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/48/download",
+      "sha256": "c4a76ef90329b175264914a50b5c7c12d4ac45a1baefa808586dc6b903fa0bda"
+    },
+    "51": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/51/download",
+      "sha256": "a3f54124f20e05181cd4fa5fc3403760fc2d8b237611202083210db2406a6808"
+    },
+    "49": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/49/download",
+      "sha256": "3a9a5b11bb8064280e9233e1fb9cfb83ed5b16002921172d3d967d68302f1ba8"
+    },
+    "47": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/47/download",
+      "sha256": "c031d52e59243420637c2da71fe0c46eb3db42f61abf8bbc8464902aa8eb645f"
+    },
+    "52": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/52/download",
+      "sha256": "e415586b19805d1b80e8a24070cbaa92f03ca39e5ba423a28395adc735b57c56"
+    },
+    "53": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/53/download",
+      "sha256": "1268a9580ae60994f5ae72040e900e3be50ba7532da27f5ba5ff9e3978e98175"
+    },
+    "56": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/56/download",
+      "sha256": "3cafe21b134a6eb6c9ef9ed1e24188005b0ee49e2a18930c08cc2eab2fc76a9c"
+    },
+    "57": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/57/download",
+      "sha256": "147eadf3f9021e33682886989d919f9afebdec0953fa442b1855ea5bc9d168a4"
+    },
+    "58": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/58/download",
+      "sha256": "215d8400a11e427f3c1993668dfc84708b1b5fcf0d3d2459e18b3d845bc6c290"
+    },
+    "59": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/59/download",
+      "sha256": "a628004433edfd88c927c2d5ca1b0b86a800d107c3345815eff1d80230e01e1b"
+    },
+    "60": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/60/download",
+      "sha256": "e97ce0de4520e70b229236c8de4bac246eff4d4cd8f55dc58fe854ddbde6798f"
+    },
+    "62": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/62/download",
+      "sha256": "fd248224674979c386479c583d469ac8c9a2df0d5a293a5139f6b283b3563abc"
+    },
+    "55": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.1/55/download",
+      "sha256": "dcfe47c6f626563c532bc1725f0ba45de0b0f23f73963bccbfba986464d81823"
+    }
+  },
+  "1.14.2": {
+    "126": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/126/download",
+      "sha256": "ccfa64c4aa180c98e89694b713338ababd1e11890dc9d07e2e734c6b30973493"
+    },
+    "66": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/66/download",
+      "sha256": "c4f0a4dd70870860bff0824cec74f1f829fdde871011c7d71e895e17de425ceb"
+    },
+    "65": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/65/download",
+      "sha256": "c0c2660ff4e907ab3bb352c52e5aa5cf9870e53fd4b26bd8ff743718f25afd34"
+    },
+    "68": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/68/download",
+      "sha256": "6b0c9f99439e3d2c8bb773eb1305422561e86bccc9804b7bee3e8de24962f480"
+    },
+    "67": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/67/download",
+      "sha256": "71bf126d01c0051fb28cae03419ba8bc89ccfabc578495b7963b9edf5b3fd766"
+    },
+    "69": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/69/download",
+      "sha256": "4d985f58e2fee40183abe0ea353d31667727654d7d39bc38329f800d443eb087"
+    },
+    "74": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/74/download",
+      "sha256": "6e8e45ce1a74888a08361834cd8c43a9bcd47647610feac5464713b86aac46ae"
+    },
+    "72": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/72/download",
+      "sha256": "9b6e28ae017315e4d18bc0fb8395b8a4c01c2aaf0a3f73dbda56a216b198a4a1"
+    },
+    "71": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/71/download",
+      "sha256": "54fa93c8044fb1c853bc553dbfc46cadb74f2789995a00d49711f9c617a82460"
+    },
+    "75": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/75/download",
+      "sha256": "2efa8556674bba328a54f16ad0ec5d09cbf9583e2dc51b2065f609a6eb60c668"
+    },
+    "70": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/70/download",
+      "sha256": "cbb62b6d20d55cd7facbea1683b5c95ee696c95ec401230c3b7189c5dad34dc1"
+    },
+    "73": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/73/download",
+      "sha256": "56a060d2ac9dcdbe933498f419b669fccffc0b12657ab04abe562a64091a5ff8"
+    },
+    "77": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/77/download",
+      "sha256": "680967aa204f6dbde3b7a802e7572fdc39bfd9d91efe80b3e64b8d8e57e2e3f3"
+    },
+    "81": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/81/download",
+      "sha256": "434081d95e8c329823aeae23061dd8a4de610123b4131c57c9aa5f9facf2a2ec"
+    },
+    "82": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/82/download",
+      "sha256": "9471e4411713f49c4d129711ccc0d87055904a3bac702660e865531bb7c2f917"
+    },
+    "85": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/85/download",
+      "sha256": "307e9bdf09d0bce44d3795c40866b5039f6b4fde1fe7a1cd6e885ab44eb1a94c"
+    },
+    "79": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/79/download",
+      "sha256": "3dcd2c1241cdc8ab179df99e2b22dc7211525d5bece02a4287e887e687171a1a"
+    },
+    "80": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/80/download",
+      "sha256": "3cc4e1e971df77d219cb12198b2a693d3be32def5997422faebc6ad321b6f5cb"
+    },
+    "84": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/84/download",
+      "sha256": "e55fd11cda01eaa37f2b0948816931b14d600e28f95ed495cb76e266949fff25"
+    },
+    "83": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/83/download",
+      "sha256": "c22d8fd1980457db92a411569106c1a97ebb288ff4d2a731d5bfd752bb14d6b7"
+    },
+    "86": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/86/download",
+      "sha256": "f140102763d8a36172612a4cf85b78f2c332f751565ba92a2d45792768e5d23e"
+    },
+    "76": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/76/download",
+      "sha256": "90c0f845ef6eaba50f05b2ac0f440dac5f29942c2cd71e429f6836d3431efb62"
+    },
+    "87": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/87/download",
+      "sha256": "db08338ecdf4f115e25df6c9caa6647458c896d4ff669c4090c7380f6990e285"
+    },
+    "90": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/90/download",
+      "sha256": "099ac379a427618d78755adcc2867a8281ec5562e669bbacd47070de268f6148"
+    },
+    "89": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/89/download",
+      "sha256": "7d34fdcc0343fdc9fea9db411bac3fbce3ef16f3fd57b90ec016c95d305cc119"
+    },
+    "95": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/95/download",
+      "sha256": "44c1544a921d734b202d573a62798ab2f78be87093de33a60a00c24f035aaa7e"
+    },
+    "92": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/92/download",
+      "sha256": "0ca47fdeecbaabfe193f15259b3950075b99039ce8f47b1f41f48f10edf93f9e"
+    },
+    "96": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/96/download",
+      "sha256": "bb8f9e27d2ad37c8f15cc902e0636101ed9ab3a4ea4e4d01d09ddf76121c8d8f"
+    },
+    "97": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/97/download",
+      "sha256": "058a200e1e8b2b3f8f41ba140c0ce6aa2368bf515da31b50afc9e8d42707d6f8"
+    },
+    "94": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/94/download",
+      "sha256": "b2c3833cc7b2159481675c139ab1d683af387ecb6468c62ea039c7f7a64fdbb9"
+    },
+    "78": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/78/download",
+      "sha256": "491595d1596f9f9bdbca7df7041f8f169dc96753a4e598be6c7ac411cf226170"
+    },
+    "99": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/99/download",
+      "sha256": "25d893557949c8c200094340b60e577bedf2f231213aa2bba1a808305cb9cbb2"
+    },
+    "102": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/102/download",
+      "sha256": "b004f5b9595694003b8378f7c020687863e3c8a38b932a6dd84971e99e7a9c4a"
+    },
+    "105": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/105/download",
+      "sha256": "6a2c1dea6825af9b21c5583827163f00059b297dcbe150e249804b8b0e79f8ed"
+    },
+    "103": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/103/download",
+      "sha256": "2f85c43f06747cd8e0d1eeb2a8583324ccd4cda351a1cd557652a23d20dc9f17"
+    },
+    "107": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/107/download",
+      "sha256": "160dd0d10e701616801cf2bd364b3dad1b0664769bdc500d05b01dd21835c6a3"
+    },
+    "98": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/98/download",
+      "sha256": "ccde912f07c1268d63f1bb39eeadd0584de8a34dd28c6b8ae1980deaf6aa2e7a"
+    },
+    "106": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/106/download",
+      "sha256": "0132d42cb4cd61e722fbd81526c4e656f24feece0e266b37898de96820915e85"
+    },
+    "100": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/100/download",
+      "sha256": "ad092f56a488cbf8761d37d6b93cdcce0fc824a175f689dcc3f6c8fbb6bf355d"
+    },
+    "104": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/104/download",
+      "sha256": "59edc0301431934ac2e15b8eb2bf5890fd70511ffdfe5f76915176089b78a42d"
+    },
+    "109": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/109/download",
+      "sha256": "a7e2d5b5983d85a475550f04005a2190bb2a9b12d55fe2ea781e44d05c63b6f4"
+    },
+    "110": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/110/download",
+      "sha256": "0635ca570706252b262f6566c497101f5f2fb225aaff8b15519899fcba5ba700"
+    },
+    "108": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/108/download",
+      "sha256": "05531af04a879f833b61daf7366dc02076616b3c05e8fdc2d40f97e53c16d37a"
+    },
+    "111": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/111/download",
+      "sha256": "b6bd3efc85426535e98b3170627e67f7cb639e62c048c9e5415b4816ff8bf157"
+    },
+    "101": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/101/download",
+      "sha256": "e8cbbeb7018c3454dff4d072f66ac96e9c217d8bc086954d0b19ac67eaee23d1"
+    },
+    "113": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/113/download",
+      "sha256": "d176092d50e733cd9560379b55fa92b0dddb71cd76dc5be1999aba7dc5d9403b"
+    },
+    "116": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/116/download",
+      "sha256": "8333e6e204b6bd83ec74338ba211a3b784ad33c85ee4d77ed4eeeebbf033e6f8"
+    },
+    "114": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/114/download",
+      "sha256": "16c4cf1cf48b10d7c17b26ca83f96f4771d63654e914e99eff3c4ac98d416869"
+    },
+    "115": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/115/download",
+      "sha256": "b85f3ae9d3e6efaf9aa1699259832ac576c06c74c5366c5b0db0c95d506fb406"
+    },
+    "117": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/117/download",
+      "sha256": "b135948367fa3fcccd2350192982d3a38ba2db9f067fc9d1499c42946990b01c"
+    },
+    "118": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/118/download",
+      "sha256": "9372ae30f1b3b6eeac0d8d2dd900d1ea0ee81935a99cf02255b2957948851212"
+    },
+    "119": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/119/download",
+      "sha256": "065ab3e744174207b9aa407101df474caef8f3a266cf37bff05feb45733e65db"
+    },
+    "120": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/120/download",
+      "sha256": "bf6a381d6b5d268833daba15859b454f74d3f750bf613bf03f929b18c6a4f28a"
+    },
+    "112": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/112/download",
+      "sha256": "f1125294a72b0562db7348ed69f7aefa937201abaa41601d415adca93f331a7f"
+    },
+    "121": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/121/download",
+      "sha256": "56721d705c9ede66a6936a05b57eadc908888678edce59d77a8d0ab978ef0b5d"
+    },
+    "122": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/122/download",
+      "sha256": "a24ce009855e6e9f55df47d2ddc3d27531af3d81a83df26ce541fc73ca46aba4"
+    },
+    "123": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/123/download",
+      "sha256": "e71487a2d52fa9453cb3ee7ce57df0b02f34fd5ee64f34cd9a1b5e62cb98a6ac"
+    },
+    "125": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/125/download",
+      "sha256": "da76252aaa9936917ad26bdb3ad77cf2058d22a6853fdbf948aecd6a043af70d"
+    },
+    "124": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.2/124/download",
+      "sha256": "19806f3bfdde75a20b7238cfa5df7e985de4ab1cbeb6ce1fcb9d19072f200134"
+    }
+  },
+  "1.14.3": {
+    "202": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/202/download",
+      "sha256": "221af785c854dd2a939035f134b32bd13430a91dd6584e6f89294a98f4392332"
+    },
+    "128": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/128/download",
+      "sha256": "2067632d856b81a7770def2c780f494199b125a5463fbcdcbd284e806ba496a4"
+    },
+    "129": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/129/download",
+      "sha256": "cbc550552b1e48d05a87b307bbc5b27e211ae775bb9765ec8a36d5734205a227"
+    },
+    "130": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/130/download",
+      "sha256": "c3af2e4fefc841ebdf48c1195ebf006f8a0d5580cd2a611d807ba1501c8b7300"
+    },
+    "131": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/131/download",
+      "sha256": "e6c6b55c35b38594007a2ff2d8e0306f8f0ac92072b161aac51b74aac2c45f58"
+    },
+    "134": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/134/download",
+      "sha256": "fa61740c057954bf81f445b259e18b72fcd83fcfa5e5197bee7f0b62d50fb67a"
+    },
+    "135": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/135/download",
+      "sha256": "6066c25fa991c7276347d870040a9c840936a96f08f4e35c508d3f60da63a85b"
+    },
+    "136": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/136/download",
+      "sha256": "33656a6c2c339a1a3307ab156447fa50284f8b0f63b28f0b276998403c3e0adf"
+    },
+    "137": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/137/download",
+      "sha256": "65a259cd78074f1a3dc68a1c59dadb2739fb5420bdf3934c95abe72e1a932327"
+    },
+    "138": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/138/download",
+      "sha256": "f2a65f75bae832e498fae99b99fcf5eaca5738e681ac3c6a8465e3ad566d181b"
+    },
+    "139": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/139/download",
+      "sha256": "dd86bdb0387f4e2414c21e0d7287740c4a4c34c81d9cc8c38f88432e973b5e85"
+    },
+    "140": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/140/download",
+      "sha256": "2b0d1f02b6dfc2f73a50e3cbd5474f2a30c1a61ce66a25e39ea28e4eafbba380"
+    },
+    "141": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/141/download",
+      "sha256": "c96296238783c782fedaa3c1714811ff565cc132cefb437d84052b1fb6035c2d"
+    },
+    "142": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/142/download",
+      "sha256": "bbdca8e06063d30c5e0697b0d4dc73944537586c00c4b03fe22f2c2e1daf452d"
+    },
+    "144": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/144/download",
+      "sha256": "44443273dc951125976b035f8351001cc499a28454ab2aa08c2c5b0bd17e7073"
+    },
+    "143": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/143/download",
+      "sha256": "fbf2b4c8f0c8a3fa3ac3b6c0279d65e509b34f17eae43468a9fff839da8859d7"
+    },
+    "145": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/145/download",
+      "sha256": "55fcf7537be84d58d7036ef6f19fb2f4c2859bfb2ebb1236b01cd58c6e3f837f"
+    },
+    "133": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/133/download",
+      "sha256": "1c01ebb01536f9e5611ad35a073bd54b162f0ae04e42bccae4d7448cd583109c"
+    },
+    "132": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/132/download",
+      "sha256": "761b477b5d8bb1f209fb89910cbc2eb8637314ac63257cc06a87f4b37d4744bf"
+    },
+    "147": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/147/download",
+      "sha256": "2d60d74426e53963c1a91d60bb9c694b4dbe94db1d81a8d206a27ed44d538041"
+    },
+    "148": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/148/download",
+      "sha256": "41c3ebdd6c0226903c039ab0d8315108bf1541abaa2dcc72b0c7b2b25cc7f7f4"
+    },
+    "146": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/146/download",
+      "sha256": "c7f379f8f1b817d1e0f949591ef7aa52d3e4d6c924e46cace1330738894b972e"
+    },
+    "149": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/149/download",
+      "sha256": "7a8d2665445fbc5d9206c389c5d464d29018a1a4705934a5ed00be6641f12031"
+    },
+    "152": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/152/download",
+      "sha256": "818baa6aa7359490e71a68ba41cf261af867c90a77285f73f81f0787a042afaa"
+    },
+    "150": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/150/download",
+      "sha256": "2ba4277bff298e142d626a696b69065177c307b3ab227564b56080babd28e1c5"
+    },
+    "151": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/151/download",
+      "sha256": "af6a670d4e2e1fb24d8999d949329cc352d91f4c3e8cb41150b489f0aae4676d"
+    },
+    "153": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/153/download",
+      "sha256": "7006d3f116ba308c27e153a447371a22fc68eabd0fc51082a96a24de72478097"
+    },
+    "155": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/155/download",
+      "sha256": "f3c160058dd04730a13adec85976159b86843d8f4502f43c5ad5e0071d77df7f"
+    },
+    "159": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/159/download",
+      "sha256": "0c715eaf11d42a31d6dcfa4ae2b61f80a46b3c303b7f52007f87410a9dfb8d8d"
+    },
+    "156": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/156/download",
+      "sha256": "8b19aa2c6fae5b6fcd7535625a3f9de5ba85433afe8f3e328a392236786c4422"
+    },
+    "157": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/157/download",
+      "sha256": "2132d35ba262758809f97f6ff9055baa70d58e50ca43b683039a1b2b1ce0fae1"
+    },
+    "158": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/158/download",
+      "sha256": "a79d9f7c648c9a7bbfa380444350edd17bf8210d67205176f2e11dbf63a3da58"
+    },
+    "161": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/161/download",
+      "sha256": "529f85b8e1235c546de417ca5e493809bdfeef14ae13521f8e8b6adeb4419910"
+    },
+    "160": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/160/download",
+      "sha256": "d15e5aca79b1abb0179efce9fa70088c2f7be89692c59ecc375b00b750db6da6"
+    },
+    "162": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/162/download",
+      "sha256": "05a24d2e26532428acb4117032d4676450683ea1c9f385d1d190c4dd58a5f430"
+    },
+    "164": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/164/download",
+      "sha256": "bb61bebc56cf4b6b33d00a64fa9d5f91c628486174507b22b1fc1768f40a5e90"
+    },
+    "172": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/172/download",
+      "sha256": "1e83e76ca72c75ed23152b88c4758c88ad498a6dbd0679a537756ad8658b3bac"
+    },
+    "167": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/167/download",
+      "sha256": "87470e61a92bd5744139943a43c3e9c21b7b2b90ca0b724d9a764456e59b5a00"
+    },
+    "154": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/154/download",
+      "sha256": "5bac1e466f6e5895980138b075f9cc9591cf40212f133e4c856ee65732fae6b3"
+    },
+    "171": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/171/download",
+      "sha256": "1a5218339f6f6d4474e8fd41ffc835f44f66b4d3871415320fd35c90e6664aa1"
+    },
+    "166": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/166/download",
+      "sha256": "e5ba24397b2196fb4a007857aa08d6597974d70d007b493037065f3b673f87ea"
+    },
+    "176": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/176/download",
+      "sha256": "21a4298a00d3e44e7fc3ffbb389c39cfdff466a522d3b0df9495d01e7db5efa6"
+    },
+    "175": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/175/download",
+      "sha256": "4194d4f6e884cad08b6042d56e0bf936bdae20638e67b6239a1ad231d37f0c7b"
+    },
+    "163": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/163/download",
+      "sha256": "8d8d35cdbea4e07cc7eee002862c069cfdab52f9b3ad841f9d06b15d1cbde7df"
+    },
+    "170": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/170/download",
+      "sha256": "d2fcf0ba41f97713bda6ea7f2523c52b4b6f446f07f8c800c2e2c2e3dbefb0ac"
+    },
+    "181": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/181/download",
+      "sha256": "f469f793eb1a21924ea85ae380dcb629bdf5619fb7294064d2f636196679658c"
+    },
+    "169": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/169/download",
+      "sha256": "df1488d42117b6bfc56303e15cc70fc58ee543de0f02be5333ff5617bfaff483"
+    },
+    "165": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/165/download",
+      "sha256": "2066c52bff44c8fced40f6f3d7f49e593c4539a8814c1c8b00e4c3cd1d31a43d"
+    },
+    "180": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/180/download",
+      "sha256": "8f174ce32406a422c95026276c7ead5f7895069b15753e70f6324bff27a8309f"
+    },
+    "177": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/177/download",
+      "sha256": "e9b85e64e1bf41f6268eb313cc4ef54f54504401e9275502929b4b79f656df8a"
+    },
+    "178": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/178/download",
+      "sha256": "ce7d7ab513b27bb881ffe37138b07c659f68127da6da6af00ed8406e81a9cadf"
+    },
+    "173": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/173/download",
+      "sha256": "3e26509e61f3ad69860e1c43d701581c03a3844cf418a7d3c53cfff2cba4e0b3"
+    },
+    "168": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/168/download",
+      "sha256": "c306223b4f5626c4aa76ec1070b5efac08ea191c3b3bb377fcf650f5331834cb"
+    },
+    "179": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/179/download",
+      "sha256": "d09cbc455ebb6aee1fbdace28fc2a442d00aff08d314580e7f85ff7b8d09b0d7"
+    },
+    "184": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/184/download",
+      "sha256": "fa7104b8ccfe4296585f864d4682d96dd9cb4ac62dbdf83233500271856c4a00"
+    },
+    "186": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/186/download",
+      "sha256": "b765264d509182e3c129f6bd95cc1fbe851cb50647b2912ce070c341cdc4c6d4"
+    },
+    "182": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/182/download",
+      "sha256": "cc74cb2980dfdf9ddcf8a23f39b0ff206af3fc3e4602428090abc0a9d2c33da2"
+    },
+    "187": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/187/download",
+      "sha256": "27d83f51b3d60f9bc5c5542d35273a304f2e9bd4e6b74c0428120825e62969f7"
+    },
+    "189": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/189/download",
+      "sha256": "7db2d4145760107949151b67a1b48e2a1bfdd510a574ff16c1ccfe3a73a4f033"
+    },
+    "188": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/188/download",
+      "sha256": "ba069dfedc4630209c2bade7ffb44e4d032f975064bb9ee73fd3eda0a9f42d92"
+    },
+    "192": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/192/download",
+      "sha256": "61fafffba144fc96e5de2beecf0042400a799dfce573209b656b54ca590bd0c1"
+    },
+    "193": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/193/download",
+      "sha256": "58678e2b8b5946650e175c40c2b75a4b2c9574ffe4aabaa2980b55d63d7d54c2"
+    },
+    "194": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/194/download",
+      "sha256": "6cbab0efc3c6a642b5dc1aa46eb8d629a4961c15b53b3e924e7509a244c5aa5c"
+    },
+    "199": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/199/download",
+      "sha256": "b857554ea2c57dc369ade3b9591986dd5d19ab707c1ca27614ad283ea4b9b9a4"
+    },
+    "198": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/198/download",
+      "sha256": "ab912779472b00a881eba7c1b6508c81e837860dbaf1c1370284e1a5b2016322"
+    },
+    "185": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/185/download",
+      "sha256": "5b9cf33c83274945c55b1d98251971b16d441e24ac26a9f71910b1d4217e211a"
+    },
+    "201": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/201/download",
+      "sha256": "2458a6b6c05043d6cd6d9a48f2d8617b0430baf041207d1992ccf5ab62646549"
+    },
+    "200": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/200/download",
+      "sha256": "509a81beca47ba39b9ce44a7dbd8938568bdf46ee47a4fc27cba0ba63e850f43"
+    },
+    "197": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.3/197/download",
+      "sha256": "9751a436faa0f53376132974fde67b95efd6ba0feff6f4f16973c40a034613b6"
+    }
+  },
+  "1.14.4": {
+    "337": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/337/download",
+      "sha256": "660c9a395f5f6b376b61669a8ee7fb4265c5bb79dc8c73f4202a3b6417203726"
+    },
+    "204": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/204/download",
+      "sha256": "f9bd1900f877409f533677626590b19607038b3b085aacd8e664f8124f729bf1"
+    },
+    "205": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/205/download",
+      "sha256": "4d9937bbdafe8acce976f40a437d187e618325648d1cf64caba42cb9fb2f8c4e"
+    },
+    "206": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/206/download",
+      "sha256": "11f8e712d5cbcf366f8e5554f7a33f5e9dddb84ec1c3108b72b7bfae42ead697"
+    },
+    "210": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/210/download",
+      "sha256": "374c6cade241d6c400b264af481cecdc81d58aac2aa00471c055177dccd43f29"
+    },
+    "207": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/207/download",
+      "sha256": "476100f6de39d2510e4aadf0fc08198a0d8128bb26ad1f18c3054e48ef5fa918"
+    },
+    "209": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/209/download",
+      "sha256": "f8900505f2ead10ac8234925830ef0d1bff834bdda81ea453c8469f1fa3cf279"
+    },
+    "212": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/212/download",
+      "sha256": "218a77f4aa30562743c03b300b17d8f21fdda43266718a02571c4222d4eb1060"
+    },
+    "208": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/208/download",
+      "sha256": "5c4c23624eeefcd57c8cee1469a3280d83703bc3a14914d628db64e9faf27e71"
+    },
+    "211": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/211/download",
+      "sha256": "a475cdd0db710f5b3e61300e040d49eed3e4d771783fa491ebaf9123a581656d"
+    },
+    "215": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/215/download",
+      "sha256": "b611a4dfa1466e05130c8d9d90d071c093e89b56fa4c57d8195da9ff7883da5c"
+    },
+    "213": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/213/download",
+      "sha256": "c97df15d560343e036a9e9fee364f32b56494e5bed660002c559a93037706d97"
+    },
+    "216": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/216/download",
+      "sha256": "c5d223c8be694cac653bed5e4984a4c36ed6da89f580e155fba7283cc18638a5"
+    },
+    "214": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/214/download",
+      "sha256": "354c7bb69b8e14f1cd29f5131b6a580afdba29e05e14f452916a87c02e724ffa"
+    },
+    "217": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/217/download",
+      "sha256": "ba915a65ee1e0f7604c370b994e275d743dd0817c05b8ba51a3f1ef658738b23"
+    },
+    "219": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/219/download",
+      "sha256": "8555e5a0cd79b51f3a24b2cddc13f544c226dbff1afbca22f474d0169e66fb7e"
+    },
+    "221": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/221/download",
+      "sha256": "ac8d0dd79a22801171601fa4d8ce756637b13006b3d75932fc4cde84a2444a92"
+    },
+    "223": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/223/download",
+      "sha256": "6f0d5800925870698d06d6fcba2caab462287a994d617454edf68fa72b1f66f1"
+    },
+    "225": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/225/download",
+      "sha256": "58a422e47a97f958976e7ca41e187d38f92c57763a7ed92240a1467496431238"
+    },
+    "222": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/222/download",
+      "sha256": "705b33702e9d8e85ba8c50d01f06b1a293aeea7e2b4b39c8b9f3edc4faf6c573"
+    },
+    "224": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/224/download",
+      "sha256": "57644d6ddc6a684dbba7ab2fc433dd2f23a9aa1bebe7ba760b0e4dd84d0d7c9c"
+    },
+    "220": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/220/download",
+      "sha256": "5576d082818cbff7435554998ff5442a1a1fd9593643daec11fad24db66882a0"
+    },
+    "218": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/218/download",
+      "sha256": "d5213413665e20d93b61471f61efcbaf123d054e2596bac87154f9dc108a7e75"
+    },
+    "230": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/230/download",
+      "sha256": "14354257e3c14d304118c7cdd7923a4d88ddae197c3ff39fac39c21e82e446db"
+    },
+    "233": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/233/download",
+      "sha256": "b5fe9057d735f3c9269c8d004bea22da8aaaac9a1e2c1ad7896c49d673756f26"
+    },
+    "231": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/231/download",
+      "sha256": "5a7f90dc1f2a4d7df53a99a1229d55b5e62b6afa31fde01f1b7b53b4c2b8edc4"
+    },
+    "234": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/234/download",
+      "sha256": "ad011db5dc61c85d8c16c2b7b806e4dc71ee261b9a1d0e4d551b0a8a746d21e6"
+    },
+    "236": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/236/download",
+      "sha256": "fe09c144ca3384512a6ff797f749df2f6a7943a2115df59cd0acb9dd85d47a85"
+    },
+    "232": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/232/download",
+      "sha256": "a65f889b89eaa004968d6398ea08035b88d4f2614b64f575f6c9bfaaa2f4a2f2"
+    },
+    "235": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/235/download",
+      "sha256": "3957dd1901d25992213677d127d6967156e7b8ed17ce5c8620eb23e83713c692"
+    },
+    "228": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/228/download",
+      "sha256": "644dcf1ebe371499b465b127587f655381ac7bf4aaf9859a5c1e5c593f3b78b0"
+    },
+    "237": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/237/download",
+      "sha256": "947c55c2ac5a2e4baba97c0aaeb40e8a431d0a6fc85076634df75195eb275600"
+    },
+    "226": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/226/download",
+      "sha256": "14591ab4f3f9bea94f34660a1e1280dd0c59a43d2c40f54f6f3342d851abcad2"
+    },
+    "238": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/238/download",
+      "sha256": "0f989b01ba05b5826ff57a57d6c9c732238606743ea4c4837626470895385576"
+    },
+    "241": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/241/download",
+      "sha256": "1fa3ea86ee20e18d8db13191785fddad2ce06273a48d21643e131df710069c6f"
+    },
+    "240": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/240/download",
+      "sha256": "627d84fafda02e227d4aeb767a81923f81f8ae4f4c3237da1d672c08deb1401d"
+    },
+    "244": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/244/download",
+      "sha256": "518ebd69738f051732861bace6414261163d69c427b391f16d8896e8b7d11fb9"
+    },
+    "229": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/229/download",
+      "sha256": "4278819206fb7d2b4174963db4ebdeedd6b36723c44c16773f16acde4f54d027"
+    },
+    "239": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/239/download",
+      "sha256": "62dcc3dd16ba40b894bf3772be1c99c06e3f6e43fe5b5d4af743cce2797b536a"
+    },
+    "246": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/246/download",
+      "sha256": "d0c007dac4b0a8e691732180acd60fb6ff1d10d7c0306e877ec8f5d33554bdff"
+    },
+    "243": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/243/download",
+      "sha256": "a57237e8ca2977650059beed5ef64353dba09879501767488f357eb45eaf9780"
+    },
+    "242": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/242/download",
+      "sha256": "054990b19c046458025947c41e13a5d8f5af32d4443d6074cd414722b5fcf76f"
+    },
+    "247": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/247/download",
+      "sha256": "8a7c92951ceb2685291da985f97c54ad70a76d3e31ce182600642ef2a17f1328"
+    },
+    "249": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/249/download",
+      "sha256": "80c84f42c3e4a4f92cff343742f59911f8289f9b5e61aeea6097ca0f2e3df9ff"
+    },
+    "248": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/248/download",
+      "sha256": "cdb8d172a2d0b14c40d69f4510df0f5d2bae4e7fd08a8c4df1c11244cb2f9605"
+    },
+    "245": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/245/download",
+      "sha256": "8675634e737389718589d3a32f7deeebbafa04d438ec14f428221fcd3e7a6720"
+    },
+    "251": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/251/download",
+      "sha256": "5c182287021f8f2693cf6b9469e7cb3b7f0784767749ab8d44985cedbd8c1d64"
+    },
+    "253": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/253/download",
+      "sha256": "a74e8db3e05da35eeca21b151e94853b65d33e4518b8e2ff13159e0ed9132546"
+    },
+    "256": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/256/download",
+      "sha256": "ad6d9d1caede9b14770cc973cc8d3112c7d62a8775f602f244c4d092601b2faf"
+    },
+    "254": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/254/download",
+      "sha256": "535ccdf5ba492f2293840ad413ce2c4e589b72ebe811578cbccf1b5802282103"
+    },
+    "258": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/258/download",
+      "sha256": "3b336486fb955dfac6114b5ef0d2e8edd859d7d670c056eaecd5d71ac9525b5d"
+    },
+    "260": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/260/download",
+      "sha256": "01d3341a255c1bbd083d3bca5c6308ce77047ea5d21b99f34e0358bf1555059a"
+    },
+    "257": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/257/download",
+      "sha256": "54aea1bfcadec2e64bf78a3eeec6c01beb34e261ad7570eb3b596f1b5bd91355"
+    },
+    "259": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/259/download",
+      "sha256": "6429876eb4f7428426c7c391b1224f0e73e7dddcd9fecf567de24dcd24b09adf"
+    },
+    "262": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/262/download",
+      "sha256": "370eb861a39fdd88e0bc339acfd2d1f5838fbb56d0d352bf77182cca3ab3e7d2"
+    },
+    "261": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/261/download",
+      "sha256": "cdd5046f2b2a631404da6d14820da9562d5ce9a74244d7dbacfc82591928e4f8"
+    },
+    "255": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/255/download",
+      "sha256": "b4d71d6f1c2c489ef0da3e57645a15e235c6ba422bb6587e55081889411dccef"
+    },
+    "250": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/250/download",
+      "sha256": "92898fdf3cc1c251ff2ba704df5a3fc6d02f8fd1ef57868756c0d10de798e88f"
+    },
+    "263": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/263/download",
+      "sha256": "39f7b1b0e0d4d89ad1691967e7c49e1bc2ef3e7d7587c8e7f7dc6df7f3e7b465"
+    },
+    "264": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/264/download",
+      "sha256": "77996f778e8d1c75a67af56c1b37c0be7436b5ff14dd3b3f67d9be0ccc51512c"
+    },
+    "267": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/267/download",
+      "sha256": "7c2a50e2375e76a3327344397fdc4e5ee8ded83d88b0d58cd4568b11347e6a24"
+    },
+    "268": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/268/download",
+      "sha256": "91891d65ccc45eb9f535641b6925b82fdea3d0a0eeadc542311aeef14bba908c"
+    },
+    "266": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/266/download",
+      "sha256": "1c0d59aa47ebd5884ea9f429404b11f86cb291c01ba940f20c657f06447ea9da"
+    },
+    "272": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/272/download",
+      "sha256": "bc4b0b6324affae4c6657ca1520cdef6253ee2113c075fbd48ea9e7bdb158996"
+    },
+    "271": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/271/download",
+      "sha256": "12bedcbb43232d526e1c79c6af1f3a0eb76510fd5a10ca500786c82cfcc97510"
+    },
+    "265": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/265/download",
+      "sha256": "96d45bb761bd15eced5db18c5c3737724546a706191f43613ab9597ea8789b6d"
+    },
+    "277": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/277/download",
+      "sha256": "387f7a9c690fc1244a75271678bbf1ebf4d0b87005e0053490c87cc4d41b97d7"
+    },
+    "269": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/269/download",
+      "sha256": "c296a1137d0a08edaa45977714ddba83ba58c36818f92bedffb7109d982d6f1d"
+    },
+    "274": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/274/download",
+      "sha256": "c10dfcbcefbf9070aa8f5fb7b3b65c8f16cacf303829e917a5f6df7a5cd3bc4c"
+    },
+    "275": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/275/download",
+      "sha256": "aaaf3f950afbbab0156eea00a17334f789569a7f8247e7928dfd826fbacb9792"
+    },
+    "278": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/278/download",
+      "sha256": "8fd03294a538fad373dfbbac6f4f2a8b221c5345f30f03ef9cecc3b53df588a2"
+    },
+    "280": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/280/download",
+      "sha256": "cc6bd0c1d15df3082370763a2548d965c39c26f9aed68da0ea193882d0003755"
+    },
+    "279": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/279/download",
+      "sha256": "fe29db3d0b8b981b74b850a996f4aabc20029af1ebafddf39634fdb304d54a6a"
+    },
+    "273": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/273/download",
+      "sha256": "e4792d15107f094d6f9ad97ab8d7c2d92a5e4444118cc24af12a1c459cea31f3"
+    },
+    "282": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/282/download",
+      "sha256": "ac8acae14e56b4c6da03416b79c236ded1801ead28145e32f330e1cd8517eab6"
+    },
+    "270": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/270/download",
+      "sha256": "3daf2f8543504ae6a801b5696ab225b38e7ec57626511ea0cb3e760810a67e14"
+    },
+    "281": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/281/download",
+      "sha256": "5325ec9588658b554758821c3936be4eab4430f13733f0e3b2d5de9476b42584"
+    },
+    "283": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/283/download",
+      "sha256": "beff5b3d4401eb8018d6d1b9240c5ba6d5545ba64fd800c5e200136dd475c30b"
+    },
+    "285": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/285/download",
+      "sha256": "69218329fd2314f9490eb41c4e842fe72438e7ec7d9a0610e3ca11b012a93242"
+    },
+    "286": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/286/download",
+      "sha256": "70e4399e3ed4ee99bd4986a796173864b97f25ed3cda7c5a61a970054b997608"
+    },
+    "289": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/289/download",
+      "sha256": "42f99ebb0a7f5327a736579dc2ab640291a7dd7704940988c3a0ff93e52b2d87"
+    },
+    "276": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/276/download",
+      "sha256": "50cb17b5b01acb7dcfd7870ee5ea17dc9c7984650c8cf01f9a4b36ce1d9b2c30"
+    },
+    "288": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/288/download",
+      "sha256": "7f043cd901c6081ecc951246ed5ad7474dfd7e8fb6a920006fb96c853399e3f6"
+    },
+    "290": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/290/download",
+      "sha256": "cb9c6d612cf7cda38daae4bf57b0aa16917d7f87e68f999f62bf9c705c5f0a6d"
+    },
+    "293": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/293/download",
+      "sha256": "31ae76ca4fd2442e74b1814bd9bf084f20597afb5d7aee93808bfde748857f54"
+    },
+    "295": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/295/download",
+      "sha256": "ffc8657ae8e03a2b1e970cef2eef6586c34545f521dfa3cf9461bea704bc6ddf"
+    },
+    "292": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/292/download",
+      "sha256": "739b0a822c94310b77576ff625a7965e9086b6ed143b05d41463b7eaa592200d"
+    },
+    "296": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/296/download",
+      "sha256": "2ec70ec7c713cc1b199a39e45ce2f39dffe15f07fb32f7eb6a331f28c66b67f7"
+    },
+    "294": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/294/download",
+      "sha256": "592303986d342ff57bd2c99acfeef729212184f0d5c2873448a7ee44bbf1532f"
+    },
+    "300": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/300/download",
+      "sha256": "0e21d44381fd0813ab7dc3e92fc760aab4a338b58a66367d35c705e462041d16"
+    },
+    "298": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/298/download",
+      "sha256": "3bfbe0304622e5c413271ce9ec20f1ec3350b51c0f9cf893cc8b6be0b796b3fb"
+    },
+    "299": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/299/download",
+      "sha256": "5453e99faa2764c181eba548c6dd9912021d24c6cbcd07b7a26509d7d210467d"
+    },
+    "287": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/287/download",
+      "sha256": "eac2a8de919229edeba5a273931f0c87f105463039d842983f0dc86b41be0459"
+    },
+    "302": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/302/download",
+      "sha256": "1131d77c6e1923152f3f31ae99d580927eb845e7b0d5089fda77dd1d6eeed23f"
+    },
+    "306": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/306/download",
+      "sha256": "8314a6143e01f1b69f73898a0bd4ab922756c6d57c27f08ae4a7799edff300b0"
+    },
+    "301": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/301/download",
+      "sha256": "b8cff88b6c51deb99b32b4770e90ac9228c3fbd02bfb93ef7053aa36d3becdc9"
+    },
+    "305": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/305/download",
+      "sha256": "59f20b067e127a2c04d62a64ebfcc049129b0ab4ceb8f011c582c560ab7a74bf"
+    },
+    "304": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/304/download",
+      "sha256": "b255b9174eedeeee827eda067dd6c844c8c7f6e9eaca4c7da022e30302911413"
+    },
+    "310": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/310/download",
+      "sha256": "23cdbd4009bd6338489d73e788ab75e3e8b91384ba02680adc8f4902cbde7730"
+    },
+    "307": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/307/download",
+      "sha256": "be0f7f605a0fe58f3dacb02037c5db2915eabd6224b91cb50026cf7ee8b29760"
+    },
+    "308": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/308/download",
+      "sha256": "6bb55682022fe9506e6f1d37d4563ed2a69bf959234adabd5578757ba68a04e8"
+    },
+    "297": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/297/download",
+      "sha256": "29f4dc47e1a1b73aeb9edf768c1ebe8bb895e2474a62d637eafd801d3ab0b2a5"
+    },
+    "312": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/312/download",
+      "sha256": "f6d7bf452c47087b46bbf3f933db05d5fe9debec7f5571252c856197e93cbd17"
+    },
+    "309": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/309/download",
+      "sha256": "0bf8d5c0661045e499db216ef07ea0ac5ce1f8c5d5075d0906e51ab5532a9f9d"
+    },
+    "303": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/303/download",
+      "sha256": "0f3c2142b5c0e949021198302c011dfae2a22288a0b74242db5911f63a2739c9"
+    },
+    "313": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/313/download",
+      "sha256": "1cba4e1672cef523748a2394f4c54424baf13109dc41015c368549953c9d6f84"
+    },
+    "314": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/314/download",
+      "sha256": "a22021578fa80986dafb47e72364d3510531569c2cc5855af2f15f170a3726d9"
+    },
+    "311": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/311/download",
+      "sha256": "978a32b5ab18f464a020a92cc6c668d2eb8300bd53a1f0cbda9faae0d0626e06"
+    },
+    "315": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/315/download",
+      "sha256": "ce53af1557d9b78b81d4d5e36bbf8379a28df3d404d151696906d0c0aaf21548"
+    },
+    "318": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/318/download",
+      "sha256": "9f115ad5bed395820d59653c8ab701b848e899941e4daa3a78abf29db258c9b5"
+    },
+    "321": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/321/download",
+      "sha256": "734852056d27ad95d108ff2ca92fb45ac896680dce0b84fe5dc2c353c5e5c839"
+    },
+    "320": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/320/download",
+      "sha256": "9ffd06455300e3cac75d3ae0d6326892294c5c3d2e97d40625688528a02cb9d0"
+    },
+    "317": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/317/download",
+      "sha256": "5064404a5658053a949527f9b79b0bd7b09a498c44106c2ee5b93a0a011870fa"
+    },
+    "323": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/323/download",
+      "sha256": "6f3c23191538bb5f96c0fdf0ecbd973b372f1dfdd9744219d7dd3e448f0cd212"
+    },
+    "322": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/322/download",
+      "sha256": "1b7e3c0aab428204d5224d1dce2420b3d36ed11d60a83d3ec6bcdfcbbc31fe44"
+    },
+    "316": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/316/download",
+      "sha256": "428a7d4ad3ddab5e4e72217cd4fc6eaccb0e9d5726e7509c426684d690fbcb0c"
+    },
+    "326": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/326/download",
+      "sha256": "5b68ede40cc61532da2cd60d5c341ca9adb9673930e98e8f301a7e131d9a4975"
+    },
+    "327": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/327/download",
+      "sha256": "ffab993333fbaaa0e2955998831ac9719b64a8a870519a1b0ed769a886575407"
+    },
+    "319": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/319/download",
+      "sha256": "ec56caaf4bcc4770d2fefd25813abeb12e030e0fd9f1c6f6d03696f0debf1f57"
+    },
+    "329": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/329/download",
+      "sha256": "4640a05d73f158e3c04c1f0cc132fb3f89ab1a8e4582c79bb720b178cd8cc8d4"
+    },
+    "331": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/331/download",
+      "sha256": "2ddbdace936c455a285394e141d3164469865a5175b14ec2cb5f32a3bbfcce18"
+    },
+    "330": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/330/download",
+      "sha256": "6e8edc83b92258f9be86daf3e81ac7b1921ee09d5fa3132ae801b01050462bca"
+    },
+    "332": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/332/download",
+      "sha256": "ff2877520f10383b4ff8804031cb6ba29f6a07d2aafa195952edbe713cf00a94"
+    },
+    "333": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/333/download",
+      "sha256": "fda01d5251154547c278479b34cfc087c946dc1818f6c3cc9edf0a9d94057033"
+    },
+    "328": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/328/download",
+      "sha256": "c1761831f0f18d5ec9aa128982cbd087ccfc94184dcab6a14c8ca55e696b04d9"
+    },
+    "335": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/335/download",
+      "sha256": "3053eeba6d5142f7a0c2fac8fcdab96a3c3e527f542c830778e7ae54c1f127e5"
+    },
+    "336": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/336/download",
+      "sha256": "d3fdf82fab9233df4b173b2f2b264561668efd0aca97e1654ce74680d0f5e765"
+    },
+    "334": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/334/download",
+      "sha256": "fc946b7641d4a27986cde7e4844cfa7a856cf46921b04eeb012368c4cfd00a19"
+    },
+    "325": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/325/download",
+      "sha256": "4133f80d5ac9d83975f688a689853384118db48b9bd4e439c2ed31bcda9767a6"
+    },
+    "324": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.14.4/324/download",
+      "sha256": "e034843ddb6fa75768a721041e011bef44de3c63ac9843a8adc8b8b38e296697"
+    }
+  },
+  "1.15": {
+    "346": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15/346/download",
+      "sha256": "e90a2291539764dba61bcbdfb9faacc917cfab5693aa3ab3f5e3e93f704bee97"
+    },
+    "340": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15/340/download",
+      "sha256": "fb3cb616cfcdb22b4d477a84c79fe11bccbf437f5bb9544be2e2abbfbb0d0456"
+    },
+    "339": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15/339/download",
+      "sha256": "7536ca306b5abd8f51ddb86901a45ff2fa6b6fdfa12b5b3a1d93c7791473ba0c"
+    },
+    "343": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15/343/download",
+      "sha256": "8b7d054e2876ba503d464188a3864eacba2aeade39827c71cbef09785d19f108"
+    },
+    "342": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15/342/download",
+      "sha256": "3917915ce59eb0fb24f64ec0b8cae589f6d2ad803e5e996de336e9dbc0fdd3ae"
+    },
+    "341": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15/341/download",
+      "sha256": "249c464f750cfc0d06e9bd3ed8a77e0eed75c2a1a2ee594092ee69c51e981fc9"
+    },
+    "344": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15/344/download",
+      "sha256": "f4e13abee4cace51c4700470f5ca7c27a0a3168b7ab7f78fb9a8f6f06744614b"
+    },
+    "345": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15/345/download",
+      "sha256": "1b823c4b09db9f02811a082b630d8b68dab66dc1e165390106c62c05642f2148"
+    }
+  },
+  "1.15.1": {
+    "397": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/397/download",
+      "sha256": "b2143c092a71be2bf7577b602d077442783a730bf9445e4bc1eef7dcefd28577"
+    },
+    "348": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/348/download",
+      "sha256": "d0237f703c58c2213acaa70098abfaaf05b637bef3d3329528b8b724d93760a7"
+    },
+    "349": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/349/download",
+      "sha256": "7a83731055cba32e8f17dcbbb79d5a9ed984cedac6f9651b06900b4aeb4e48f9"
+    },
+    "350": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/350/download",
+      "sha256": "cfd2c4d665f53503fc5169eb04c1dc0ea6c7ccc3100c4a869960e96f3b33cc28"
+    },
+    "351": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/351/download",
+      "sha256": "a3a88c85f39bfbf8f61d7b7464223830db98069823131df00a1d5b71de787f8e"
+    },
+    "353": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/353/download",
+      "sha256": "6c9b2c5dd8b9cda982fe8475231ad65d2266607a754b649e2d4c2d303e7d32cc"
+    },
+    "352": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/352/download",
+      "sha256": "adcd7ba43e3ad6bba43cf0581b2fde0119b07fb3a0c61faa0697356c3bb6362d"
+    },
+    "355": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/355/download",
+      "sha256": "6d3a158627b31d2ac6232af0ede46c153d6f36bf68c93eacfe2fcfb971e7f647"
+    },
+    "354": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/354/download",
+      "sha256": "94af83b12712af5666d8436e75e40dcd07b4c562e3ef5daaeb62f1fe34d238bd"
+    },
+    "356": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/356/download",
+      "sha256": "00a45c7911835e18b2b34979e3272a2f7b02a61468466e26046b78799c3a4299"
+    },
+    "361": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/361/download",
+      "sha256": "055eff79cccfabc7de53493d60254d109449b64ea5bfd1d8faa924c21a41b784"
+    },
+    "360": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/360/download",
+      "sha256": "f9f307dbd310a0b33a38d8a52a680a4fddcfc401d2f3422f60bdfebff449c79c"
+    },
+    "358": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/358/download",
+      "sha256": "92812cf533a236c750e775c71e1cafda7b319bcd023f82c7c4e2902a27a554d2"
+    },
+    "362": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/362/download",
+      "sha256": "734d2b73081281eb897508d82aba29d0f65608d90be4dfb9ce35a28466589675"
+    },
+    "359": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/359/download",
+      "sha256": "d0685b403b3a19b3e4f974361a17b08f904fda30d45e3db1d25f24e73c4bbaf5"
+    },
+    "357": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/357/download",
+      "sha256": "dd06d96f20a54c403a7bd4f50a76e70589718085689083d8ef602a7e2ddb4f57"
+    },
+    "364": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/364/download",
+      "sha256": "03f1e4e670bf8b9a44e758611c28206f3fc7b6e7c72faec2b7ea1884501073f3"
+    },
+    "363": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/363/download",
+      "sha256": "51a5b9dbcdefd6b451c09772ac6d8ac329a9b81ff5a59c448926ddc629eaf53b"
+    },
+    "366": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/366/download",
+      "sha256": "205e1675b4af034ae96949dad48f46534cadc9a17ba89ad90b8a8738797f3c7c"
+    },
+    "365": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/365/download",
+      "sha256": "a24f35638a96e501dbe9936ccafc3fbe930303d3cd461a053498ed535d9be9e6"
+    },
+    "368": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/368/download",
+      "sha256": "27051b31f9bb40d75b33456fb47e83f0cdf5e6766273ac175b29e54fa447513c"
+    },
+    "367": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/367/download",
+      "sha256": "91f1dab2fda3bf5a0a44cc7a370f2a38ed332a85253ec8cac05ef346b75124e1"
+    },
+    "374": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/374/download",
+      "sha256": "ed6ff6a8d28c6eac325dd76bea2ea65e51b23557c1f8136f01d6a78177e4eabc"
+    },
+    "370": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/370/download",
+      "sha256": "8aa8ec10d50fccbec04129596c83684af772b243ffe43c59cf835538fc0d8323"
+    },
+    "369": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/369/download",
+      "sha256": "a86f82d97275caad8f0feef4e17b802fe9abd81152c08b106f5d29411ae189cc"
+    },
+    "373": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/373/download",
+      "sha256": "7c8a9c2a4b63c9f6bc281114827bb6a00a0d94dd9592baf6f934c6ebba4e6536"
+    },
+    "371": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/371/download",
+      "sha256": "6f1c02b7b2b415ce506a82e2141161f67fd9defa1e59dd99f56999d36c715bb5"
+    },
+    "372": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/372/download",
+      "sha256": "0ceb7375d6240c53e255b13cef63f658997ff28fa85561d744a869b8fbfcf41d"
+    },
+    "377": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/377/download",
+      "sha256": "1630079110b6d29bca963a186b77ec51a880905495836b6150f316239b60290a"
+    },
+    "376": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/376/download",
+      "sha256": "6ec9d103c0692c898a675eee4a0d541886ff4ac7fb3138aacb7685c6483d24ce"
+    },
+    "378": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/378/download",
+      "sha256": "e63dd04eab9b94193799492407d93ae5e98d005d8a8f0daf66b7d0d477ba98dc"
+    },
+    "379": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/379/download",
+      "sha256": "380f55b7aa9da37c4fd90f5289a69d39021b3fca1a44f470f8a8599368e51961"
+    },
+    "382": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/382/download",
+      "sha256": "1a39cd7de563955491b3ed8f1152a899c043aca2467ac22aa32b2ecb7bf2f734"
+    },
+    "381": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/381/download",
+      "sha256": "063ad07619403f7881f49f15e0bad8a2ca9b38e5fcbebcfb3bff13283cccfd96"
+    },
+    "383": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/383/download",
+      "sha256": "b64b056584626d77798fee5e0cb693c7bdbd3997055a25aac40e92761643effe"
+    },
+    "384": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/384/download",
+      "sha256": "e278d35b97fe9267da0e34224b9b3ef271aebb459f9f909e118d5310f78f7f29"
+    },
+    "386": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/386/download",
+      "sha256": "41a3adc45753e877c4efb2a28515fc1d888d43f725a7cef87b93eb097a98b2dd"
+    },
+    "387": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/387/download",
+      "sha256": "111622b800c329ba7504afa5161c6a4ef5a385b1c21efa0615539cbd9199d65e"
+    },
+    "375": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/375/download",
+      "sha256": "4843203770ff5e3949b185bf1796d3dff88fb0450218977af6ec4f74004b9116"
+    },
+    "389": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/389/download",
+      "sha256": "33e535227801258c3a2fa4e4616ad06fa1e24e38280789b6598af29e185d72ca"
+    },
+    "385": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/385/download",
+      "sha256": "fbb8f6e92b9da032d6123a3314abf0c22ea05be00a6489435e4eee2cbb506f4a"
+    },
+    "390": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/390/download",
+      "sha256": "50b0d4c9a62bd30239187920e13c816141569298b74dca188bdc0d523430ee94"
+    },
+    "394": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/394/download",
+      "sha256": "4dacbd48647469fec2719933c88614e4c4b5b335fdb23c5ca28d78d4d8f5e0c4"
+    },
+    "392": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/392/download",
+      "sha256": "bcb4a21d3defd145883537249bfd7bae8141c41af06c8643ac684c9e7417525a"
+    },
+    "393": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/393/download",
+      "sha256": "a57188cd9f684820929f37e4bb5aac94d33cf73ef00cb07dba8dfd330a1a1ceb"
+    },
+    "396": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/396/download",
+      "sha256": "f4e616f9784a88b60a33aa03de8bc9659228f199db71b4dbc7f64c6dee9f1022"
+    },
+    "395": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/395/download",
+      "sha256": "0dbf3ec9b9540117ee90052cf83acc98189962585b1c431bfe07e187fc659e0c"
+    },
+    "388": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/388/download",
+      "sha256": "78a62457d339fa6684377e169c52ed66213b0594de73ff794d9a873728a61ebd"
+    },
+    "380": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/380/download",
+      "sha256": "23a1c948901a43ce1052205b3c0dc667e93f88cc675816f8fd9df56739ce5e68"
+    },
+    "391": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.1/391/download",
+      "sha256": "5f40bfc1efbec0b4f539f8af7f96d565486a9c5926a0bdf563fa19c5731ef361"
+    }
+  },
+  "1.15.2": {
+    "606": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/606/download",
+      "sha256": "183e64d70f76913163c006d9144345554683cefd96881b27e176812522228236"
+    },
+    "398": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/398/download",
+      "sha256": "1428381f72947a3c38257168456f90ce307e783880a291f29f2efcbf3a1bc8f8"
+    },
+    "399": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/399/download",
+      "sha256": "04266ce14181397aa6aaf76a8a203f25347cb5d03fce3968d9e17b3f49e011e4"
+    },
+    "400": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/400/download",
+      "sha256": "5e3abccbc26268286251c171d02f9ddeff2dab9d1a1f41bb3bbe17bdec5a6aae"
+    },
+    "401": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/401/download",
+      "sha256": "51caf9afc45f46ffd3b82743cd15fc012ed8b808c4c805fbcf5edb58c637a83d"
+    },
+    "403": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/403/download",
+      "sha256": "fccb2d62151e027e478a2452fdad399d419c5e680a58dd68eb9212bee32d21f4"
+    },
+    "402": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/402/download",
+      "sha256": "5cc9f277e654cd2fcb6ef5d2aee3b112e67ab63bde45a76b61abcd886d6ebccb"
+    },
+    "407": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/407/download",
+      "sha256": "f27db2a21b568cfe21825d022877ef14b179e0c382b6af0ef1f9c6b63c9e6afc"
+    },
+    "406": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/406/download",
+      "sha256": "1d1f8fdae4a09fa69340ca3f9c0ae76ece72de7253084a8bb846f9abfcd13d82"
+    },
+    "416": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/416/download",
+      "sha256": "0196d16371868bbadee15647bf5b4c5f43b2c11851221ba0335c76067c0bd635"
+    },
+    "405": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/405/download",
+      "sha256": "b79333064a3d5376c857c4650725becd6be59f658657ced65ce3f410ff48b39c"
+    },
+    "408": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/408/download",
+      "sha256": "dfabf131a2bdbf03ae719f5851cdb12b369b7f1e23d969859f4cf44232368cac"
+    },
+    "410": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/410/download",
+      "sha256": "e601a83283ff258cd656b65fce590f243bbdd82d7bd63095dc5d4fd925a11c86"
+    },
+    "417": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/417/download",
+      "sha256": "3243de4fb3bb06bbab4d2f5355081d25c5fa96f982df8f04011d6f81a8724d97"
+    },
+    "404": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/404/download",
+      "sha256": "de4beaad47481649a30a3f369faf250265951d840b2bc488a14100423348330d"
+    },
+    "418": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/418/download",
+      "sha256": "3a44cf97dc16f0944621d21a9f6f1efc35411d28cc35a3a9ed223c105fce4d4d"
+    },
+    "421": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/421/download",
+      "sha256": "ba9251bac4c2da7e355ec73a0a053d450c85d345660ee499df80e98734917c1a"
+    },
+    "419": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/419/download",
+      "sha256": "7ef86d0c1c1a7d13e00197874f55381cc0ffa9d0802a012e136330e4b8d2917e"
+    },
+    "426": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/426/download",
+      "sha256": "474c4a6b5cdcf0831e94fc87e54924ad444019c1ef1b2c527d048eca1b42e39f"
+    },
+    "423": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/423/download",
+      "sha256": "391fc78e4590cfdc4c5dfc32771ebcc1f16649e1282d2b0cc7f7516445743cd6"
+    },
+    "425": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/425/download",
+      "sha256": "58d8f0fcaf048e5d9d04977999ab8463d9b01b14da05cfddf9674a13e29ef677"
+    },
+    "424": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/424/download",
+      "sha256": "f4520638114664848f9dc31fdb201b2f7de8b4f388dfcdb8f4ca3de022652745"
+    },
+    "427": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/427/download",
+      "sha256": "d13bd35e5a38ba49a8f6eb596980ba332e88c7a99ca8bf8bec593f2aea62ff3b"
+    },
+    "422": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/422/download",
+      "sha256": "85650a7d9996c608cb469dfd0b8b2ed1386d2ec5c80dacede36ca9842e0b3fc6"
+    },
+    "429": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/429/download",
+      "sha256": "ca20d6a1662f714dd7fb21dd57ee14791e0544a738e43e4f7e57c0e5af738c4a"
+    },
+    "420": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/420/download",
+      "sha256": "ff750a182f0982919d5d41013cdedc06f30704d7c896d912f66afe016429c44a"
+    },
+    "430": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/430/download",
+      "sha256": "91890b103f90db630ec9410b42ef14a53797af097c6170bbc7802cbd9608a303"
+    },
+    "431": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/431/download",
+      "sha256": "5ba6f38d62793940d606093999368c350c2324fbb6d0a3b054e5d2514ad97987"
+    },
+    "435": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/435/download",
+      "sha256": "59d285f3902f6661e4b1a2774e045b99075fdaac2ccd75966000523f3e753828"
+    },
+    "438": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/438/download",
+      "sha256": "ef10d2852365ac706487091a8a137915acd211e9371c61ce6389f6c9758d9d63"
+    },
+    "437": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/437/download",
+      "sha256": "91153af6d6f8ce7d6bf4eaada9898bf60406aff4aed4707d64a1cd44451fccec"
+    },
+    "439": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/439/download",
+      "sha256": "8f26f2a0f1ad168234bfb7ce9b6d9d79e5afd1af10fa3d13f1ede16e5920295b"
+    },
+    "432": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/432/download",
+      "sha256": "e99d78e4a47a2397a3f5729b4d91c08ad9877589479645cc0f570470d4ed4749"
+    },
+    "440": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/440/download",
+      "sha256": "93cedcb161197b4a20dd58d636a4e6d57c0ee44e5f2c89c03e80a6724741b23d"
+    },
+    "441": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/441/download",
+      "sha256": "d03c2028f92e499149b8de9117e5b59848a78202c889f6b20bc04672e90e1eff"
+    },
+    "442": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/442/download",
+      "sha256": "2c24fb124405069e2aa3693bc963e4d1d1b93bc454c453934f410f1fc1c94348"
+    },
+    "443": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/443/download",
+      "sha256": "df123730547ade38469aaffb7a92928aa8abef643112356520b9d1c79151b207"
+    },
+    "436": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/436/download",
+      "sha256": "b5bb4833c654fdca4daac648cfda500e69b41608557716bbc84db5eb46c0bb2a"
+    },
+    "444": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/444/download",
+      "sha256": "ea1bfb9b4b244aaa901ae50ad6ae758d0d0fbf69ed7df8c9893e1d3d5ccd48da"
+    },
+    "446": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/446/download",
+      "sha256": "a89f1031db83dc3b169e00034b1b92c64b3b5b50310d80dc4e754802ef1daa85"
+    },
+    "449": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/449/download",
+      "sha256": "91e05ff2918be9d9888a00a584cf2dbacff5921822f12ce3c8b53639694c7651"
+    },
+    "448": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/448/download",
+      "sha256": "f5afff0f780ef2ab16348aac73350f454eaa7b3cb847981fa7174ed97275997c"
+    },
+    "450": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/450/download",
+      "sha256": "a77b28fec48bf905f9c78339f9068be79928ee88d6bc8500d489ada5811d90cd"
+    },
+    "451": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/451/download",
+      "sha256": "d11ce35e2bdec28acd74bf592e6f72b47371662c7a24e4956f38b3ff8f7e6c6e"
+    },
+    "447": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/447/download",
+      "sha256": "c1f5439b98c21c56cb1381bcec747ecc31f4b5665a12c235a16b64e1f4b6a5bd"
+    },
+    "454": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/454/download",
+      "sha256": "01b706eabbc9afea4398dab697573f26d2d0ad4dda94c5a0a1e87666b983efc7"
+    },
+    "456": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/456/download",
+      "sha256": "49760b5adacda0a32f1605ce8b9b6e05cdf9ec4d7d1dec302485160549a968c6"
+    },
+    "453": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/453/download",
+      "sha256": "8166bab0642380935ed840843ba4cfcd37cba96ad7f35dac777c2ef81bfe5c61"
+    },
+    "458": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/458/download",
+      "sha256": "16cd8156cc1552e50a7767c6c39524ddc46a80bbb967abf38f1d35e28db64237"
+    },
+    "452": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/452/download",
+      "sha256": "de9fc9896d47739d57495179df7324a0f487984494003400ea3733d0c8024a3f"
+    },
+    "455": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/455/download",
+      "sha256": "78dda2660ef5a9a8725cbf2aaad0901d36c7fac9e9f9063d495a9b29d20e0dae"
+    },
+    "457": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/457/download",
+      "sha256": "ee81cb876c1f0087c8aab1ee9ec4a1679124b278c1adcced8fc3cec8e47dd2db"
+    },
+    "460": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/460/download",
+      "sha256": "86c8b6d17a8b5bebadced6b3f3ba514dc3b0ed48038c3363ba96abafe1797b20"
+    },
+    "459": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/459/download",
+      "sha256": "4e83fe79c7906e7d8fc291be033e30a0dd5a05b2bede04ab2ab1957d08c7b4ad"
+    },
+    "462": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/462/download",
+      "sha256": "90084cfb7a8659b41e747fc0a7e66bc791ccde5dd25e2373ba122b49ee9a6d75"
+    },
+    "470": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/470/download",
+      "sha256": "67002a5c84cb627460520c3cd3b58ba13388e6d9ae449572c5e3a8d4162d6e1a"
+    },
+    "461": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/461/download",
+      "sha256": "8a928170baad944f495fbd9af7baf5f0b3e326bb2b4ecf5b6a9a8293606ec9a7"
+    },
+    "465": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/465/download",
+      "sha256": "d2b4c2bd9483d04d6c7ede40835669bda6cab202c737d2c4cc9cac413e227706"
+    },
+    "466": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/466/download",
+      "sha256": "fe94c59f78af203e62a5c56cd60c15d5a30ee6239c15516fdabfc7cef5a89937"
+    },
+    "445": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/445/download",
+      "sha256": "c282b4958d4b49c64a305179f8333921a15bc98f106422d53bea1f577a06530d"
+    },
+    "467": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/467/download",
+      "sha256": "bb8159f7fd9d5dff597331ab48c83816381b6bd317706612268d988a244dddb7"
+    },
+    "463": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/463/download",
+      "sha256": "46e410667e3ac09a1f8bdf30d8e9c049c4a36f3fb32c991b82560b792f675ff9"
+    },
+    "477": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/477/download",
+      "sha256": "95e61f7a7d8a71b10a5f670cb81ce05745ddad9597c23b8d943eabdb8cc062d5"
+    },
+    "478": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/478/download",
+      "sha256": "9fe125f8b4dcea08a3afac1d9d2492cc9cb5f65eea717afa202c86bf3a17f0ee"
+    },
+    "482": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/482/download",
+      "sha256": "d4e395a6d38a5a2b5edad9334a5bdfce87ff43cface27307a198ec254498c2d9"
+    },
+    "464": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/464/download",
+      "sha256": "ed59694ba3831043f75990912aa91f834aad7b51c62c37828fff86d9ef1fe378"
+    },
+    "486": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/486/download",
+      "sha256": "f0645a22ddc46a78a0e9b81416a68fa22c391da061b1003eeebb5929c9ee5af5"
+    },
+    "487": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/487/download",
+      "sha256": "41789d2fe4e4a89154a77c0a45634348537d352b85782d96b26479fd2b9a5a02"
+    },
+    "484": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/484/download",
+      "sha256": "3295c45c5f695bd53f015d37dcf28e7816080f81f987ec0aecc83408bd193a84"
+    },
+    "483": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/483/download",
+      "sha256": "a5196e1884c554ce507fec3d2056190b16bfc5a39d67f23ffd352e35e44dbaac"
+    },
+    "489": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/489/download",
+      "sha256": "7d9968a9b79dffc97aa7ff8a08d7e352dae7dd552cf02e0335f0d9cb1d87dd1d"
+    },
+    "488": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/488/download",
+      "sha256": "02c20ef210bbc500aff28e7c6a0184fa2e4ce4af39ac6da3459dd8981565dcea"
+    },
+    "491": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/491/download",
+      "sha256": "eaa4e3ad060228935ad65b4c91fde5641297634090f365b1c0cc059058c7dc4d"
+    },
+    "493": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/493/download",
+      "sha256": "094329c5b745f3479a6b491867b51de1467ac5d472541bfa35a27636ffabb517"
+    },
+    "490": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/490/download",
+      "sha256": "cd59fb218854de4ea627d73b6e1b64385640ab74bb4489f8c7bf04d9a30c5347"
+    },
+    "495": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/495/download",
+      "sha256": "89cea4c80dd45b7eebd51bcf1280047cbf59e584598c4491684f7eb503201122"
+    },
+    "498": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/498/download",
+      "sha256": "6c8c07397ceef1eac24b308a89472ffc26e59092288b9f9174102c8ce671d565"
+    },
+    "499": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/499/download",
+      "sha256": "9fd485b1430e91d990799b71da26a737058b78cba2dc657358988d473077e4a3"
+    },
+    "500": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/500/download",
+      "sha256": "5de72d0d77d9a1fd4a015e87d5707911243c06a4f65cfa4bebf09593a736c978"
+    },
+    "497": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/497/download",
+      "sha256": "00f64822f6d43305ae9713e6b967d317f853ea705b97b2156facfac60962e2b0"
+    },
+    "501": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/501/download",
+      "sha256": "56c85f6f1495e300bd48621cd39ef0bf2728ffd73ba2ebb6f81170c81c41b8df"
+    },
+    "496": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/496/download",
+      "sha256": "dabc17129b60c3668107107d5f838f38b8865876adff6f8f79c9d3f80899a15e"
+    },
+    "505": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/505/download",
+      "sha256": "8b11fc79560ae34a3da34ec6fa5552fb3b8da5767d442de45ccaae5b2bcd29c6"
+    },
+    "502": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/502/download",
+      "sha256": "3d6048c2423f7c585d215502473bf571d2902ac662ee0d7af169a614ee29b4df"
+    },
+    "507": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/507/download",
+      "sha256": "470656552d6a74d9853e91c51a02beaaba7f00ef8d8525a1b1e9dd3d87663bdf"
+    },
+    "504": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/504/download",
+      "sha256": "cff1ba5687cfc64cfa6154326ff8dcd19f0a55ef00b7d0d8214a289ce3e6ba40"
+    },
+    "506": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/506/download",
+      "sha256": "c7f3603e7810655f839251e91544405538b1d015affe25e2889d25428ec0a224"
+    },
+    "503": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/503/download",
+      "sha256": "4c0b3bb2ff47fb89467fe6a7ff9c320ea611263b0f7f58b894d26be17c9bc7c2"
+    },
+    "510": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/510/download",
+      "sha256": "eaf20b124774d94c6273bff5ca18435c1d229c86c21cc621d220dc8cd7a89bc6"
+    },
+    "509": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/509/download",
+      "sha256": "cf142491a08868e4b64ea8814d740cb21ef1c8f0b6ee2cac6dfffb48bc8a3d88"
+    },
+    "511": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/511/download",
+      "sha256": "914d2921dbd8c662697c5598f63cb14f197d57ab159a43bd9cd4c4bfbfa8afe6"
+    },
+    "513": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/513/download",
+      "sha256": "fb87c1fa7f13a2a278a09ac5f6f2ce53e3f95857346218de4facc54f37d716af"
+    },
+    "512": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/512/download",
+      "sha256": "139ccb21269f018c95037d18aa89f0b3bf7774d95fd50f9b07bf693dfb27e015"
+    },
+    "518": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/518/download",
+      "sha256": "3da6a51c6bdab4e9b579bd087365795a19d4470deb335ee5ccdcde5baef57cc0"
+    },
+    "517": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/517/download",
+      "sha256": "ce9565bbf0e9531556ababa2896ec5e13dfd5ce60735e58ddf28abd25c21a31d"
+    },
+    "516": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/516/download",
+      "sha256": "27be121068ba699b4b72ef9bdeae2b69c88e343d0f7b7f0f37b3d0367937aaba"
+    },
+    "519": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/519/download",
+      "sha256": "26be74811fdcf0f59fe1f2dc3c299289f71d6b5989ef037aac71a8400a2b1238"
+    },
+    "521": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/521/download",
+      "sha256": "6e4ee195c5653270fd43ddc83103c091c83a91af3090ce3db284ae0de2801b4f"
+    },
+    "520": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/520/download",
+      "sha256": "f72a42a878b2e963c49e5c8f9e05e76f0bb4e144bdebdd24a5119d24030f7b88"
+    },
+    "522": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/522/download",
+      "sha256": "3f94465b00027127ba9f85ffb1679cb405716cf3a3f48b5df6eb4ac71e1d8fc7"
+    },
+    "514": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/514/download",
+      "sha256": "e673df7c27fb8a6d66b1393476ff958b75832ed3a605a4a764a434703061794b"
+    },
+    "524": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/524/download",
+      "sha256": "f23c24b76a0364519c0667b92a3a7d173f8ad5442b58f1672b571612149ee979"
+    },
+    "525": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/525/download",
+      "sha256": "c28ef92a96aa2338cc5dfd5c26b8012eb18178e1c2b5065ac17886252d5c512f"
+    },
+    "526": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/526/download",
+      "sha256": "c90e2359055888ba6155ecaaaccdc913d81b9e08ce84f6b6af0fae2f12a1a9f9"
+    },
+    "528": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/528/download",
+      "sha256": "b310cd01d0e37165af8b4a280bc9f54395a6d14a1a2c4ca71f93382b900bbb9b"
+    },
+    "527": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/527/download",
+      "sha256": "b8b2d2d704b75586e70f6413e8d1f1c691599906257e1ac2af30eab9c21e9f8d"
+    },
+    "529": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/529/download",
+      "sha256": "0015971cbbce4c342f8cab240655d1cf049011b8e949cb8fea8860a41166ec20"
+    },
+    "532": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/532/download",
+      "sha256": "9256a4c6a3ab4efdada5cbc90aed95f56d16416cb24719e97e0690698c8196e9"
+    },
+    "530": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/530/download",
+      "sha256": "e984e3c1dedbf2e2fdcd2ccea1d2827203065ec57d19abf17d998ead2131ec5f"
+    },
+    "533": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/533/download",
+      "sha256": "69ac6e874f615ed6a0cfa4f9c0aacf1c334c83014622c6bc9923c698976b8e7c"
+    },
+    "536": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/536/download",
+      "sha256": "5ad546e9c8c37ca5ba71f3cc84727f35bcef4bbc5490d2986bf96a78536f997e"
+    },
+    "534": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/534/download",
+      "sha256": "2548e9f42a40c7394b815e6eee104f73a3f4a9fe7e4bca1cc3cf83e5eba76e6d"
+    },
+    "531": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/531/download",
+      "sha256": "ffcd439a60834de245939ea3e5b7ebfc451d381425720e855f93dac528f0030b"
+    },
+    "539": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/539/download",
+      "sha256": "91e925e4023cf43fe2ee134a0c626f7b860d95bac9d18750b5eda45752a8c53f"
+    },
+    "537": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/537/download",
+      "sha256": "48d56b1a23c27f2688e8d701d745128be5bf6d80ef787477c8ede3572d053be4"
+    },
+    "542": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/542/download",
+      "sha256": "217c3f914bdb997b6cf99227221d408efb77ac364ffe3f1cdcbd5aae7ac614ff"
+    },
+    "538": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/538/download",
+      "sha256": "ece4dda7b5d8abf5ba70beaa6bbcbf3fce07f31391cd58998436eab7f9b914a1"
+    },
+    "535": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/535/download",
+      "sha256": "22c54eb086cbb880868ec5cf3f51c304be97564531ab30a3cdb42c1bc1925833"
+    },
+    "540": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/540/download",
+      "sha256": "3293273d5c266c26db4d5fc770229e8a195f98a2063365b65b7743e8f9b7a70a"
+    },
+    "543": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/543/download",
+      "sha256": "7695ba077e06dcd75b927ef7badbc706f3b113a23358b72c53a4d7ff27addb67"
+    },
+    "544": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/544/download",
+      "sha256": "29c7d9661d319cd999c87fe60b986c8e5e670afa46c2b1c577a749c114ca3a46"
+    },
+    "541": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/541/download",
+      "sha256": "fdc381ac70d6ea166b37f6a57e2f6853b292b3270a13f97761a4caefb1eaf934"
+    },
+    "545": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/545/download",
+      "sha256": "dc522adb4ab394467b8160d365aeff151f04b33ffaab8ecc527e44389349df68"
+    },
+    "548": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/548/download",
+      "sha256": "b02a9a54543e3ee9e2110dd6386c8bd3faad08071516de756cf3825827f1c773"
+    },
+    "547": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/547/download",
+      "sha256": "7adacd8d9391ca7549da349fdafc44638c6fc8048bb57103fc56bbf91f8a2f0a"
+    },
+    "549": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/549/download",
+      "sha256": "f9ca45039f4851f3080a997592931504a45c959fe1aa5019e804786480ca4ef7"
+    },
+    "555": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/555/download",
+      "sha256": "a3d075c657819a07a1f303c363b132b3d511cc3d30e2dca52d9227f09528183e"
+    },
+    "550": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/550/download",
+      "sha256": "c8bc7c52cebd0f04f93653b2418b2bad1aee49629c07f22a74aa0ab3c52ae22c"
+    },
+    "556": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/556/download",
+      "sha256": "c1ef933ee563160af6c90a357208abe8f4b2cdc1cb0716695926c66e9349555b"
+    },
+    "546": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/546/download",
+      "sha256": "edd9127be1da32df172d3170aea47ea22420bb33ebaf5edf1e4fdb95c582c36e"
+    },
+    "551": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/551/download",
+      "sha256": "1fdd20bf6ed44c42332497fbaa9ec20d28000d2023a8ca85d076f90d4ce2c981"
+    },
+    "554": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/554/download",
+      "sha256": "2b7389d2ec1edb046fcd46c53f80d1e14910b432e05a6db90606fea2d72866c7"
+    },
+    "552": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/552/download",
+      "sha256": "5dc90d2c7f4dbe400644d5fcd6ca76357c4490b57f6d8697420e3d22f537c61d"
+    },
+    "558": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/558/download",
+      "sha256": "5ae92a5c3b1fd92fbb419d9743f72769f3aea572ed95f5aa9a4f4a7554a2dea0"
+    },
+    "557": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/557/download",
+      "sha256": "365d23081f3747f1ae6e4d26e92017f845d1084422a427e2dc6a8f872b473e3b"
+    },
+    "562": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/562/download",
+      "sha256": "c2b92c7fb639ff9f4ee9cd4effa504c1763441e71e5e00c64d9782f72672d089"
+    },
+    "559": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/559/download",
+      "sha256": "ab098d12a5ad23d9a5df22cb61427269dcf925e62cc4597d820c8ab483893999"
+    },
+    "563": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/563/download",
+      "sha256": "b306b194ac920a6c5ccbf6f9e7573a4d0d147562f8ad9afec21efe9acb27eb62"
+    },
+    "565": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/565/download",
+      "sha256": "44f1f46d9f24b3c2776721f809ee9a8ba786d7fd34144ecfc1749b3803feb725"
+    },
+    "564": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/564/download",
+      "sha256": "67963dec02997cbd4c9bcd43e6c705a90f9f353c59ed4fbc2b3e01d756b98915"
+    },
+    "560": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/560/download",
+      "sha256": "345e0f09330f1f24bf134ca582a15c597c286912ae90222794ba2197d74c02ae"
+    },
+    "566": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/566/download",
+      "sha256": "edb91d4c033bb78da04b13fcc5cb758ae5e043605f401dc7950eae9bf8850b70"
+    },
+    "567": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/567/download",
+      "sha256": "c65d4d291babf107a3cbd9bd7d9dd573746a6e217ffb167f698b04a246aa9c90"
+    },
+    "561": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/561/download",
+      "sha256": "67480f9bbe0fdff20809fdddd6d3e2ddda0977102fc40107315977212dd02ff9"
+    },
+    "569": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/569/download",
+      "sha256": "87640faabbe0141bcd57fb066b5a150e7e927831631bdf2aa054d0db3b3580f9"
+    },
+    "571": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/571/download",
+      "sha256": "4db2d6455da78a2c2905e6f26f6e233f1c3c03a70903ebd1f4224e0999a80414"
+    },
+    "570": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/570/download",
+      "sha256": "2102636a1c92a3142d48d8917e9acd4d0d931b89ff57d9a83d8019fb369d6a12"
+    },
+    "574": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/574/download",
+      "sha256": "cff2ee91339e8d836335ced77000b1c04edd2db5e0e0d4ecd30629ba6c4e1ca9"
+    },
+    "573": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/573/download",
+      "sha256": "689ac7b41e499901c6532a81dde4b9aeed4d08dde7b2594740e4ff64d29bea0e"
+    },
+    "576": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/576/download",
+      "sha256": "2e25855aedc9172e5b6c80b9df5913091d0e2105564f21523cf150fa24fda5e5"
+    },
+    "575": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/575/download",
+      "sha256": "3d3bae0f72c7f5defd30bf33c6e2879703628c0e8840672ae2233b8cb8573f4e"
+    },
+    "568": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/568/download",
+      "sha256": "444814ba15aae86f54074d7ea84102c1d12b63c8d1137f97ac7c0bb2de7d7947"
+    },
+    "578": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/578/download",
+      "sha256": "2453c8ebe716d34734d9db80c7862050f9987622f8eb9018e4f0966fcfa2278f"
+    },
+    "577": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/577/download",
+      "sha256": "bf5e3f62a9a43395b0e6fea788466c967cb63742baf55a85a563db62ab04df49"
+    },
+    "584": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/584/download",
+      "sha256": "91d71fe5d09327c88eeb5a30d44989205e6c141b35207331f3ec824c65ce3165"
+    },
+    "585": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/585/download",
+      "sha256": "fdd7066d95687f077adb0387336ef86c2e6d424f4fc3362949196662d6d213aa"
+    },
+    "582": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/582/download",
+      "sha256": "df94e054a2b599b406ab35f6fc3b5cda81e0bc9c43663adaf79ad622935b98ee"
+    },
+    "581": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/581/download",
+      "sha256": "1c044a95287ac26d9bb9ccf1f7cf019debb73ff9c3e2b61f163c36557b89b1d6"
+    },
+    "583": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/583/download",
+      "sha256": "014042942e13f72ff77c48333a5ebcf1e8c724d33fa04383006678e1b3a14789"
+    },
+    "579": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/579/download",
+      "sha256": "23824e8b705565bd9b0437b67f2e5eee6ab8d44b5e07ca7ce6b944f2b92a9ab2"
+    },
+    "586": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/586/download",
+      "sha256": "d6900d8dabc4c3f066dc848a5456e75f55fae5bab60a1f5b6e64f14b5e652ddb"
+    },
+    "587": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/587/download",
+      "sha256": "bc566e7aa892be552645e9da41caf0266c43c57f186e91a3fb52e1d7eeda2483"
+    },
+    "591": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/591/download",
+      "sha256": "873fb9447934c61d55bdde365c0529912866d21f6e061ed7ba4be0e2af4741c6"
+    },
+    "588": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/588/download",
+      "sha256": "0abd2a86b8482cf388a4ac58946e6bf3a136ec9ea9e2445f225e356372ae363d"
+    },
+    "594": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/594/download",
+      "sha256": "62d4b90843a32efcd1c125cda81359d9411fe91e1990684fcae0cb066c0f7f06"
+    },
+    "590": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/590/download",
+      "sha256": "ce5195bb3bd2d47ba22c1b4ac1d528b86d3170c4c355120990f912de083c917d"
+    },
+    "592": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/592/download",
+      "sha256": "446be4d6d28bc5396e00f50f0da73cedd93c22fc3819905ec7f437f95144ffe7"
+    },
+    "593": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/593/download",
+      "sha256": "d5522fdaf57d070c1da7ab3fcda363c865f201064f14a3c714b68aac809c07dd"
+    },
+    "580": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/580/download",
+      "sha256": "7a79294705c6a3ce16e7ade6c323178c2b36fb6ff5119a095529173c576978a1"
+    },
+    "595": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/595/download",
+      "sha256": "c801a2a1089fa266c2bf7410e7f9f6c1014c88678b8338690d5a3d673d3e9129"
+    },
+    "589": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/589/download",
+      "sha256": "b3cec2390eda22c87dcf44d99e9ef239bf0968d2e71f33311bbf5d02785247a2"
+    },
+    "597": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/597/download",
+      "sha256": "b8b8b896255839ab1bd168bb60fb6e3bf817cc7c13261443c2ceff3f4ae55234"
+    },
+    "600": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/600/download",
+      "sha256": "08dc2a9c3578c1fe342c082ed97d664eb390b82d41fe4716f108ce8e321095fc"
+    },
+    "603": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/603/download",
+      "sha256": "208767355a6ed4e15adf94dd6e023ebc74af7530630801d0c6a57397a7d20195"
+    },
+    "604": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/604/download",
+      "sha256": "1456c345d76eb9a4d5dc6406821e79f09e82b5784067eae0f0c0bb5015eb753c"
+    },
+    "602": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/602/download",
+      "sha256": "6bc9152789af909468950c8c4f42238a181453baa1a51680aca9a3688ffa3e1e"
+    },
+    "596": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/596/download",
+      "sha256": "bd0a997e946c9b37a5d3acdb685b1f7b53aba34f644039681cc80fba9e328eec"
+    },
+    "601": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/601/download",
+      "sha256": "1db52f0298bafb8bf4eabf9cb10d4e91fe34af7c89ce3ec43a7f0291d447ec7d"
+    },
+    "599": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/599/download",
+      "sha256": "90f93766371bdd5bc96dd8a32228627891b46bc446bb11d8a2a724f32c5b4c56"
+    },
+    "605": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.15.2/605/download",
+      "sha256": "c5c6b09e162194f89751b86822304f764c080979fb42647e290bf408b34ce0f6"
+    }
+  },
+  "1.16.1": {
+    "710": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/710/download",
+      "sha256": "e55ffb540c59b1798c62f5dd354adce4a4e328a05f876595274b587139da3efb"
+    },
+    "608": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/608/download",
+      "sha256": "9b8ba7a7607d6555bff979308c5f1bc91b4f17e4b6843c6b756a491d094b13d2"
+    },
+    "610": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/610/download",
+      "sha256": "ef3263c5996087c942f2939bc16d82eda5b785d6fe64567bf82464a442aa3212"
+    },
+    "612": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/612/download",
+      "sha256": "898e85c2faa7b3de55c20ae0b1d1ff887a7073ecd3db6ccd5e3f0e4a625c3a86"
+    },
+    "613": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/613/download",
+      "sha256": "8ec69163c0f8b6c47b7ddb609b4f47ea1e6cb799e9fa508432c542b2572c863d"
+    },
+    "615": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/615/download",
+      "sha256": "b6c5b5d982fc1694e6228c3bbe0a04c7771dbaa200933581bedaa54632591a4d"
+    },
+    "611": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/611/download",
+      "sha256": "4db685eef862d8aad7cb5bbbb42d2b2291a4f3a34f7adfc3e93072984b2158cc"
+    },
+    "616": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/616/download",
+      "sha256": "a3613becd21ba66e308170ea0ee8f2c2a283c2e0ea1a6bf37b99ee076a38d212"
+    },
+    "619": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/619/download",
+      "sha256": "6f9c254cae64fad6d69ccf28367983e57c979e6d166016b7d66f1d84a655e391"
+    },
+    "617": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/617/download",
+      "sha256": "396b367f3e6b9b3e7ee63e1c82a2fbac35b69c246bcd839ef34049932c9d1f13"
+    },
+    "614": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/614/download",
+      "sha256": "24270d7f9b738fc0c2e5593c75009e5de6ab667df9c06b8ff89d1e15fa26691f"
+    },
+    "621": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/621/download",
+      "sha256": "eda0a0de15ba872c109d0c139f6914f98d29b6533df5c2c9c4a8349df6a34458"
+    },
+    "609": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/609/download",
+      "sha256": "8951e336156a015c078a999eaf39c2955d6a8ea37aca999477920822b05b8962"
+    },
+    "623": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/623/download",
+      "sha256": "12d19040822c2c671160b89554b4c250e033d771802ce015f9763252574f4276"
+    },
+    "618": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/618/download",
+      "sha256": "47da432bfa885692e69a8750ba39cb17ddd4f5f6be87d42af94f8b7bab8c8214"
+    },
+    "622": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/622/download",
+      "sha256": "dd8fb34c8cb66b0cb7664c028f12a3ad6345bc471e2a6217b228d5c2b7197c9e"
+    },
+    "624": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/624/download",
+      "sha256": "154c0681c1f99e75503d8e9bb0b9bcc384740bf210260e20c46b24a3121b4df1"
+    },
+    "625": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/625/download",
+      "sha256": "51c742027f7f02dbe767a78b86f2315592c87fb8ac591b2433979945c16b6266"
+    },
+    "630": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/630/download",
+      "sha256": "b98d1703d14af05da8cb327c3e2e32f8c439a309e0f30110d9ea354ae67bef9a"
+    },
+    "629": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/629/download",
+      "sha256": "0d10d3b7e5269a46e6bcbeb3e68261366bf8c4bfeed0494342994114f0fdeae0"
+    },
+    "633": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/633/download",
+      "sha256": "c2f9056b9ef8adb1c10275309a71c1b4f3029d0a724374ebadcad66c897432df"
+    },
+    "628": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/628/download",
+      "sha256": "2eecc022d75d91f79150cc898923a20512149ce83bf5dd5ee43abe1f9b207d03"
+    },
+    "620": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/620/download",
+      "sha256": "0a82773717f6e234afdf54dac647aebba7629fad74586db4c1ae373003b4f533"
+    },
+    "631": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/631/download",
+      "sha256": "8d7c4ec0458b17826b5420cc41e3ecb0ac2d674ae8654d4bdf612073248f9181"
+    },
+    "632": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/632/download",
+      "sha256": "c820f92257c711e46a9b95b1f1a534e101fb4c559aa5c7c299a3a24fd18fff98"
+    },
+    "634": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/634/download",
+      "sha256": "47ffa839b441fe94e4e7e60b0e6ad1ff7ad91002e0ab977ba0ac4836ce471841"
+    },
+    "627": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/627/download",
+      "sha256": "a748521bcc4372e70c27beff92b03a08bcfb9a26fa7d106043f27690ab03b4aa"
+    },
+    "635": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/635/download",
+      "sha256": "c84ec59ce1a5b3681924c95d2b8b9e3729916142ddd44ea760e604e2e0cacc64"
+    },
+    "626": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/626/download",
+      "sha256": "3bf8295e01ea448d6b5a936afe9b2b5ae3d83c380577dff6270386a5e4418aee"
+    },
+    "636": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/636/download",
+      "sha256": "65fc75bf6c7c8b405f0158ebf49c1373430e7397498970f8ae752136d7acb134"
+    },
+    "637": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/637/download",
+      "sha256": "9913c9cfbc2c6a4b2f08d26922bae48407bde36e2ea278aec0605a43be07dfdd"
+    },
+    "638": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/638/download",
+      "sha256": "204f3b0f3cccd171be53026ad5bcde09f8dd3755b7c9188567f0fef0bc2e874e"
+    },
+    "640": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/640/download",
+      "sha256": "a1d421cc8bce14065bc2be53504af85a981e30cf5b0b3f9d2aa97c7dc47901d8"
+    },
+    "642": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/642/download",
+      "sha256": "ddd6dcf145730db55e7e7018e22841e9d71ca6622059c13550201466e5e1f1d7"
+    },
+    "643": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/643/download",
+      "sha256": "aab534c90b08a7f581d2cf55203c2eac8f183f5401656876c0ee4a6e33c74bfb"
+    },
+    "641": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/641/download",
+      "sha256": "b2b49287c36b4e7aee616b20c8c3b23fc158a92784d7a2b2282cfc55f4a3fe3e"
+    },
+    "639": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/639/download",
+      "sha256": "26ece6dca6aac63045ce54f0911e1314e51e36a19c8ea7c94efb360a378b350f"
+    },
+    "647": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/647/download",
+      "sha256": "05b389763d928b494f4395977ab8d174cfa68a4f60016f7ee3366a36fe4b29f1"
+    },
+    "648": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/648/download",
+      "sha256": "cf92ba3220b699fd772c29e37717a5e3e5954106451adab8d3eea18de5f85122"
+    },
+    "646": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/646/download",
+      "sha256": "79308aa7649f8e8d7df8ac93814f1fd8600b1118520c0a61c08c9e6c9142fb95"
+    },
+    "651": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/651/download",
+      "sha256": "76b8e6263dd80f554313dacaf782604e69a91129e6fbd74eddd72f40b165586a"
+    },
+    "649": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/649/download",
+      "sha256": "b32abd562cf654cc0e595f46a7f96d5770cb23e3273fc4624266fbcfeccad154"
+    },
+    "652": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/652/download",
+      "sha256": "da569bdb92c2a29a5e47ec58b30eb619ab195798f6cb4ffb0fa29f6df6513747"
+    },
+    "650": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/650/download",
+      "sha256": "8c50bb2febe62e043d80f6b88d3e6c88fb9e99d516ebc060d0f26efadc9264fe"
+    },
+    "645": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/645/download",
+      "sha256": "f2dc0930a286607acc2b9148e57afd808c6c6195e01a02284f1ffe3685f55f8d"
+    },
+    "653": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/653/download",
+      "sha256": "53c59f27979c43de05e8db65e2cb08f1679fe235f325e2a3ea6927fe0d8aca29"
+    },
+    "654": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/654/download",
+      "sha256": "864c02767f63f9bfe416df1313df6820cb6e766ca0a6eb64c605330a2058aa8f"
+    },
+    "657": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/657/download",
+      "sha256": "b82f4fcf886d82943c987a2a957cd55d2119ec4d8f1e1567952499e908d3a641"
+    },
+    "659": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/659/download",
+      "sha256": "80652654d36f53dbbfad4a8fff39cdbda011510d0e15caa037780fed50f2f3dd"
+    },
+    "656": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/656/download",
+      "sha256": "b62f0409de450c24e47d234c1fe37e22a20030468c8085023ff847318ed7d96d"
+    },
+    "662": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/662/download",
+      "sha256": "269c61af2f69305fc67630da17f22be4c1f88eccd5f1af7de64c49289d30c2e1"
+    },
+    "663": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/663/download",
+      "sha256": "7e8384dea67612c21c877cfb1b658272a856294bbf685094dee56fecdc760df1"
+    },
+    "658": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/658/download",
+      "sha256": "3dc38fddf72a16cb0a5572975390ac5f6fbc68d9ca52c91e2ac73b21980676c2"
+    },
+    "660": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/660/download",
+      "sha256": "5b883f4dda76abd718960c9d47a9f6ab3a00fd683ffdf049ac2c35c9b92a5f88"
+    },
+    "664": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/664/download",
+      "sha256": "148ab930e363f18dc1f6465e92463fb342e6d10f2045664af85e065066b026c6"
+    },
+    "655": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/655/download",
+      "sha256": "94705406c11ed27b9c17f2731fced517275fc1a1542b224438adda0015e658b2"
+    },
+    "661": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/661/download",
+      "sha256": "1107dd832dddbadfb95a16e38fefd92b3d53976e4d532310cab485c093e89481"
+    },
+    "668": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/668/download",
+      "sha256": "8aa4c4e6223cb11058aa0d18103f3da04255cbf4155b13bf15d611e97b0e56af"
+    },
+    "666": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/666/download",
+      "sha256": "efdd939bf1cd59de189167d4a95720079a7a02182614e2e87d0313fcd4549ff7"
+    },
+    "667": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/667/download",
+      "sha256": "6cc1e700f377ab459da97039209b95a077d41ed3dc6c75414c0fde45675e9982"
+    },
+    "665": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/665/download",
+      "sha256": "165ae710dd98e76450390b30fe2e2b6b641eb3948f77a301c27d0333aef5afb3"
+    },
+    "669": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/669/download",
+      "sha256": "3bc45d2e040920d5f0304e9d2eb960934a012d04ea0591a99934b850fb74b31e"
+    },
+    "671": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/671/download",
+      "sha256": "b3a504955a384fd7d6a0f25fc756fecbb86247f4566f1e9c39e2df6f03eb8fb7"
+    },
+    "672": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/672/download",
+      "sha256": "66bd11551a5b7d9c63b1603051c9e81309d3b195c33d108e7028385165dc5db9"
+    },
+    "674": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/674/download",
+      "sha256": "84a8acabc36d9d985e379cd6178670b4d712fcab57b8547dbb7c0ab7978c5b4d"
+    },
+    "675": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/675/download",
+      "sha256": "03eea1b067b5ba7809ae38899b09f4979a60b1d9ee91cc4baf2fd58a9b4a8ef3"
+    },
+    "670": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/670/download",
+      "sha256": "e0513f87e0c839838d9db26535a5c48d1185b7d02856f6101a75448e41448692"
+    },
+    "676": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/676/download",
+      "sha256": "66a26558eab8bd3fabec4faf749dcd609706767d5579af20e6ae3d51fdeee48d"
+    },
+    "677": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/677/download",
+      "sha256": "22e83b588a6984cbce4678b99c257d6b66029b31bd4e268853cf97b8280cd130"
+    },
+    "680": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/680/download",
+      "sha256": "e6795c0d6471b5d8f320448cf3cc0bfcf68b11231cca25820b3e302be261e832"
+    },
+    "678": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/678/download",
+      "sha256": "d965016c0a27b31d5f1fc960f0bdcf304c17942cb574f4e5b9441c2156f1ae84"
+    },
+    "681": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/681/download",
+      "sha256": "1d6b35a27667d5451f3bf2b67e6b59fa3871ce4ceceb66dae27f6a1a6f5cad2c"
+    },
+    "679": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/679/download",
+      "sha256": "66c005266912f664fc1659b6182d61c72f169f8117d0cc56f2ef5c8ce3e6f9c7"
+    },
+    "684": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/684/download",
+      "sha256": "52669519c983885fd5040c7edf671d9ee4c4387f1f769c03a1ca11cfdeea8eeb"
+    },
+    "685": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/685/download",
+      "sha256": "fed40d163dc7977c3aa06ad52b98ee19e2ceaa064f93c23140ae32594a9ab99f"
+    },
+    "683": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/683/download",
+      "sha256": "761b4013878f78320f03573c657d805f9fbf4d91b818bf48ce74bf3efdd2ae50"
+    },
+    "687": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/687/download",
+      "sha256": "773d811ede5cb34e57b66dcabf33dcd322b0394225e9fcfac373d089e7c6b0b1"
+    },
+    "686": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/686/download",
+      "sha256": "30b44982acf6fc743bac4ce258d1a7afdfb680f9ce2d596a6715f82f93c43b41"
+    },
+    "688": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/688/download",
+      "sha256": "a0dee7788dc2a633cba9eea3e424f3476eadf8b1c4daef2a9c4788a0fd1290aa"
+    },
+    "682": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/682/download",
+      "sha256": "636a3f5e7a22e07976f136e87bed8d3d32780b2d6a1324154e206f92312c8bb7"
+    },
+    "689": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/689/download",
+      "sha256": "d4a73b731a9e335801fbea801022635241cc5853fca19d430f0ff48dd42cd10b"
+    },
+    "673": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/673/download",
+      "sha256": "ea1c22e9884aa600850d205148eb720f485c48fa079cac985b6fd64467cbc14c"
+    },
+    "691": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/691/download",
+      "sha256": "ea16c8a1e608282f25c2a58b747a440b0c4d4c0997c7469c123abb372e9a66c2"
+    },
+    "696": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/696/download",
+      "sha256": "dd264d1f0db1c171efdd408af6b571bb6c385b390f8ced3a1de2f15d204e1de7"
+    },
+    "694": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/694/download",
+      "sha256": "759de28b6b3a0f4140958ca58c1a8f489e5fd27bda02434df844e48d1dfb0870"
+    },
+    "693": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/693/download",
+      "sha256": "a4d550df58859687af2971d62c72eb9cf65decf7784bc1881ad8fb6bbeac506b"
+    },
+    "699": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/699/download",
+      "sha256": "a2af85b96c1c3c1e43e3f1d208cec2d5268bb29afc118545e8d5c7f7cd6e1876"
+    },
+    "697": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/697/download",
+      "sha256": "7ff659d81b35054f8fad4c63d7b53112ac75cac16fdb0fc3b26f97aba77f8b2d"
+    },
+    "695": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/695/download",
+      "sha256": "292a0be8c17c63c893fef33ab399af59dea4a9f35872c406c2d9aaaa62d15744"
+    },
+    "700": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/700/download",
+      "sha256": "2fe8f62608bb1a0086128a00c6603ff579eeb61e0b86ed2a68b91021447251f7"
+    },
+    "698": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/698/download",
+      "sha256": "d7991adaa7b049b77b0fb0a40f4a6dd58f9f363ed44c6497402797af45fb8754"
+    },
+    "692": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/692/download",
+      "sha256": "e6ec535ef75c272a026c4640b59414305270c9c9972cb37ccafe471322d4bf33"
+    },
+    "701": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/701/download",
+      "sha256": "4730a05f393382619900c0df45c55eccedf129cdc35162d6da53c6c0677bf254"
+    },
+    "702": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/702/download",
+      "sha256": "0e9877592893433abfb1e7ba58d63c68bbee8519e5a7d31886aef3170bd86c58"
+    },
+    "705": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/705/download",
+      "sha256": "6a314eb0e430c45a4a550785a214cd59090eb1998132e20e3b6c4a1f0a9e59c6"
+    },
+    "703": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/703/download",
+      "sha256": "c5c1b58387c2918f1479f2addda3cd8b83f6861964e1ee085d5376f3022120ec"
+    },
+    "706": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/706/download",
+      "sha256": "322b499bce8e8f64f1e6b8cacf10170724be23827e4eaf7cecc7ff70dac34e36"
+    },
+    "704": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/704/download",
+      "sha256": "4743450e54336d49d75879d87e97f99fc92371ce30fd1d5653718c9187c1250f"
+    },
+    "708": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/708/download",
+      "sha256": "fda7af8df22ae1c82b75c98e87e4b5a29b6fa4aa892fb2e32734face37c024f8"
+    },
+    "707": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.1/707/download",
+      "sha256": "ce320fb87e76a01a84c6d990a77dc727308bf789bcedadb9ea70a3a72b619d72"
+    }
+  },
+  "1.16.2": {
+    "750": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/750/download",
+      "sha256": "85cef82a550ebfa6804ea8e2fc166e24184860fa9ab3efbd9b9f796d9f83055e"
+    },
+    "711": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/711/download",
+      "sha256": "bc9e121f8a47754776c6de3588b828566a395409e5a9580495e1f27e1495c258"
+    },
+    "712": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/712/download",
+      "sha256": "09affddf85ffe3633551b85cd906eb58b629815e5c716275bd5efc9c6527d260"
+    },
+    "713": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/713/download",
+      "sha256": "11bdff3914540d262aaac4592d7b94f6690aa79d8b46691cc6858c182533c55e"
+    },
+    "717": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/717/download",
+      "sha256": "1a0ca8a8e2d14ee86be9d1e56373049b53862dcf2d4fe5b5b638aa4d7f85597c"
+    },
+    "715": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/715/download",
+      "sha256": "7b834754cbafc7c4d1de49fedbe193d133ff1196fb551dcabf63cbe58a0b9478"
+    },
+    "714": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/714/download",
+      "sha256": "3fe9fe9a47407e913c9e1347b705fddd597ab8a872cfddd0d21b80ea0e106236"
+    },
+    "718": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/718/download",
+      "sha256": "21281f122266210068924cd2030fb08dc98db3c818e598791028fd0d177d261b"
+    },
+    "720": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/720/download",
+      "sha256": "9ef4a6995328442828d21015acffcbbf568c684dafb5a43bc5c50b4bbfc28132"
+    },
+    "716": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/716/download",
+      "sha256": "5e0c1dd8afbf4eb4c83039f957923fad92b87a15514b66ef0627fcb38e5ba59b"
+    },
+    "722": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/722/download",
+      "sha256": "034c913123fd4f64c3cd1883095508fd45aa9f824f81bb63f98eeeb209c943dd"
+    },
+    "724": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/724/download",
+      "sha256": "4a72b6b1d5f079d76bf62d07901c109769962b2d237970cf27d171bbcfa2d532"
+    },
+    "721": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/721/download",
+      "sha256": "10743837ae37dba3b6e478a54b71ad2d33f71e9de9fe86afc18181623b36d0bd"
+    },
+    "723": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/723/download",
+      "sha256": "6d837c4637edb7b7fe8bbfde0f3b4b3c4042a9db850144b3345a473a6add9c8e"
+    },
+    "726": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/726/download",
+      "sha256": "07460513ba8ff16c2542fde9901cb1b4cd01951de04ed47482a0c5bee514aee4"
+    },
+    "719": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/719/download",
+      "sha256": "13d08bee8abcfc2bf060f6d9be1219ca27bdffa791dab785c25065c7032c7457"
+    },
+    "729": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/729/download",
+      "sha256": "e3f968acb331c818b0f0e374f174d7a6c554f26b4e5d9a3c8e8faa9204afdcd6"
+    },
+    "728": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/728/download",
+      "sha256": "a2d4b9195351ed614ba66c04c1681301a7421829e757d2357af026ea197939fb"
+    },
+    "731": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/731/download",
+      "sha256": "6d28c852772211696afa98a15e528789135ed2950ada14b4313c676d2a307f87"
+    },
+    "727": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/727/download",
+      "sha256": "575a64a333f0c2e8292c5f9a92768f2c3b83e8db487ce8685927bc06dd77cffe"
+    },
+    "730": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/730/download",
+      "sha256": "8ba4ee08005e156da53ebd5c43befed3d969623bc25611acf5330dbc9f56da69"
+    },
+    "732": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/732/download",
+      "sha256": "c4546b2734c7b49acdded690a3ff53d5703c6a222fe28683eb1ffa98e1696d50"
+    },
+    "735": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/735/download",
+      "sha256": "accee35036255cae794d1a390abc019c14d67034d9aa008e47a96816d96e58c6"
+    },
+    "733": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/733/download",
+      "sha256": "c7093e74183026301533b05fc75b4c58ddff9621bb8de9d1cf3c57ec92e0c627"
+    },
+    "734": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/734/download",
+      "sha256": "a7651a6d587c275736c3e614ac1c2516eeda531a718814565064458a5dd8ae23"
+    },
+    "736": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/736/download",
+      "sha256": "93fd37f10177877003f2f7c13fdece899f27cd46d730e89f1b561542ec7717d8"
+    },
+    "725": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/725/download",
+      "sha256": "6cdbd9cfc25e75d95e1b47bee8b9e52729dc4b958c0f6c2ec09a3c1338c48d95"
+    },
+    "738": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/738/download",
+      "sha256": "68e5da86e3a7f95f7251cca769e6243a29511771fab428145e9ef83ae7675d58"
+    },
+    "739": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/739/download",
+      "sha256": "c2001eb75f15fac8866f021971cf1f34b9af002f3f794aac4238f1a8522f6d96"
+    },
+    "737": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/737/download",
+      "sha256": "6dd3d4021e2eb41ad4931fb6ca74661f121d3ab107b31e12ba0ada62e4f99a8e"
+    },
+    "745": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/745/download",
+      "sha256": "84ed02645a341ef3eb656bcf008c5f30fa1f2e26cda8c8a76a8f32dcc50b45e5"
+    },
+    "747": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/747/download",
+      "sha256": "907445310eb05dbefe75d20c2e8c462ca5679349ea60457e7956dceaf2c15d12"
+    },
+    "746": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/746/download",
+      "sha256": "f3e464fa050fee03627c576807c344f43daff3eb1f7aafda29969ca698426810"
+    },
+    "748": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/748/download",
+      "sha256": "896c0f1346fd13e4e3a594e82a074eb9032e5d24eaa8d2a61833d2b98ed067c2"
+    },
+    "749": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/749/download",
+      "sha256": "c0671b2e9d1b53b1dcdca390cee558a4fd24cde31fcfd036644fb5e77b447f96"
+    },
+    "740": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.2/740/download",
+      "sha256": "b06cf6cf24ba731b3a486bbe41455c933dfeebcd6db7b1aa2f39792286b59d61"
+    }
+  },
+  "1.16.3": {
+    "808": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/808/download",
+      "sha256": "9d46992387cab7f2242c438071cc78786f7661bf8013d09537e950533ee037d3"
+    },
+    "753": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/753/download",
+      "sha256": "c4e96ddf5948fce1e8c52d912870b4748453fd9c5079c55204082bdd6931e142"
+    },
+    "754": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/754/download",
+      "sha256": "46fba77fbce4ce9d52048c70bdd25978fec4caf62937ff9c751daebf6a44aa58"
+    },
+    "755": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/755/download",
+      "sha256": "269169cba32684efc67853d6144f5f30e015c8991fb8cd8dd6045f0398c36f67"
+    },
+    "756": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/756/download",
+      "sha256": "967f074e7b78e7e8756c0c068b782be914776e17bce90e59c19b7931587e04b5"
+    },
+    "752": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/752/download",
+      "sha256": "4c912d4044cda0ecae98d5b6c28dbd0e31426361b166ad2eb9c2ce70e2cfb50e"
+    },
+    "757": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/757/download",
+      "sha256": "859a54f4be57f91eea25f17b45c6f1f0ebc73ccfc6953f973a7774c937c9e6aa"
+    },
+    "761": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/761/download",
+      "sha256": "5bda21731a5863e806421ff24c05b59afaceeec9abc94e34707676e65392ad13"
+    },
+    "760": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/760/download",
+      "sha256": "a303de77804909ef1bddd6c8275482cbb9148dd87e0d5afe0ac64a7a1f422b13"
+    },
+    "758": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/758/download",
+      "sha256": "3bb5cabff92d672d519564dc0256a5c4287fed3a99048db58a03e04a6106349d"
+    },
+    "762": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/762/download",
+      "sha256": "b325b2ff58e88da12a9f4455e478786ccf4d42f92c3f08523dab689c5e88170d"
+    },
+    "764": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/764/download",
+      "sha256": "4f8d31a5dbdd87f9bd1bf48774ee8380a20070d2ebb531b5642db6a43cfc61f4"
+    },
+    "759": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/759/download",
+      "sha256": "3ba5572f4bc3228781320857a398fbd897a2e8e1bafa2c33fd9969fa2c1f7082"
+    },
+    "766": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/766/download",
+      "sha256": "0f3d1794bc7d73190f887b2827f2fd6871b69461266fa4689a3c25fb104684d2"
+    },
+    "763": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/763/download",
+      "sha256": "68c2e8ac22751fa11469d4783a3ffeb73ce439944b642985ed636588de196ee3"
+    },
+    "765": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/765/download",
+      "sha256": "41354a487db68c0bcebb42e63ff3cdcb68a68983f1fd770eec8e5d1b77fce975"
+    },
+    "773": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/773/download",
+      "sha256": "1fdc0e87c593f1229c9a3d187c599ae5016a55f0d82d4f79b808061bfb433a98"
+    },
+    "770": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/770/download",
+      "sha256": "560a58999d283a21308de74a3d233a99e9af1e115d3ee45b29913b41c179b17e"
+    },
+    "767": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/767/download",
+      "sha256": "b6b883151eaeb609b495c653659d377ba1d0c6b860ce24cf21eb5f25a8ea5ae8"
+    },
+    "769": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/769/download",
+      "sha256": "a6028cc46d44cf802ad8b53ea44a0b031a1e8125cc17eb4c458a0976675d2df5"
+    },
+    "768": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/768/download",
+      "sha256": "7f8d9873a927b1c69b960e9553d4e0ce03360caa9e5d2d76ced5ae77e9285a1d"
+    },
+    "774": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/774/download",
+      "sha256": "e525311d3eaafd162a0797b616362135773d6fa54ac6b93a8617fbfff905eb2a"
+    },
+    "775": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/775/download",
+      "sha256": "ff3c071c91ed58829225dd36f5984a80f6e4bb5f9fda6348902beb82cdd0dd3e"
+    },
+    "772": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/772/download",
+      "sha256": "da4b12d149f4b71dc5762f639d54edf87557920ce81efd8fcbb24796b890baa7"
+    },
+    "776": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/776/download",
+      "sha256": "725a87f426d75eecf684f2131f01768d16e02e81e3e0aa5a1aa722fb5c18f9b1"
+    },
+    "771": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/771/download",
+      "sha256": "061fe84f7c1f1172768f7c310780ad1175afb571c606c4c9801b9a1bea338ee6"
+    },
+    "777": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/777/download",
+      "sha256": "559a63e63338617faaa2ca291575486c7a82d90330542b071c1a5a4fb12661f5"
+    },
+    "779": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/779/download",
+      "sha256": "00d994a1203e4a22a1dfcf03d78d71425969ced9b0ccc98d578483591d142b87"
+    },
+    "785": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/785/download",
+      "sha256": "57b4c5c665e527e50e28d04c42488076ff72a4e3726be10ceea305ad044d15c0"
+    },
+    "778": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/778/download",
+      "sha256": "92e535331359d4edcca20d1a85502cdc73cd5115a8ae519b614d193a68f350be"
+    },
+    "781": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/781/download",
+      "sha256": "3baee8ebc8c99bcd32dbf22b377f81058b47597f0d68e42f87b73469554b7699"
+    },
+    "784": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/784/download",
+      "sha256": "5f80eb8f6690507b86ab8556169a23514f7ffd784efbda7b94fc849da9ccce14"
+    },
+    "783": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/783/download",
+      "sha256": "4a1200ae1e9e8c0fcfff30ab29accd1359f05dd8d01746fcd5362053a4ceef90"
+    },
+    "780": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/780/download",
+      "sha256": "eb244ed55abf41347a574ebb52ddd37c61087d0e635f5b7ef3101fa143e6a1ae"
+    },
+    "786": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/786/download",
+      "sha256": "b432064dbccc675a8d77f07dab00b63844bb13a9c2cbd5e6c7057dac95ca0077"
+    },
+    "782": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/782/download",
+      "sha256": "7e2adf845be4077051fb7394ceb1fd5741f15913bf611e633c10a0df89178942"
+    },
+    "788": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/788/download",
+      "sha256": "85581f1de2260fa9a0c51376f12f2185c3194becff3e5503def79398f17b25f6"
+    },
+    "787": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/787/download",
+      "sha256": "f87cec732816a9186c6d25d325273d7465db2f364daab3b8e64da19e6fd5826f"
+    },
+    "791": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/791/download",
+      "sha256": "e4b3f8d429e1554cd65f69c9dcd220ec455ce2d131e80acb4b4ce0cb3dff5bc0"
+    },
+    "790": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/790/download",
+      "sha256": "d5251d17b8f81837acd95f9f4459339f4f99ae39ad4411bd44f597632e411ac5"
+    },
+    "793": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/793/download",
+      "sha256": "f8e7fa65e9aa12dd1b7812e1f78f03a43fb6ec1b3636e471c4e6cb66e7e5b7eb"
+    },
+    "789": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/789/download",
+      "sha256": "02115d88a90e022aee35e9677c6e8eb09b80ea4b6b823e78deef47cf715b89f3"
+    },
+    "796": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/796/download",
+      "sha256": "cbf80476ab5a2e7e7fabf23d14d0db804cbc2cb10bb28fcc9c63c66faf38106c"
+    },
+    "795": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/795/download",
+      "sha256": "81316c4ef444d643a0460e9843ba11a770c4147018de9b9ce9fb83a697f56fb2"
+    },
+    "794": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/794/download",
+      "sha256": "a7f1c87606e0d123e81f379c1e88a04905ba58301da2ba007a16e70bb04ae4d8"
+    },
+    "792": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/792/download",
+      "sha256": "b020363ece4d9a0e55fe03382e308fdee6e542c89b6c248e1f9530fef4a4a594"
+    },
+    "798": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/798/download",
+      "sha256": "5d6df053a9584f81c81b406c3232c503f5e22c894b9239ceeace93444923af56"
+    },
+    "799": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/799/download",
+      "sha256": "f5373045bca4b67cdfc0373c43ac297dcb67e0b339bedda1c11007232f3e4b7e"
+    },
+    "800": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/800/download",
+      "sha256": "5621620c4c43b909ccd55dabdf27045471300b53d4fb4c418bf369de254ab042"
+    },
+    "802": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/802/download",
+      "sha256": "f83774694570cdd951bdb18581de10c7ab17d35bb9243792c58ca3236669f43f"
+    },
+    "803": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/803/download",
+      "sha256": "f684744fca55154f7fd7e255925233242bc689d700a65243d38c9ed1a1667a4d"
+    },
+    "797": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/797/download",
+      "sha256": "f318aacde0df4fd7b6cc80baab71429b594727265f063278aeae4f61f3820293"
+    },
+    "804": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/804/download",
+      "sha256": "6e7cde2d58fd4cd1280d88dae00b98278491e3684c8ad59d019fe51f04394b0e"
+    },
+    "801": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/801/download",
+      "sha256": "fa8be0cd338f115528853a17f966d925d63fa6de5db83b562e9332c5a2aa3a96"
+    },
+    "805": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.3/805/download",
+      "sha256": "51376745c8fe1a3f2fe7257592bdd3bf2d37865befdbdbf29936935471f855af"
+    }
+  },
+  "1.16.4": {
+    "956": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/956/download",
+      "sha256": "0423769ce836a137e3433ae6591d95f2fe070a8ec033e48bd8dd09a5be8db4fa"
+    },
+    "810": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/810/download",
+      "sha256": "3149f01d1a8985dc7040e41b82d17d6c8c4556cd61a2021528b421796170d043"
+    },
+    "812": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/812/download",
+      "sha256": "ccd1eca388cc35c6855a091ae1b42ed7c5b5e80fb6bb81c8bc0ee11c6a5010e7"
+    },
+    "811": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/811/download",
+      "sha256": "ec7cbb02ece999c0a4d01b94a2904c8ea842997299425d538e87a303bcaa489a"
+    },
+    "814": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/814/download",
+      "sha256": "70d0e06f99eab320fc5760537b3d3389922c1df98b756f0396921620fc115ee9"
+    },
+    "820": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/820/download",
+      "sha256": "e84bf1e46416a13a2d9d049d78400485735a4f075e0d4c5f3c046623c3947a51"
+    },
+    "817": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/817/download",
+      "sha256": "8e546da8b0cb0a214070c2fc1c691df01fe13d14dbb68e407667a524447b510c"
+    },
+    "816": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/816/download",
+      "sha256": "f64e4e1933d9bb2b4372595c6c34741faafde8adc0c521ad4561b9a457df95e2"
+    },
+    "815": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/815/download",
+      "sha256": "a88cecf61760dd7a7aa11342528f40a8c20b5b341751ed0a45c13f323f0bc0b4"
+    },
+    "819": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/819/download",
+      "sha256": "0770920517ad6afe2d3ac15d12b93ef7da0c71dceb23e51744e5f3952ccbf333"
+    },
+    "824": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/824/download",
+      "sha256": "de5bb58b44ad3a64b7312c275837d28b8788370b6df5413c0c63f84aeee41646"
+    },
+    "813": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/813/download",
+      "sha256": "38f9b0f73a328c97d5856dfe819a2493805113a64ec4152895afeb89d90fc733"
+    },
+    "822": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/822/download",
+      "sha256": "a20915e4cabe73273e5d40652590576e0f6f1625c11a49f5bc3bd39472048961"
+    },
+    "818": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/818/download",
+      "sha256": "fdfcc1f585d17f9b111d2d067ac5343ba1d3abcb99964138c84feb2cfdd898bc"
+    },
+    "826": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/826/download",
+      "sha256": "d0b4aed18bbe98a22d095d345fd1abe1a2ee6f62e50e88dc6d49bcbb816d6d5d"
+    },
+    "827": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/827/download",
+      "sha256": "2ac0dc62f7c7746feb233a9a41077fcf8dda887a9028c7bc94aa8ba6fc2856ea"
+    },
+    "831": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/831/download",
+      "sha256": "7fecb58e1592bf4d47c0821eb366f73de7fc57464ca87dbe1c4653aa5106ce09"
+    },
+    "829": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/829/download",
+      "sha256": "a14c46615dcc62d03a92df406c645a4b03c30ff80ec668cf1ccb377ef88e6358"
+    },
+    "830": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/830/download",
+      "sha256": "c50f8d1a77c6ffe89219390ccf15a5992c118f9d1e10c19f1e10b231932c43f5"
+    },
+    "825": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/825/download",
+      "sha256": "99efebc9aed721396cb02e747ad28c29418f2ec9d64d6ef287ed884c7fdc66b4"
+    },
+    "832": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/832/download",
+      "sha256": "410f1a5f2a1f5d1c67d687608a59ec2a4b2dab7b3b5a6bf9b8f30021b7c9b915"
+    },
+    "821": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/821/download",
+      "sha256": "e89530303cb09c26406371515ee0748d2471a073f21d88e20f9d3c75be9b0d71"
+    },
+    "834": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/834/download",
+      "sha256": "fa885adc24cb8bbe920d2c4acf621d40679756822825e759c1aa67924a72355f"
+    },
+    "828": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/828/download",
+      "sha256": "834f3e8dc8b0472d18b7810063613106a5626c8aae195c624b3bfcfdccdcabfd"
+    },
+    "835": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/835/download",
+      "sha256": "dc2d547cfe262817540e835bdc2d84207fb0e6615ef18c3eff3354a0b0a89949"
+    },
+    "836": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/836/download",
+      "sha256": "9c046ce2a646a37082cf0e82095d10f111ff4b39a4480ba2ae0cbed805995a51"
+    },
+    "840": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/840/download",
+      "sha256": "c7ce57710fe9abd41fab565e242c6b61807c5b7b2569fe363db3324129f87357"
+    },
+    "837": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/837/download",
+      "sha256": "a68f0734276093438736b1b59318690b5239981fe27085b5fc21e50a65bd909c"
+    },
+    "839": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/839/download",
+      "sha256": "d0230aee87f695ca50436d745a43e4229d765da71a01bde20b4993d2d08ed2ab"
+    },
+    "841": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/841/download",
+      "sha256": "1c347b64cbd86284919fadc96f3da4f45c64fcd53c02a98767ab6a7f52ea80fa"
+    },
+    "833": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/833/download",
+      "sha256": "2e286fdb444ef37fa7d96a9326b875cedc126a3bed0ccc3a40c6b2ba19b811f5"
+    },
+    "843": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/843/download",
+      "sha256": "372b4ce609d0102a95124015b62a716f06c030a48c5ea5cc0f6183994e39f1da"
+    },
+    "842": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/842/download",
+      "sha256": "c92410c322d454980ab00aa5e2a509af483eb347d4749f7a75897941335e3191"
+    },
+    "845": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/845/download",
+      "sha256": "7d0e3ed7e563c5a9bb1d287ac305e911a6910ad80cf0abc70c01ca6af6bd9793"
+    },
+    "844": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/844/download",
+      "sha256": "f6d78330da8806c84be2595d422d2c9d7c2936d584c0bbcdb63eb9c3f885a262"
+    },
+    "847": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/847/download",
+      "sha256": "3541a312be25ccce7969566b82711337743708fad98a409c8f6e31c95b2a7cbb"
+    },
+    "851": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/851/download",
+      "sha256": "2f9c1b37a4b8718c7a96fe43025f2adcd34c5ae285976815cfce67b3afcef52d"
+    },
+    "846": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/846/download",
+      "sha256": "bb783de792375235721675fba868b5123efe9a6f03f53f855778870cf8504094"
+    },
+    "848": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/848/download",
+      "sha256": "5d1035e5fa3e01aee45608fe5f63532794953bd0e38e376eddb067b719afdcef"
+    },
+    "850": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/850/download",
+      "sha256": "cb89e718e2e98e21dd29bc1a514d615093608b791161d28c422e5f7d8ce4cf48"
+    },
+    "854": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/854/download",
+      "sha256": "2471abf80370ad5245765e847ebb67bb8c30f91820bb6e82fc32be60b5dae53c"
+    },
+    "853": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/853/download",
+      "sha256": "bbdb45122bcf0c6feb25a7ac820e59e68677095d7e385132d3c631c1d49dc3f2"
+    },
+    "855": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/855/download",
+      "sha256": "080942392b3bfbe506d4695bb7259c34f63bfb1dd8685b3d5fc8ba767771298f"
+    },
+    "857": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/857/download",
+      "sha256": "42ac4bd166f10bf164b4e067c6da5f168276c2f827c5548957a25f9feffad4e3"
+    },
+    "860": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/860/download",
+      "sha256": "327a0b4fc8fcab580eee275c9f2843d53f9d5f924e0e7749016d52d37ecaf891"
+    },
+    "838": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/838/download",
+      "sha256": "b9d12db1ac2aadcddd8a31a8eabd9f511c3819021723c6c343fcb9fcac6547ad"
+    },
+    "858": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/858/download",
+      "sha256": "8e6debbcdc8d71ff7dd2cf6af5a1775a6364c6e3a50e52ef82b4ae281bd3c93c"
+    },
+    "859": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/859/download",
+      "sha256": "dc28e025618ef23021f9a9a418503e364f9a535e3864db0bca84c3fb7c2055ed"
+    },
+    "862": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/862/download",
+      "sha256": "21f697479f6ac1dde7227e50b2bbfb04f99cd735fd2cdc664ffd52896851b689"
+    },
+    "863": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/863/download",
+      "sha256": "66a41dfe6e4a444b1fd712c04db739da3c6eb3498c8cf84a8b8a1f740cc812cc"
+    },
+    "865": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/865/download",
+      "sha256": "52c0afaf1ade6a798015f6958df4af3f5ebd43ec2201153cdea000d93cea7767"
+    },
+    "864": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/864/download",
+      "sha256": "42db5f2b6891603516807ff37bee74434499542ae4dd26147941e388a6ccbd8b"
+    },
+    "867": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/867/download",
+      "sha256": "031d16186f1b8f7b209fbe2a0117157031000d587b4556399b1e6aa77c78ce55"
+    },
+    "866": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/866/download",
+      "sha256": "2239c5bfdfeb76c278227c43de3b0243fc3c604f7bac8da487b1ef60156cbff0"
+    },
+    "870": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/870/download",
+      "sha256": "1bc283c140e2bd08a666f28bcc4af53191df3cb958904d9a5bc59ad717165b46"
+    },
+    "869": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/869/download",
+      "sha256": "b2ef16693bf442365040ed2db8c97815f3bf8ac148f2a123f77aa494ecf4baa9"
+    },
+    "868": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/868/download",
+      "sha256": "7c2880f417eeb3a3871f05783d0ddd8803711b0d2c2be963469aa7c96af90874"
+    },
+    "861": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/861/download",
+      "sha256": "0595aa749c1b361581eff6314318abbe947ea7cbf1ef1227493a69449670de3e"
+    },
+    "871": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/871/download",
+      "sha256": "ec70a9518598730e3bd7c8d392cd7193e281d1f64e3feaf8fe4e133217fc8d51"
+    },
+    "852": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/852/download",
+      "sha256": "dc2737c68b50bdebe59f8dba008d6cf75a2feade3bd21dda3346430a6daae774"
+    },
+    "873": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/873/download",
+      "sha256": "ba896eb97c367b68bc7b348ca510fbe13924213e5b02d8896bfa2904c0688942"
+    },
+    "875": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/875/download",
+      "sha256": "77713d4495c2879e0df3bf3cb5fc65e68fca9b7566ea9a6f895298017bd51fa8"
+    },
+    "876": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/876/download",
+      "sha256": "4656241c6715d5f01b27ae4aa93484c55b427f0f45a504592d3fe2017df280ed"
+    },
+    "878": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/878/download",
+      "sha256": "271fa0699740bcad64343648bd1f51583c0c376b70588d23f5f4926206ef7cb7"
+    },
+    "874": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/874/download",
+      "sha256": "9662a10b7a9e328e0c7d4604779402441f5afeed42f77770b1911390bd29cbf8"
+    },
+    "880": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/880/download",
+      "sha256": "d4e1c2707ad28b4ca5d95d6caadad63391436138da9c9ffc55db1d1498e0e1f6"
+    },
+    "879": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/879/download",
+      "sha256": "03f7820b4c09d12aeea1601b3d116308d07ae959d06f089d5c0e4ada2199cc8b"
+    },
+    "882": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/882/download",
+      "sha256": "97aa7e9efe365b3361ebe4a6ac92a34feaa8faafb7b80c3184d72f94b9b9a71f"
+    },
+    "881": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/881/download",
+      "sha256": "9cf39fcf576fde0e5fc03a3123b7e6878d573c4c5b8159def566f48bb2b33b04"
+    },
+    "884": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/884/download",
+      "sha256": "54b10fa3000e84c1ebac38853abc2161583fb02ce6e0f9a2a5502e31c48fdd74"
+    },
+    "883": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/883/download",
+      "sha256": "2188b467909413b6bdb5fbbaf40139fe4eef5ddd78db76411bf1823270b837c6"
+    },
+    "886": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/886/download",
+      "sha256": "f166ecd3e8c4bd3decad5d4952ba70fafbd0acee78b2c8abc5f9a5508cf54a2e"
+    },
+    "888": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/888/download",
+      "sha256": "130a1c95370915890f07033a9ad8608b44d4661b27b36ec23d3c0072a0240f45"
+    },
+    "890": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/890/download",
+      "sha256": "016557739bb1cfe90b6e240a6045743815ecd7eca50dc7272d77e4c64e8ba87c"
+    },
+    "872": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/872/download",
+      "sha256": "f8334c46862c91ba93ed1d0d35fcc5e979e365d41398dc639066066b956bbe80"
+    },
+    "887": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/887/download",
+      "sha256": "5460cdf19e8c041328fad30a21f70d15f81095acbdc3076525cea5cf7dba959c"
+    },
+    "894": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/894/download",
+      "sha256": "aa71109144942f0f01062428d335c1b14abeba9ee19e0ddf18481e91b4dc2688"
+    },
+    "893": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/893/download",
+      "sha256": "d533296597203b14adb19c2fef72e351223cdf86c4adae5725fb14bbaab5afac"
+    },
+    "896": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/896/download",
+      "sha256": "7aa12f9be266ba9cd9bf58cc5a38ac6603b896673f592a954a798ab346b2a885"
+    },
+    "895": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/895/download",
+      "sha256": "6903cf6d6c0c676c4aba3c758e3a7c275a91b4f6de4a40294b35c2d5c4e51d20"
+    },
+    "892": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/892/download",
+      "sha256": "07df5d552ca26d2318409dbe5b17792ce2f2ad2a33e228f4c0decd1d29f2e3a9"
+    },
+    "897": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/897/download",
+      "sha256": "efc18adef663acde670067cea959063bb97fe0b718cbe3fbe7a80933b9af4fde"
+    },
+    "899": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/899/download",
+      "sha256": "7124a7af5f9c48a3a5fe7643a987d2205fbf41faefcde27865d255b734a89a8e"
+    },
+    "898": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/898/download",
+      "sha256": "01a00b1d8d4d2586f8b9c0161f7dfe1474ed5e2e54bc494431796d73d828efd3"
+    },
+    "901": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/901/download",
+      "sha256": "9af36c2a8830769971188ea1f7ab5ae76f86efab0b3a85d65f0ae8faa24bd4f0"
+    },
+    "900": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/900/download",
+      "sha256": "a7b7e1df89ea2a69c249b2317d1ff3ceb43d864cb1e8be46e0594e3acd98b2d8"
+    },
+    "903": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/903/download",
+      "sha256": "a7662ec4ff36d5e0ae6f85507b2b6349a0cdfd4cb4f274e05c20a195a00a4f29"
+    },
+    "902": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/902/download",
+      "sha256": "bdd80fc348650b10c183c9bfb061ad3d48dde4cf36bb244c319dafc60b8d9857"
+    },
+    "904": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/904/download",
+      "sha256": "c50a2276e7e2e0f83c7a316a2fcdfcba90e585a1dfd0e0428d27805915fed803"
+    },
+    "889": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/889/download",
+      "sha256": "064aa61493fe35295de4e942aada394282823dd74d016fc2d61a51edf53041f7"
+    },
+    "906": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/906/download",
+      "sha256": "212e1376eb4cd5f43bbba304ad9e275db1bb053000df22c6f22a6cf297e05c23"
+    },
+    "908": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/908/download",
+      "sha256": "f6a1eb9bbf0ef36a6215c467d0ffc5d1e57a97232013fb77d416e66f6f414cc1"
+    },
+    "905": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/905/download",
+      "sha256": "001376c26d9e42f96ba4d050184b67602bcd2cae95418f8a88052154663efed1"
+    },
+    "911": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/911/download",
+      "sha256": "007c6484e2a06e2e0ca75d7b4e1935c89235f95fbb7333a821c1ca5388615271"
+    },
+    "913": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/913/download",
+      "sha256": "774f93d5bcde340101a943d616579f925f3c989e1aca5f2a0cb5d3d2555f69fc"
+    },
+    "914": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/914/download",
+      "sha256": "b9df2b838164a0533dab1cfa3088d6afc8ac2180f6c1441b5e5f4ff1d161b65b"
+    },
+    "917": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/917/download",
+      "sha256": "7742b8f1fac4353f6a4a8a6df5591bdd438d9b1be8d82f4f22c886796ce3bed9"
+    },
+    "912": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/912/download",
+      "sha256": "f4d6283ca063acafa0488090411e63988e103dd1d087ebfc7447cd0cd93a2373"
+    },
+    "916": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/916/download",
+      "sha256": "a4ba547609d319d11c8a55f997584e13f6df2f1a90968799d5e8a5331e3bebdc"
+    },
+    "918": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/918/download",
+      "sha256": "371caae92166da3a741ee6ea10709dbfca49f27d24ee117a0ff9fd3518714463"
+    },
+    "915": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/915/download",
+      "sha256": "31f992326465c2cfd7382b3b7b505392c26748acc54c82ce56190b74f981d05b"
+    },
+    "919": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/919/download",
+      "sha256": "fc6b3ad020dd8a3ae7dc049933e91040c4869b68053de36462d6f319de690796"
+    },
+    "922": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/922/download",
+      "sha256": "7f3902fdd67f2f4bf668e3df3cfbfd9ae8616a128d4e693fa3d140e28dd4ff21"
+    },
+    "921": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/921/download",
+      "sha256": "7db7ad5663be09e87c79ee9038c05b83f1f4a4e202d8a5050a69269e6bdc63f8"
+    },
+    "920": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/920/download",
+      "sha256": "8123df41dabb115daf2d2118ddbde8e0f9ec0484c8e94e18b168615141cb1e21"
+    },
+    "924": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/924/download",
+      "sha256": "1c7de3b66682f33b9d5ed84eb3588b98d5b1b4b960dd1c018c1cb76740693cd4"
+    },
+    "926": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/926/download",
+      "sha256": "2a41ba95b13b37dda61249801c9a775cf200603989a3fb7bf672b62fc2f1b00f"
+    },
+    "925": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/925/download",
+      "sha256": "73161bb957df1d45e2772c028d310b6f934a8ef5c2a301e81c0961bca6fbb8ad"
+    },
+    "928": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/928/download",
+      "sha256": "bf13e0b5e477707b36a2fd00dbef8a9c2bd2120d56b3c88c45ccbed5a59c81b4"
+    },
+    "927": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/927/download",
+      "sha256": "8129bae43f395f55e3ae4ca16610ab1fac622fbd3b84e78ba2531037561dd017"
+    },
+    "930": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/930/download",
+      "sha256": "2226ba21c9b66c53f354b10f14448c810a33d747c9ec00d3c263f22c7ce343dc"
+    },
+    "933": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/933/download",
+      "sha256": "39a5fb7ca31475372940a0efd9c1f21b84eba2e69fca9bd5b50f62404a263e1a"
+    },
+    "929": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/929/download",
+      "sha256": "165e376ed6a5775d99d2281c376519d7b906ab70a813092a31b93d56c9b48f8f"
+    },
+    "931": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/931/download",
+      "sha256": "61d4d5ccea6435bc2b59cfbaaa271d8bc659a42ce5987bdff365be5706116748"
+    },
+    "935": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/935/download",
+      "sha256": "d3ca0120a03928f719f7f880ff772a35175cf8415c2f9a1c32906edfaa792c03"
+    },
+    "936": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/936/download",
+      "sha256": "03af3690145affa231ebfef9f7366d9219dc591831c1d5b796a0d8f6873add92"
+    },
+    "932": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/932/download",
+      "sha256": "c347babf84e4cb456f41285904affa944c3220be6744f63a17fd3dc015c30f19"
+    },
+    "937": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/937/download",
+      "sha256": "b708d1cce8e2a9ea187900b4104703e43c1a63a094e287f28b0b8ed621e6c325"
+    },
+    "934": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/934/download",
+      "sha256": "3468910c311cace6ebf2a5326f9d1ce634e7184f8f27fbdff75e5f89567a597e"
+    },
+    "938": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/938/download",
+      "sha256": "c608616ec1d3350b3b3ac1bb3abda9143f846a1a1d63babde5b3441dc33db654"
+    },
+    "941": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/941/download",
+      "sha256": "16583f05faaf308b3adb7307acfb1848241125f36e94df68f7381b478ea1e44a"
+    },
+    "940": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/940/download",
+      "sha256": "7bd84d4a4d058efbf2fb58f007733df81399fd4204e071045b7a794e9eb5ccb1"
+    },
+    "944": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/944/download",
+      "sha256": "823aa68dfb4f8821c82dbaa334c3291bf5e0aa8d9cd3d25cab49d5df576e2469"
+    },
+    "939": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/939/download",
+      "sha256": "e0f30028df21bfe52cac8d1019135365a34a7bc5c84af8e44e8e3894fa8bcb66"
+    },
+    "942": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/942/download",
+      "sha256": "40bd921e3387d3ca6366904d380a90ac4706eeedc6d2259f4f209f8c5eea4bd4"
+    },
+    "943": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/943/download",
+      "sha256": "f5c03a4a01712ef01b2c19db38c31848cec9afe847cfdd18bdbe96c1925e2a9e"
+    },
+    "946": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/946/download",
+      "sha256": "e3dddc83d8ad8fb48d5ae2574199c5ee8968a8ebd3e4c781570bd6e6b70730b2"
+    },
+    "945": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/945/download",
+      "sha256": "7b96799421010ce7f3bc1d87dae65f1216d942dd833bd7fc0f9dde08e574de2f"
+    },
+    "949": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/949/download",
+      "sha256": "a1aa25c36b2d64742de5dbd6c84cffb291d5fc2e4bb52adf191f22390e817fba"
+    },
+    "947": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/947/download",
+      "sha256": "dcb789bfc3eab23ff2552ac58572ccc0ace9d13480c10f85c155e506d2eaf775"
+    },
+    "948": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/948/download",
+      "sha256": "fed1ffa1e79727bda8d1f73678a2af3df45d81b8585809a8125aa6b9c270d24b"
+    },
+    "950": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/950/download",
+      "sha256": "1de0692c6278e55e9104c28057b09aaf8823b7db1173bf66fd5989b090601c72"
+    },
+    "953": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/953/download",
+      "sha256": "127ba3024fe33112d8ee3a6e9846cf96b947092878268a11f9411fbf688ee6a4"
+    },
+    "951": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/951/download",
+      "sha256": "257d6884f278fbfefce52ff22c119d4ae5cc814bac94f0315018ba1206635a6a"
+    },
+    "952": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/952/download",
+      "sha256": "68bfaf46c16fa837f4054b5966da674b234a54c1c42f6394cbfcb52cb7a96a24"
+    },
+    "954": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/954/download",
+      "sha256": "95a5216f7e73440452e5fc04dcd343823eda6b28547d669f1715932e01b2ef14"
+    },
+    "955": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.4/955/download",
+      "sha256": "0469ce5957cbea94599488e330e4326216eb0dacc2f0018fa9fa8a15f019003a"
+    }
+  },
+  "1.16.5": {
+    "1171": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1171/download",
+      "sha256": "bc041cc71ee321a3b36253f6ac6da091b77c926821dbb82ea762003426c43626"
+    },
+    "958": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/958/download",
+      "sha256": "a1fd66c498d4b1cdda61dcb54f8582d9aa3b36357a1a0224abd31f0de92ad509"
+    },
+    "957": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/957/download",
+      "sha256": "76ba177bbbd9bb9db253ba8030481f7e83c07ced2a02f87686aef31199adf0d9"
+    },
+    "959": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/959/download",
+      "sha256": "23f9d985305cc43d2f101be3b04c3cf008db8d93601d74824740d7c98910ee82"
+    },
+    "964": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/964/download",
+      "sha256": "e65defa13e01b1837909c702fde1bcb016bf1377e49f930ac59490819a5479be"
+    },
+    "960": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/960/download",
+      "sha256": "b7a171ce0aea5776242d0128e65024065ba874c095efd0c1125766aa7a3684f8"
+    },
+    "963": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/963/download",
+      "sha256": "a5b1dfb2d5b9121e11f285b6cbe7c302a057ebb9933442d58b255e4c49e1dc9b"
+    },
+    "962": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/962/download",
+      "sha256": "7cd6c8235471929e965994deb2af702a9ba55cc7f2c174615b799ba9285e587d"
+    },
+    "965": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/965/download",
+      "sha256": "4cda96ea15e76615a323176f2d138b713d2172cdcf607357f0f797f5bcfcfa40"
+    },
+    "966": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/966/download",
+      "sha256": "e63e03ef61139e8449b998e9456ba5267ca81b592635b1f27e0aa260fadfe613"
+    },
+    "961": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/961/download",
+      "sha256": "7cc5070a33dff4b0137fc8ede9779babd223a862656b4c62391044ef0a637edb"
+    },
+    "968": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/968/download",
+      "sha256": "fbbbac077f78d1e2f947f0f8b459e3ba5f27442fd493a44e978994af2f67174d"
+    },
+    "967": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/967/download",
+      "sha256": "1167fe42b308230c68c4380bdd2746cc9b3891b9aa347476cbdee34aab31bccb"
+    },
+    "969": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/969/download",
+      "sha256": "3dbb11add5a919a007bdba55ec6a4279d4279c8106413a045ff9b32e6c13c943"
+    },
+    "974": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/974/download",
+      "sha256": "d0bd3fa28f9c6f9af22d715d82cc0d85ba78a0da6bf65649e1ee5293da5f986b"
+    },
+    "970": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/970/download",
+      "sha256": "c2fe06c58b47248242d4b0b93868db54922b06bf52bb29f20128bc878848e8bc"
+    },
+    "971": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/971/download",
+      "sha256": "b8b28374b075057a9d230569fc8c6ee3c36dbd186b43c2cb914d5fc1c087c553"
+    },
+    "975": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/975/download",
+      "sha256": "80469c5d7c1bf842c2abe191f6ea123dfe7092293f040f015f6877d2b0914ba0"
+    },
+    "972": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/972/download",
+      "sha256": "0fee8d0ca80ede75ddb2c567c3da64e27723c424ad79fd7c14c3daf69c90dc04"
+    },
+    "973": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/973/download",
+      "sha256": "fb65a0000ad3e1e5bc74f915549f862c3df25c2224eed23f71a4d70f15334aba"
+    },
+    "979": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/979/download",
+      "sha256": "41eca411c7db73eae347af9b49316caf392b47307f6608ef169b14a97ae90681"
+    },
+    "982": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/982/download",
+      "sha256": "db4a93040799d25e24d6aa624c68709ff54df12e8bc6f33ddf151abb26476848"
+    },
+    "976": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/976/download",
+      "sha256": "c2a9a6dd9a9d16b114ba82207a4528be4fdbe322f88ced872771ea753ebff378"
+    },
+    "977": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/977/download",
+      "sha256": "50fff52acc314a798bc4d66c2a4ad589dca17f6d08f3755146c39e79d67f9147"
+    },
+    "978": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/978/download",
+      "sha256": "29ad2faa400797b224398db857082dbec56b46553e0816b09d00e76f3ab59ed2"
+    },
+    "980": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/980/download",
+      "sha256": "c90af38ffe172216dc3dfe9a6c01b2a91af9700fd6ac8379873b1d2b3422bdd7"
+    },
+    "981": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/981/download",
+      "sha256": "39bf0d0f21e5a4c2e57f4ea217ba0454f2ab50329c6652e209ca3c7bd7c5de48"
+    },
+    "984": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/984/download",
+      "sha256": "aafd4a3c5b8ad09c869fe64833a2d18a05fa0ddd3276fccc7298bb6e9fa2e519"
+    },
+    "983": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/983/download",
+      "sha256": "6d8ed48a8ef88853198aa52cb063881c61ecc715fa303c6fd20f252cf3df725f"
+    },
+    "985": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/985/download",
+      "sha256": "7aaf54a013fdb44980164b5ca43e041ebefaccad2f86da8a9560b256dd94a397"
+    },
+    "987": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/987/download",
+      "sha256": "bdd69066e94bde02ab61eb10a3b21169019995606945a70f27b4164a9e9e302b"
+    },
+    "986": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/986/download",
+      "sha256": "21375061640d8b34f702c248129fc3c2998ef9f2cb2bb980b20f46a4a9067416"
+    },
+    "989": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/989/download",
+      "sha256": "44474d252479ea578ff49d3052ff4bb2e581c9cbe4e20645efb194d5dddc364f"
+    },
+    "992": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/992/download",
+      "sha256": "39c22eda6ced216a5a0867fa3b467533d8cad408c0726426347b383cb0a85a1d"
+    },
+    "994": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/994/download",
+      "sha256": "a8a9d5e4cf05ded1c128f7d3c03e88c789506febe24c2d5d10edcf862bc9ef95"
+    },
+    "995": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/995/download",
+      "sha256": "6fc527a67163ca6420509932b64efb6ccffb6ef1f6f74d01f27bb7bc76c449ad"
+    },
+    "991": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/991/download",
+      "sha256": "069c6d0cf852df57700565c33ed4f37d4cdb5ef1d82c7b181563f03689bfa345"
+    },
+    "993": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/993/download",
+      "sha256": "60927ed462a0226ff86daf96a8e05937e8d1090c20200ffe46df48da5300ede0"
+    },
+    "996": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/996/download",
+      "sha256": "daacd4983d3b8d19f1b76495b63ce49441402bb818e480b4cffcf7178f5b404f"
+    },
+    "998": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/998/download",
+      "sha256": "7a9185875f1d6395ee65bed68ca41a658e33a36a0e2edd0d1b0756ced0a61be7"
+    },
+    "990": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/990/download",
+      "sha256": "197369ed2e4d65246307d7b23d4f16c4b2409abe1e6fca185ff73379c0727f7b"
+    },
+    "1000": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1000/download",
+      "sha256": "1690efc19c8bf9ec25bae15abc7637621128684aa7bbddc4ff7cef757d6adad0"
+    },
+    "1002": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1002/download",
+      "sha256": "3778812fa17023045dbba160a20a3fd5ce264566105167d09cc842914b66018e"
+    },
+    "1003": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1003/download",
+      "sha256": "828d19cad842ada653ad00a1eaeaa782661dfa1dd1ef141538c9ce61b670343a"
+    },
+    "1004": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1004/download",
+      "sha256": "fae7a795f01ae7832522404f3577901754878745d75ad63402f2dc56d374be01"
+    },
+    "999": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/999/download",
+      "sha256": "c4353b9d05623106bce8f4afd733d8ee6350d9be539482f9e331f57f7e1c626f"
+    },
+    "997": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/997/download",
+      "sha256": "955e6fb7695a5697c5a05529f35393d65dfa6ad9bc688193dee90f88349698b7"
+    },
+    "1005": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1005/download",
+      "sha256": "9c5a4d35445beb76840d1851af0afeaccd0c99a79e9c85100d7a45bffe1dfebd"
+    },
+    "1007": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1007/download",
+      "sha256": "0f82cfd78cc72a01474cac2a7d93ba80d82cd0bef160c69b4665d77fb2e084a1"
+    },
+    "1006": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1006/download",
+      "sha256": "7e2d0f85612453ac8ce2dd307084e75e11e4a1c2a0e8a52b25a4a940b4c160c9"
+    },
+    "1009": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1009/download",
+      "sha256": "5744df3806aade3701cdb8128dbb7ce02ca6f4899f26777e81d14a931f6a51fc"
+    },
+    "1010": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1010/download",
+      "sha256": "6e2badc28362e3af993d305ec6578aeedc22097764b262310cf7cb30c67ad2f3"
+    },
+    "1014": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1014/download",
+      "sha256": "4f82e6795840c96eeef4b83d1ccdd7d46196cf97e29779f080e85459ecf2f396"
+    },
+    "1011": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1011/download",
+      "sha256": "f7965b38f45b40d72d65f5e21345e24aaf6b2579c9443f228af1400fa035bca3"
+    },
+    "1012": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1012/download",
+      "sha256": "a7ed3f33024d35f81c7ea6540ffee79ed1a5e5036fc636f134ba7effec175d06"
+    },
+    "1001": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1001/download",
+      "sha256": "84e0dd82e0265b5b0b624d2fcd3c7b97021dcfde1a9addded0d6454fbf991b58"
+    },
+    "1016": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1016/download",
+      "sha256": "07a1daf633dad66d2a9472de4e8da9f139e8600bdd9349bd9b8254eb34c33cd1"
+    },
+    "1017": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1017/download",
+      "sha256": "6965efe429b4e2cb08e450b4529cbab4a65c9909270942c3c2fbe4aec0a0f4be"
+    },
+    "1018": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1018/download",
+      "sha256": "3cbb2edbf8ecbfd2877ab5556a4bee042fae54dc9a6d9d1623b86787540fa8ec"
+    },
+    "1021": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1021/download",
+      "sha256": "ee62b4a81c7634ef5334c50ed2169731006dfba0cdb795a00d4fe9671655ab23"
+    },
+    "1015": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1015/download",
+      "sha256": "9c972a6c47b2b31df9476e6586767baf78d3275e1a47d14c33e9addbdf646fe5"
+    },
+    "1022": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1022/download",
+      "sha256": "920c43da0bc00e8bc672af4bbd20e3ac4472e86695b28958495b1eeeafcb2c92"
+    },
+    "1023": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1023/download",
+      "sha256": "20050441799ae8a58523b9464807b7398ed1f122deac02efde6a3edabea109e6"
+    },
+    "1019": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1019/download",
+      "sha256": "707b0935cf64854d2c3a8a65ca16ef16a0c4be0b2056d9d34a103914d3b14459"
+    },
+    "1025": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1025/download",
+      "sha256": "2c6a8654ee3f5c6ca694f6ab3c18e39488c4936ca90169fa8fa1ef69e507cb85"
+    },
+    "1026": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1026/download",
+      "sha256": "c696c3bf3b302670b7ab242ff495ca12948fef5882d5a9fdb57667f0109ae780"
+    },
+    "1020": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1020/download",
+      "sha256": "80fbe09e7425dab82f2de6f2f61dc1d2408b1d8b31be9f39529c15626b64e91e"
+    },
+    "1027": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1027/download",
+      "sha256": "bb7d9039cec0bf1cd76bc461a9b4cb6808e35b312c71f344589317d1d8c41942"
+    },
+    "1024": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1024/download",
+      "sha256": "d0ef9a2442d4b87dbce108095fc2948cc423f5e2f5322a90323143a1f73e0d09"
+    },
+    "1028": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1028/download",
+      "sha256": "967d187408a3f27a3623f86331174d5b4c1a6b25b3020199399fb1799107e1a4"
+    },
+    "1030": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1030/download",
+      "sha256": "c71bad8011b75e282fd0349f65e2124fe12629a2e9d437a941d417be800d2925"
+    },
+    "1031": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1031/download",
+      "sha256": "874283fa2ef9b3fa6a8396f2783b8efa790a8593c89689724fda6f7399afaecc"
+    },
+    "1033": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1033/download",
+      "sha256": "c8cf53273517f16e37fcb38a07f048f8c4f7eadba2f65a0b50a6c8db667a682b"
+    },
+    "1035": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1035/download",
+      "sha256": "f0444d08b4918a24bef3b66f1b267fd3e4802f0fed9d4711ec99bf9f500932b8"
+    },
+    "1036": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1036/download",
+      "sha256": "92781a010659ddcd9eeb34d223fc0176beca01fa845dbd10aff33c508e9695f9"
+    },
+    "1039": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1039/download",
+      "sha256": "0d28e614b8c0512afab9c101e02c064e6c8d8b8eff3ca9da150526e5c483b66a"
+    },
+    "1032": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1032/download",
+      "sha256": "ebe10730ab8bd93af03734aa2f89fd9e2b34fe334f9427976e69a9052eeed96c"
+    },
+    "1034": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1034/download",
+      "sha256": "7eb22d65f8c0833f91f704b522b12db6d6cf6121b34c678af9ca0590e07f4be6"
+    },
+    "1038": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1038/download",
+      "sha256": "58972f688f49f2068628af6636dff000d68129a09a5625d001138f4d05ec3eb6"
+    },
+    "1029": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1029/download",
+      "sha256": "4cf3205bda6f4fd051a696ff6d5f40276fa80de72b0196e3f60ec1dabccc3629"
+    },
+    "1044": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1044/download",
+      "sha256": "0dca653ecc6696555bae6334200bf79c45f25fae66de96e901fb533e471b9d3b"
+    },
+    "1040": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1040/download",
+      "sha256": "2b04a857a4a7e9781e6d2d93cd9b9767acce9b8e7c7d2e5b19cdff12e8bc68ad"
+    },
+    "1043": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1043/download",
+      "sha256": "a848bee89a7ffa3cb38c3ac29af487799f19dc5c9b4344456ae2956acc77fd1c"
+    },
+    "1041": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1041/download",
+      "sha256": "ee8d73471eda5dd7ab09981843c80c9bb9e6ad573155a73eaa1f7553c6dc03f4"
+    },
+    "1042": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1042/download",
+      "sha256": "a8f07a4209d75a8fc1119e50ed7ed3eab20d1eda043b2c97939dce40c3cfde51"
+    },
+    "1048": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1048/download",
+      "sha256": "cc735773abe31b85caa8a3cf36c71cd0ac341f3ac49360e3c5a6359e9ed692fe"
+    },
+    "1046": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1046/download",
+      "sha256": "a4f31393cc20464e8a09d1b8d16c9bb2e025e9cba8cc748c21b000073106ae2e"
+    },
+    "1047": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1047/download",
+      "sha256": "69655dad7a0b69db95a6b5f299e79305fb54a50356df6422ccee9fd5a4767f19"
+    },
+    "1050": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1050/download",
+      "sha256": "693a88bb1aeba996a739ebeed037a1fb7fda33858103e695e3bf7af3e0eab5da"
+    },
+    "1049": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1049/download",
+      "sha256": "5cb6215cefc00012c28f1c551985782201a9c1fb6635c3e5359196a452143e85"
+    },
+    "1045": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1045/download",
+      "sha256": "4a651d4c34bd3d6df565d8ac1b72bada70a220636b9bc9c9876b2c0ddc39ad82"
+    },
+    "1052": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1052/download",
+      "sha256": "03fa6bb8fa369d985514a39d21f11dbd70fbacc3611d3aaa2d7972200a9d4253"
+    },
+    "1053": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1053/download",
+      "sha256": "9f9fdfdaec4cf858a275c40ea9dd3ff3d93553493f3fecbd6b8c88a30753da13"
+    },
+    "1051": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1051/download",
+      "sha256": "63cbd59bc94300ae8ad063665a294330f7c36291678c71f19078fe7eb9540c7b"
+    },
+    "1056": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1056/download",
+      "sha256": "ea65874e87acdc9aa9e982d9733c1a04abada7654a1191bca46acfd07d6ad47f"
+    },
+    "1054": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1054/download",
+      "sha256": "842c327394837e3aae7d90d379f64b9ec9696b07e5d87fd08a600b0ffeeebd3c"
+    },
+    "1057": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1057/download",
+      "sha256": "b53af084f2f7c61fa0a9266b232cb878833d9eb4cbd86b0b06e500d0411e1913"
+    },
+    "1059": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1059/download",
+      "sha256": "facde3cd27a1f75d79148e81dc4beaedec49ab19eec037e2d87dc144e159d7f6"
+    },
+    "1055": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1055/download",
+      "sha256": "24e3bf2347b0dc56e1e4c0bff46099f38aec9efcc257a0350178f422a2c576a8"
+    },
+    "1062": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1062/download",
+      "sha256": "ab0e6507d94622fc1429c7cf95b478669ed4bd9af377790677a9ed283de29377"
+    },
+    "1066": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1066/download",
+      "sha256": "8d8d0902dcb5c3ed2b9484afaeaed36a3eead3ab2cc0a1a16a51a6a22e70e9f0"
+    },
+    "1065": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1065/download",
+      "sha256": "d8bee7a3cd77ffbb73ae7bfb7394b79ed7cc6b75c30806347a1162bd1203ccf1"
+    },
+    "1064": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1064/download",
+      "sha256": "c732c835f40b734f14167231f9c2ed93f1933445af94e496de4116af0604ffa4"
+    },
+    "1058": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1058/download",
+      "sha256": "94831be1f024c93e18793483eb12eaf801eb4ee67fe3682bb49bb3d57005c9a5"
+    },
+    "1067": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1067/download",
+      "sha256": "c22feaaa301f16d7050c15a554cf3c2ac5b13d14f8565fd1721f71facb70ea7b"
+    },
+    "1060": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1060/download",
+      "sha256": "5fd183a9e43c2ff9e31fb6853cfeef53ca376198b469b494d241cbcab25cc09e"
+    },
+    "1068": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1068/download",
+      "sha256": "8ddd162940d7c2ffe44d8734bfe80223361d57be12e69e4b1535aac7985ba37c"
+    },
+    "1061": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1061/download",
+      "sha256": "0f6e32bb7c9ee87ba0e35ef95c258b0d95eb097e1754445790cdc889d772aed3"
+    },
+    "1069": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1069/download",
+      "sha256": "5ac0fa9bd39ce9714f08d5460e5cd68cd496cd0aa163393ea89e1cf3120044ad"
+    },
+    "1070": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1070/download",
+      "sha256": "4a9192da1b8cb4cebac555770ea1d3c40f9f5c25dffa5015b114ca07dfd52e65"
+    },
+    "1072": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1072/download",
+      "sha256": "17724d12dbff6cb443a881710169902a499786c759090ed91259170d7882ede0"
+    },
+    "1073": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1073/download",
+      "sha256": "dd01c4dd25e3b42db392ad11e8e661ea10bf16eca9e4236877d5e6b6709de676"
+    },
+    "1076": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1076/download",
+      "sha256": "ca7ef0bb636c3d8966f838c4ca313bf3d7ed16acbc6b3c46559437b199fac6fa"
+    },
+    "1074": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1074/download",
+      "sha256": "ebac3723fe3d79e9e49957f4d623ccb1eebd4e9852e564ad1baa994edbccddc6"
+    },
+    "1071": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1071/download",
+      "sha256": "83fe488826d4cde6cab3bd968d44ea4fccce90abcd7de9b6c7354493efa667c7"
+    },
+    "1075": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1075/download",
+      "sha256": "a2e2d6117235f2447e22d09a75c4254e9f944f6a169f6314a90f6b26d12d41c0"
+    },
+    "1077": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1077/download",
+      "sha256": "0716dec9b3eee76192593738b786b9639a84df66ce699bcc6aedf23767b0ebeb"
+    },
+    "1079": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1079/download",
+      "sha256": "668b849c425bd857b727b7b4d15a30d1ad6b9d6b2018643814a7e5e8d5a388f8"
+    },
+    "1080": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1080/download",
+      "sha256": "a9add0825e9bb5ec4314ef7c0fc4b61ee8895dfbae4ba07bc23f2a1ce5c19eb2"
+    },
+    "1084": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1084/download",
+      "sha256": "afe30533d739f682f0065069e99cc8267f62eb8287a9151837808caf29a092d4"
+    },
+    "1078": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1078/download",
+      "sha256": "bf3ebde5d03402b8268317845c514243d8415c73b70ee90a20376619cb3b87c3"
+    },
+    "1082": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1082/download",
+      "sha256": "1ad20c5f22b9c56ca4e72d9f1abfd521f65c44131d73a05da901690e099516d8"
+    },
+    "1085": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1085/download",
+      "sha256": "869721bfdc72b105ab3fc50be8dd1eba8a19b20f1c5c2faf27412728088bc97f"
+    },
+    "1087": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1087/download",
+      "sha256": "e85c9901bbacb1b1c5c905bf41224d48f9dcecbc3e9bd9cbe85453d681a9fc3f"
+    },
+    "1088": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1088/download",
+      "sha256": "99d07c92c492c32b9734c0d5b8045124c7a0131dc721b292307f55e0f55fcb4b"
+    },
+    "1086": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1086/download",
+      "sha256": "2446b20f6a31f34b2fe8b50bed4032d04a40a6bb70ba411f84bd23cd6ddde738"
+    },
+    "1081": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1081/download",
+      "sha256": "09bfea58f5ff6b6c4fabef964adcc8d7085e430db2cd5c03dea4b2c5c07be975"
+    },
+    "1083": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1083/download",
+      "sha256": "0125ffa37c22c6072da0311e1d06425bd648b570bb9f9c53000a9cb6a23d61de"
+    },
+    "1089": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1089/download",
+      "sha256": "da5d96e980640cd58b4c0527721d0b6545add3d08e34a6e60b7d85eef23c9eea"
+    },
+    "1090": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1090/download",
+      "sha256": "666caf35ff998845eba6d68d94f8224c7fa7484995c6c0f7d6820962ffdaabc5"
+    },
+    "1092": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1092/download",
+      "sha256": "ac01fe6a6f4ccb308c0cb3f103939c5c4c490f5facebe4f51ee451174d016915"
+    },
+    "1093": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1093/download",
+      "sha256": "3bbe8823dbfbfa86332bae88d69249d387956bfcf29a157cb980073b9cf2774d"
+    },
+    "1096": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1096/download",
+      "sha256": "896c02ec69655c962b83c585f010a4b285a9b6aee20904136931aaf4bc9e164c"
+    },
+    "1098": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1098/download",
+      "sha256": "38632321cc316d162f2dc9d40fe7eb69e3e6447c4a20f71cd5b0e49b558d7876"
+    },
+    "1097": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1097/download",
+      "sha256": "1a47c89f1b8ce96edb012f95c837b60e3a5b893928c58464f0ecd2541b295e17"
+    },
+    "1099": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1099/download",
+      "sha256": "0139807b9bc57e3a9b9d44eeb5ea4a603955b161e290c4d6a018599d1164c7c7"
+    },
+    "1091": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1091/download",
+      "sha256": "d55e5a4cf8cd71b860d3281f37ca1bbdee565345e270ba0b7977a3912eb6a79a"
+    },
+    "1100": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1100/download",
+      "sha256": "86fc8af5e11b74603d8c259ed451be1512a5a55819c78b6228efc08e4fb970fb"
+    },
+    "1101": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1101/download",
+      "sha256": "6d45e20477f1f3d4b1eab9b7c494da5b51bb41ebb07169b8796da96baa58a7df"
+    },
+    "1102": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1102/download",
+      "sha256": "0706b8838684af875a0409f5559140b0c631291acf5956e6aac623953cab2e8d"
+    },
+    "1103": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1103/download",
+      "sha256": "4e769aac8bdacf051ddab2fb2192451f77d6878963669d07a8ad4122769ed614"
+    },
+    "1104": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1104/download",
+      "sha256": "95b686c73a46d58eba4788ac62475a50cec3b6d416b40366e82fe973df60adcb"
+    },
+    "1106": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1106/download",
+      "sha256": "d13f6733eabdab6a3f1d82740dfd133ccc4557a23af66dc0612e60244b50b8bf"
+    },
+    "1107": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1107/download",
+      "sha256": "6165a0540d46483feb8892effac330573775c8c0e1c776ec04d93423ebfa91d8"
+    },
+    "1110": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1110/download",
+      "sha256": "5f3444ac924ebbfc096be8095cbe0a566c4ebd1f5cab45b311ac8237b3f10c00"
+    },
+    "1108": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1108/download",
+      "sha256": "d80e6f1be505c63f5310604eaa4fce3b3fa2a398a55fd76e9b2b5f8705c79449"
+    },
+    "1095": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1095/download",
+      "sha256": "dd584ab8818eb0a750069ff404e94e36791f253d785999a8e16a94e03af22e43"
+    },
+    "1111": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1111/download",
+      "sha256": "b3b10cd933337268252eff53fd6ef7c1601a41d1772de8f7f6202ec752577905"
+    },
+    "1112": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1112/download",
+      "sha256": "6f534241777c6caf0f63794cd8ffbbd44c77396dc0d391ad9d687f328c0a22c5"
+    },
+    "1114": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1114/download",
+      "sha256": "19213f06ea03a7262b34c20d7876f037be391bfbf51c66d7e96ba581b51210a8"
+    },
+    "1116": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1116/download",
+      "sha256": "e4c13df3bf3b6582962ca57bc8297c70f381ce2b84bf50f6d8245efb9bb21321"
+    },
+    "1115": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1115/download",
+      "sha256": "fd4c1b6147722d5c3c2132c9c2eca81545897af2e255a86a0446f379c38f8a82"
+    },
+    "1109": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1109/download",
+      "sha256": "111c6e1160321fd5d000dc6e68169556f873561d1eb5b6e06c0febddfbc7d477"
+    },
+    "1113": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1113/download",
+      "sha256": "3ba112f6a816fa8f30d5a0a944a9f5af77c2de31be4d972247cb7c39853a4b40"
+    },
+    "1119": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1119/download",
+      "sha256": "f3090c85501b4e5d7639ed4f61d20988301676047c888f71b68888640a1286f0"
+    },
+    "1120": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1120/download",
+      "sha256": "e095b12a42605d6587a3b54b57ed9073f14d4e3a0cc4c0d2a5c0d5401b261604"
+    },
+    "1105": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1105/download",
+      "sha256": "6de34825ff80c35f69dfac292c7919e48e71715baf8c75d8e12f931c1404caeb"
+    },
+    "1123": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1123/download",
+      "sha256": "e0a887874ed4dc088df771050744a7d103da03d9874424d7fce9985f5eea081e"
+    },
+    "1125": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1125/download",
+      "sha256": "0f7ebdeb7cf879eb508ba31366d28a659c7e937f155f0a2c8eed23ab98bc1c3a"
+    },
+    "1121": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1121/download",
+      "sha256": "7bf87920a2f2724f58c3c96e31437345b1482fabaf67f25d1d944db4070c2fe1"
+    },
+    "1117": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1117/download",
+      "sha256": "ba0890dec6d1dac3dfca5af0f883a3543804a2b10244d3b27292b366eccb1bff"
+    },
+    "1126": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1126/download",
+      "sha256": "65b3f491df5f6a74edbf29348b71df5bfc06515714f7df5d6e873c06bb0b1d8b"
+    },
+    "1124": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1124/download",
+      "sha256": "7cb8fcf94eb4475cd6e99f13f2095536a2bfbe425f3cab3a87d6130625741647"
+    },
+    "1128": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1128/download",
+      "sha256": "a3b6e2eba0c4a2a349d701af66fa7485cfda042e583e96644e40be755ab37fe8"
+    },
+    "1127": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1127/download",
+      "sha256": "0bdd216b808cebaf64b6860e618f9e5d2adaaf59a00da1a8bd933f852d0c624e"
+    },
+    "1129": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1129/download",
+      "sha256": "498907948c9a4b3869dd07fdccd49f8b61ae9b4413a51c7aa97fbf64aa2414a9"
+    },
+    "1130": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1130/download",
+      "sha256": "cf3e96f8f536b675048a268aa584d42e2b3cf35a7c89dd236bfba62f9175b6cb"
+    },
+    "1118": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1118/download",
+      "sha256": "f27acea07a3c38bb5d6ac3257e79b9863529c582b9a921b0a4a99b1d268684c3"
+    },
+    "1132": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1132/download",
+      "sha256": "c830133cb3036e9eabca298379849b00df0cf130ed6302930b03d47d77a4d707"
+    },
+    "1131": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1131/download",
+      "sha256": "13ee581dd79dff8d2cec875b1b1875c1e434a29aa92b1bd1ebd3159286372d33"
+    },
+    "1133": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1133/download",
+      "sha256": "f03e071c69a4daf7170b1e9e5d4cb2b58e277b8627fa0c49859bc52ce8f4bbc9"
+    },
+    "1134": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1134/download",
+      "sha256": "f498bcc5e15c82e5f5904cf8e83b225a0635c55711c3b1dc754f00342c4dfd0e"
+    },
+    "1135": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1135/download",
+      "sha256": "1ce998d895c900e8f9eac19e2cf658549ba62b7dc03d4349644646241a915d2d"
+    },
+    "1137": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1137/download",
+      "sha256": "24b23f446dbae82d7190c0a35a8c64f20a8db901e1544f887edac77ea448b9f9"
+    },
+    "1136": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1136/download",
+      "sha256": "74e2e7c00da68a784d0598d4217b08f186a3a96dd29d78f18cbad59e54e28e07"
+    },
+    "1122": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1122/download",
+      "sha256": "ea6a144953fcc5d514c1b7c45cd80f4ca8d216916ae63f10d492ce89998a87b7"
+    },
+    "1139": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1139/download",
+      "sha256": "b08f6557d56d4304cc8fa479433a2b006083b2de03f29de05eda1f77878e75f9"
+    },
+    "1138": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1138/download",
+      "sha256": "13bef8785e83dbce9a6181f2f988b8fe9e936080a1674c2ee88e55cd97c52411"
+    },
+    "1140": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1140/download",
+      "sha256": "c5f48f705eeb750bffde8128152efd3af82f6a75b901441ee5bc993413bf19ff"
+    },
+    "1141": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1141/download",
+      "sha256": "6970768396ac7cabe4df774bc85fc016cdee6d1b83234df7663b05cb752fb245"
+    },
+    "1144": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1144/download",
+      "sha256": "c5429f739b7306acf8b719e6a770e979b48bc3d257853d6ebcdabd9e5b73dacc"
+    },
+    "1151": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1151/download",
+      "sha256": "4923d0bd0f1c7ce1e829ec7a06f5ed975fbf617aaf2c6c17419a97ccf3f49794"
+    },
+    "1153": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1153/download",
+      "sha256": "3b7cb891a7a26f45bef3125e67a054b6b30d8536ad0bb83c30804bf34178946f"
+    },
+    "1150": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1150/download",
+      "sha256": "3f5cb3188db79481c1c5f6e8c3fc91212c5b310cb88019a4d631e81e33aaafde"
+    },
+    "1152": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1152/download",
+      "sha256": "bc7c109abf59c5f005e8369fd674585380b5492232fee1bdf0f2b15bb6d43070"
+    },
+    "1142": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1142/download",
+      "sha256": "bf104d9912d5caee4b09f4f31dda9049794413d833720493a9370b722ff36fcf"
+    },
+    "1143": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1143/download",
+      "sha256": "9e3cac15288a65b8b2b2b752548040794e4975a1bb4a469ee7c01cd942d26951"
+    },
+    "1155": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1155/download",
+      "sha256": "c6dbdbe6c42a913f7d45adb41de4b6025643b854427a67cc688bf2152d385173"
+    },
+    "1156": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1156/download",
+      "sha256": "60ed5cc6da52c7d1fcd89db49e5a892d553ecb403be1a1722ed94b81476cbc3c"
+    },
+    "1149": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1149/download",
+      "sha256": "2de16104a6435709475546172e54fd77153ad616f0897d7726fce6f8acc81d53"
+    },
+    "1158": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1158/download",
+      "sha256": "132b06d1accfb71f5de85cd4c02db3e1e4af78d20773f2eaf783306c9aa9ee76"
+    },
+    "1154": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1154/download",
+      "sha256": "9945e6b54b1e6dd3aad72336ceeae129cbe90ff855d40a332dadf68b0834c8dd"
+    },
+    "1159": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1159/download",
+      "sha256": "7b196d510808299de16a54d349b72d764b1593922a2879d264a2817025873a40"
+    },
+    "1163": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1163/download",
+      "sha256": "1627cdb3467aebab9fd5091af8923e7f687f94a5b1bba6d91376135b93f41e15"
+    },
+    "1157": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1157/download",
+      "sha256": "6570bf1f050f9e919f281f8bc58d68ee25408f23a82c5af1aefb3031d683b038"
+    },
+    "1165": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1165/download",
+      "sha256": "4148d86663abe0c2ab44c7ccb289df09cc43afeabf99cef27af3506137d0df12"
+    },
+    "1161": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1161/download",
+      "sha256": "edf43a97bb7e91896eab7cc655a924658b69812e2f491a2f9c8801377440416b"
+    },
+    "1162": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1162/download",
+      "sha256": "d9b7de1892680913fd9f116b82f4425764ccf39cd8b920aa23bd2b4589d5f2cb"
+    },
+    "1167": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1167/download",
+      "sha256": "4ceeb137b1cec8db16d2a9f0b022b9fe584ed94c554ad288a2c91934d38935f5"
+    },
+    "1166": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1166/download",
+      "sha256": "a630b4d3cef94dc869ccc42deaceb768e519a2543fbfef3fcfe5f73207193d31"
+    },
+    "1160": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1160/download",
+      "sha256": "7b1c548cc69676959373f30a501d09aadb9f2d024fe173209e9b384175085b5f"
+    },
+    "1164": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1164/download",
+      "sha256": "6a598bcea7ec3ef9835e3c71d22e1dd733262d532015880e612a6283c3c31baf"
+    },
+    "1170": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1170/download",
+      "sha256": "041d284c2f526b79c6037564c250765ec87ac07964954b1ad63f50d83e8edb28"
+    },
+    "1169": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.16.5/1169/download",
+      "sha256": "185a6d25fc39b43df1895a5c34ee45f9db339fe0ac82c7b8312d0cb2da3432d1"
+    }
+  },
+  "1.17": {
+    "1255": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1255/download",
+      "sha256": "30cad152da3564d56e00e85646a9a51a3dc6f2046f4e8ddc80223035a82312ae"
+    },
+    "1173": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1173/download",
+      "sha256": "45b5822252387dcbf4754e2dfa8923ead3b51902c985e350d8c40ca451f33fa2"
+    },
+    "1174": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1174/download",
+      "sha256": "43c4d7dcbf056fe14b824e4ec8e364dad631e65d0c0cc7e782bf62e749c8947b"
+    },
+    "1176": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1176/download",
+      "sha256": "91e87ae815c032bf6520a9b98be55ce47ef9142c5350f77c53f2b55a7d17e7b7"
+    },
+    "1175": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1175/download",
+      "sha256": "36c88cf14d618bfec214c7163e2fcf6ce05957fb86ef7cc53f70fddd7ea2f72a"
+    },
+    "1172": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1172/download",
+      "sha256": "bc7578c5bf62cd356b7d31322b7b075879379a34b551af2668e2051e5d481617"
+    },
+    "1177": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1177/download",
+      "sha256": "26dae908f9c198d590513469154958eded09b9edbe4f717b963fd775fb4b9865"
+    },
+    "1178": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1178/download",
+      "sha256": "20af0861a6c5af84e1ec20bb0d2412786b86b5670054d3e2eba4b18e80e1b430"
+    },
+    "1180": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1180/download",
+      "sha256": "3dd39f16ffbf8e3c5f7823cdfe7d128b4fb393c2d0c1d08277a72c92013172bd"
+    },
+    "1182": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1182/download",
+      "sha256": "ca092255d4d7f91ed41b5839d8cbbe633d8536d47859fe23403cc4948a8fb775"
+    },
+    "1181": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1181/download",
+      "sha256": "42c99dffc7a12a6bf02c3067edbe7aa22029252a039aa818ccc0b40c2dd24181"
+    },
+    "1184": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1184/download",
+      "sha256": "d8cfc208ed9afa1f45929cc6b24071a4d7589101d5f8a90776edc3918dad67bc"
+    },
+    "1185": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1185/download",
+      "sha256": "7319bdbe1595efced0d3307f3dfc9ee59da3ce4a91159ae3ea3e7652401b1fa3"
+    },
+    "1188": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1188/download",
+      "sha256": "41f19986a7072d28ad9135dd39a041b429c55d169e55de4b134ccde5e7ba6c9d"
+    },
+    "1189": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1189/download",
+      "sha256": "5c3c3201c25155da43255604dff49a98dbe4b955a56ee0bbba58bd690e590793"
+    },
+    "1190": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1190/download",
+      "sha256": "442cdfb2408e4085a9b5dd4bcacc7b224df752ddaf1a67642b5a607a16f68668"
+    },
+    "1187": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1187/download",
+      "sha256": "9be61d7c83383636b4d8972835ba2d56efc4427413f86fe316ece2d40264b43c"
+    },
+    "1194": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1194/download",
+      "sha256": "90badeccc61a7f4601719be3804c889117cb21663941fa0653d25ce9eada6aef"
+    },
+    "1192": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1192/download",
+      "sha256": "ab45887d39d2fa68ec6d8f26ee2bac8de1551f561c4f6e00634e9894e3ca8c27"
+    },
+    "1191": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1191/download",
+      "sha256": "b6ea6c0e3ab2399b68bd02d7fd7517554677b70bda1191ae8228b1dbf5dd85c7"
+    },
+    "1179": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1179/download",
+      "sha256": "9300789744d2e3653c51859638443e10a8f66068571ee2ccf4be6c0cfcab6ec3"
+    },
+    "1193": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1193/download",
+      "sha256": "3c8026cfdb21250f42779460b7d1b9f3efe807aa9a0a5a770620ee6334777ae2"
+    },
+    "1196": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1196/download",
+      "sha256": "7941599e9146a27b548bb90127ff592ea5372a988b3bc6ee1c0d15d9b59e9fca"
+    },
+    "1198": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1198/download",
+      "sha256": "2a6f55b25827aeb3cfd7202bcc3d413d28b6794bf0165b78abada7a9e827c2b4"
+    },
+    "1195": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1195/download",
+      "sha256": "c5cfbdaf27cde86a11e7f62290c42e2a3febb563f85e62faef8de8caee15db9f"
+    },
+    "1197": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1197/download",
+      "sha256": "ee2f3410dec8d1db3f68a4a5630eca5150be44d7a69427d56b031a1914f49410"
+    },
+    "1199": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1199/download",
+      "sha256": "ce2265ccc45675030b90a3a7016f1381cf653e0c04f7bb9e36fa262bbeb6bf40"
+    },
+    "1200": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1200/download",
+      "sha256": "c70232deefe9742b9ed718279a1a0b2f50d147a519f5873e20b89fdd382cc571"
+    },
+    "1202": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1202/download",
+      "sha256": "1cd9e4f7085bf9f83493056dd31cfb28199550c788714ba8eb2bc22f7a9bc2d1"
+    },
+    "1201": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1201/download",
+      "sha256": "1bf442068aca991ddab16acd5f0341d25d280a26ed408e6b6da57bdbc8253878"
+    },
+    "1204": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1204/download",
+      "sha256": "40059d3ad69e7a95b7a16b582653b8b642927243bdd6b0aafceaf16818373fad"
+    },
+    "1205": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1205/download",
+      "sha256": "d57ef7ad5fdfd67ab82f723e519c08ecda81fcaf8bac4b879ab35de7f8aaf47e"
+    },
+    "1207": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1207/download",
+      "sha256": "4f7f2298451be6a810d6de81b4a58e99ed59aa3290e501707b00e8e42a8d1f49"
+    },
+    "1208": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1208/download",
+      "sha256": "c19a39671d4c4dc1e190ee8704824241f3b73b539e2bc378e6c92ffec89d5abb"
+    },
+    "1210": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1210/download",
+      "sha256": "421a010391b0f8cc84b91517a3f4742fd921a81e599a38be72dbe25ecb308efc"
+    },
+    "1206": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1206/download",
+      "sha256": "99926c9b51c9a7930d0280b72afe5cfc0a0f8b7d2f3fb567fee1614dc4c17328"
+    },
+    "1214": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1214/download",
+      "sha256": "9c7d3350f31a6b4302ac14f97dacea81646422eb39038f19b58b08e009cc6079"
+    },
+    "1212": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1212/download",
+      "sha256": "588cf9f23ee417c2da9b7892a1fa49104bba9e519c8a9dda8562e822439432ae"
+    },
+    "1209": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1209/download",
+      "sha256": "c69f4db3c3308b344ab3df2f777bfc3f1cf28ae6c61f97efde5770499a8077d7"
+    },
+    "1215": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1215/download",
+      "sha256": "e2d7e3c02cb800da075170a25556edf634bc76e9c7308f22039a1e217c91cb7c"
+    },
+    "1218": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1218/download",
+      "sha256": "a5987f816ffc4b0c2271fc99f528a9114a263cb316c05ad7892d335c8acc32a2"
+    },
+    "1213": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1213/download",
+      "sha256": "5285720f2ed3839c156978f1059d1a48ea4228fb1356fda4ec5f3f5225260977"
+    },
+    "1221": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1221/download",
+      "sha256": "a56f5607cbed004aa9c27f6aed34389a602216454b34ee1130cacf7b453be631"
+    },
+    "1219": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1219/download",
+      "sha256": "12094fd41b23bbf826e3c3be6921a9dfa2eede67acfd03eee5255551c6b47f11"
+    },
+    "1223": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1223/download",
+      "sha256": "43f6d494e4ada44b1ab961884b582f00b042db28f3cc8d9d559ce8dd3b31b157"
+    },
+    "1217": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1217/download",
+      "sha256": "4ffd8ea5ccbdd00b0db2271a43c8489dc84df432a844680717a21c633d2986d7"
+    },
+    "1222": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1222/download",
+      "sha256": "e19daf4c42c1b5d32d34369b52778f9054d2c863b38d8b4866a1e9e446b60835"
+    },
+    "1220": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1220/download",
+      "sha256": "abd09f4bcc8eb4ba40bff2360eb5238587b9e093b395e42a1ee30e8bff7bb168"
+    },
+    "1211": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1211/download",
+      "sha256": "2fb111461ec959b01da436f4ce5a7710d8cddbfbdce6e5eb9f6c37b448ce9f9e"
+    },
+    "1224": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1224/download",
+      "sha256": "49bf91cb2378e04c7a11d545f5e5a7ccd993e440d1fe4540b861a17fb3595709"
+    },
+    "1225": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1225/download",
+      "sha256": "3bebe85447da903e174cc3dca14acee7d323124eca6a37d7dc39e0b988125aae"
+    },
+    "1227": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1227/download",
+      "sha256": "e823f411716d1ba021849568f73b347e14a5e33cf2f78d1a99af00a55b7acfe5"
+    },
+    "1230": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1230/download",
+      "sha256": "56505c8d94bd9b22459b46326ee68887a28c3d44455e84866e86839e97d121a8"
+    },
+    "1231": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1231/download",
+      "sha256": "c31780eebc2f0206d0f24fa79df2440d7acc5ff0215c3c8d4473122bb3fd5c8c"
+    },
+    "1229": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1229/download",
+      "sha256": "41a67bd12007ce847c0c9d4acfbddd8ecf2339eb02b7bf1e83efd681366b0742"
+    },
+    "1233": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1233/download",
+      "sha256": "f4df8ded4dcacbc37d55a81511934608c760f23a0974d1de7b81512cbdb2c73d"
+    },
+    "1228": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1228/download",
+      "sha256": "44ec830e17d437c5ceda9ea714b8282121d6eb28440c33d6684dd0b8a49a8695"
+    },
+    "1232": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1232/download",
+      "sha256": "71668a3fbb3894cdf260a9b60e919a18249524a3a050a33e1149cddbf2719042"
+    },
+    "1234": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1234/download",
+      "sha256": "d36fe18fb7e3252133623a65e2fa356042e69e405313d19afff21644da91adb9"
+    },
+    "1226": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1226/download",
+      "sha256": "fb5d92e4460de245791962f5408f26eea1c5c21357127e3dd481c280e33b9a69"
+    },
+    "1235": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1235/download",
+      "sha256": "435e34d74c9252be53acd33dea6a1a4400b222851e0cc16606358dc03144ee14"
+    },
+    "1236": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1236/download",
+      "sha256": "45c42f3ce4075b5858b5d90e28607818e2fb809a3b4b134acc1eae75f8e1b9c1"
+    },
+    "1237": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1237/download",
+      "sha256": "f4fa4a57312ca3edbdf0c9efdbac094d431626f4268e3b1e66e5d5bb9c49a9d5"
+    },
+    "1241": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1241/download",
+      "sha256": "e1cd20d87537ee3370542444878dd93c6155e1c8a2415c2b81f78a8d8c37c20c"
+    },
+    "1238": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1238/download",
+      "sha256": "9eb0d2f0506400900dbf844afdabaa598f1492ffe643789db2cb358083bf3e06"
+    },
+    "1243": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1243/download",
+      "sha256": "02b96622e04d00d083b85f85c8fbd4bdf2306538586e4a3170ebb51cf61261d6"
+    },
+    "1242": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1242/download",
+      "sha256": "d2f5eb8e37406a6ca09fe23e752ab137473b4100140d29c259b7bf200ccf858b"
+    },
+    "1239": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1239/download",
+      "sha256": "5d7063c0f6494bc2ae3063a89023b6de9c8952ce868a2ee78b0ddcb415da4a0c"
+    },
+    "1245": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1245/download",
+      "sha256": "55b066e3c09164e58d330d9105ba7fedbb75ccd202b9b67e52fc84d155f71b97"
+    },
+    "1244": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1244/download",
+      "sha256": "e6dbdcedda7920e5fd2f18c694f82968a419c2d88b77363d322e18a868a9dd4c"
+    },
+    "1246": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1246/download",
+      "sha256": "a3dca30bbc5708a3a391ccce34431d5b350b81a2af7195b76b7004f5e3ce15ec"
+    },
+    "1248": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1248/download",
+      "sha256": "493b6b9612759b6f10e1af7805f608548a8f5d8aba8b39f42a7327d92c1b962c"
+    },
+    "1247": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1247/download",
+      "sha256": "51b86c2e0bef5101771d3ab596e8d50a2dea7a11a845e85a11b0e7d299d82846"
+    },
+    "1251": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1251/download",
+      "sha256": "4cae7750e30a4c4a2a1917513f1c3dbe494d518c3051f813e399a0b7471c4011"
+    },
+    "1249": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1249/download",
+      "sha256": "08d7cda73c847a998bdf3fcc152c92e7302df58d24437b9aea9f4441c6e74577"
+    },
+    "1250": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1250/download",
+      "sha256": "422ad925d3cb2fa27abeaeaa1176747ebd0d9a99a4dc6b7374b566bc673ca91c"
+    },
+    "1252": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1252/download",
+      "sha256": "c7aaabbfa74eaabed846ae00eab5a4721f666aa3e757b3f12f6e71ed8927278c"
+    },
+    "1240": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1240/download",
+      "sha256": "8fb4363d54f66cd6417e2ea2dc748bdfbc13d5105cc8885e17a6c647b139fce0"
+    },
+    "1253": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1253/download",
+      "sha256": "95decae814a9ac609e1ef9c338506579009dbdb23644c9252658000d6978a39f"
+    },
+    "1254": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17/1254/download",
+      "sha256": "980d6541f18b676efe68c633a6c23e4cd74f6a32a8345f94eb68d88813c706fb"
+    }
+  },
+  "1.17.1": {
+    "1428": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1428/download",
+      "sha256": "09014a62a89c424f2312264d2e9514fa9e3174735199b1d48ec7ceb78e91596a"
+    },
+    "1257": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1257/download",
+      "sha256": "4cd58288b72007188e8e397108ed82a3c5517517d01033096954109a252a77e5"
+    },
+    "1264": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1264/download",
+      "sha256": "fbb186428fef801719b6c0132637739f2f99813b7a6963c62e329c2b45d091e5"
+    },
+    "1260": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1260/download",
+      "sha256": "2ac0698d563bc0d6af14f7ef0862557a6423d84ca47508c897269f31665867bf"
+    },
+    "1256": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1256/download",
+      "sha256": "0c100492062ab28cdb7900306961a0d088047d88fb3d96d61eee45954368a934"
+    },
+    "1262": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1262/download",
+      "sha256": "47c05c62920d83e9aa3b214f0768bfd040749b045f8fcbc1647e142a2bb393d2"
+    },
+    "1259": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1259/download",
+      "sha256": "0a22233f5f9ac3884b80b5f3c4095d1c7e3cc173f6acab46dfb40a76a0274cd8"
+    },
+    "1261": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1261/download",
+      "sha256": "09bc990045fe45cce38425b529f5ee86f8343ef9c06239059285e22d85e3f98c"
+    },
+    "1258": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1258/download",
+      "sha256": "75796e1c92c66df829a27354e38e325586778e2c2461b8eae353d5a5474bc340"
+    },
+    "1265": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1265/download",
+      "sha256": "61c4eeb26a09959d03486251ae307b361bf6aa1b6807e6b3de1443c4912b56e9"
+    },
+    "1267": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1267/download",
+      "sha256": "af097002f9f0a4b4dbec237c0140fb3be780f17f34c6858350e92127d3c9b1c5"
+    },
+    "1270": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1270/download",
+      "sha256": "531b17bf27d249dc7b95539b4c5d2afc0b0f62607c4564efec263ae891d17271"
+    },
+    "1266": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1266/download",
+      "sha256": "75e4dd068a9eca4f219c349d617566cbd1b950c0002922fdaf778130ed038faa"
+    },
+    "1263": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1263/download",
+      "sha256": "6c5f5939d9ec2d5024f7bfd578a6bfbf4792e4cdeadb6294641c1575d7cd30fc"
+    },
+    "1272": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1272/download",
+      "sha256": "a3c42ed3d080e4554fc84beafd62ff606ea1b5e8498bac097b1c2fc8ef0f8381"
+    },
+    "1274": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1274/download",
+      "sha256": "b2978e532b91f93ec19f2eb7a0dc6597ad08620d1c2b682019f73eeb3889ff71"
+    },
+    "1275": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1275/download",
+      "sha256": "81ae2c4c7081579e3374c2364d76635e17a9086398b5376ddf709db21304cf05"
+    },
+    "1283": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1283/download",
+      "sha256": "82171d690afe57e073a92118f9c4138a8ac2358a88d5651d1a0083ed5e5b55a1"
+    },
+    "1279": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1279/download",
+      "sha256": "fd3e15e221f175e45595ec32a0d0673ad8e68bff9616f4c38b916cf3c8eab3c0"
+    },
+    "1285": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1285/download",
+      "sha256": "31ce02d24769fb32fa6a88a288b3266d07c5fce13564816d2ebd96601ff6c10d"
+    },
+    "1278": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1278/download",
+      "sha256": "27cb11b92aa1ae408b1248efcab69df20e7e28f0c3c10043014fa54e2d5c0239"
+    },
+    "1281": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1281/download",
+      "sha256": "a8be94eb557464face3743fc9fb2672a924225ecf3b59b0d3ca0474797b25033"
+    },
+    "1282": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1282/download",
+      "sha256": "1f8ade04b07a7da3830c935a1d8fb46016728e12ea6622c46151d17ebc60a3d5"
+    },
+    "1277": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1277/download",
+      "sha256": "62cf59bc8f2364a237f882de2ca2d682a7bde2f3b22833d0f9d13ed697e6810b"
+    },
+    "1284": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1284/download",
+      "sha256": "866949e956b56a45b4dafeeb8f6d678bec59f047eb59e5abd7364b3de84be33c"
+    },
+    "1271": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1271/download",
+      "sha256": "89bccb6718482ab587f8cb45203773ce2c24f6dd7744d94b286d43b842a109bf"
+    },
+    "1280": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1280/download",
+      "sha256": "56c7947101851fa7f2321d932c3f718e53918fd32df4cffce787858771f63ec7"
+    },
+    "1286": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1286/download",
+      "sha256": "d35ccae1c2472de891bab4c3a43603d46e3f72542d9bb8330a3ef766c0eb1db6"
+    },
+    "1287": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1287/download",
+      "sha256": "fc4a716103bf765e0b8dcc8dc225173c1726a39c3707d0132c201d4d9fc14ad5"
+    },
+    "1289": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1289/download",
+      "sha256": "bf75046718d69e52b312b07ebb81eed677923235f006aa17b1bc945a520020c3"
+    },
+    "1288": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1288/download",
+      "sha256": "05079dec984b5a072af0aef161745b90ee635c96949f5740b05f39f4708e20ea"
+    },
+    "1292": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1292/download",
+      "sha256": "1eb42432b0a81e65ea0a935d4171c5d057eeab878b496148da7745de684c10b2"
+    },
+    "1293": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1293/download",
+      "sha256": "6ea80a7ecf294bd28752f991c192428490e56f1e37f05f5ecfe5da776ab19097"
+    },
+    "1290": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1290/download",
+      "sha256": "c9a52d268fa121045cf38dc2e5910a5185639bcb49ebee1238e87bff05859c8e"
+    },
+    "1291": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1291/download",
+      "sha256": "34cf6ad168a3ec50e9e4bad68dbb7d04633edff09b7a2458a06de112d3f3df8b"
+    },
+    "1296": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1296/download",
+      "sha256": "86a1dcf84c10c4377b26df1cee56010d11bbae4a71d33a482a669cb58f825787"
+    },
+    "1301": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1301/download",
+      "sha256": "fc5516fbf08fee35b474a97efeb261fa21d4d17c9cf5ae94a29fa9b27abcb2d4"
+    },
+    "1298": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1298/download",
+      "sha256": "b53979ce69823b34aa4b72bbad30b0502829ebc7b1b8e193a227793305221b05"
+    },
+    "1297": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1297/download",
+      "sha256": "a6cf25539b09602d75cea5e362f7755210c515f2863ef4b5f13c8d73e3dc97ec"
+    },
+    "1300": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1300/download",
+      "sha256": "f310799b570dccccca51cfb353e0607e7c5717f92d806eae481b1d325c44d492"
+    },
+    "1299": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1299/download",
+      "sha256": "161da46df8c0e9bf4052b9f2434be7e4b4d48816e11b57e29a64e2722b383caf"
+    },
+    "1303": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1303/download",
+      "sha256": "cf5dc960b52acfac105bbc7792393458b4f28129395f5843c156dcc32a686788"
+    },
+    "1302": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1302/download",
+      "sha256": "a7247a7c09b3cbe07ea5e5b874134f33f45bfc794ec3a5c9f9f82ad5b2afcbb9"
+    },
+    "1294": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1294/download",
+      "sha256": "4d08c3df87e63217ac86d50824e4189b3840d8c0bdd73739c10c0ea922071d5d"
+    },
+    "1295": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1295/download",
+      "sha256": "b7d2c1e3be96b3fd98550dea0cf58865712beac1681dc3f84cc2703a49d302ef"
+    },
+    "1304": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1304/download",
+      "sha256": "d044d875b66870fee7f08e9f4725bfdcdbc9611b988a11d0a647ebc7c4a9a007"
+    },
+    "1307": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1307/download",
+      "sha256": "94cbe8eb86a9e9e380a8d21eced6636ad37371a45628d86e558eeaee939638b3"
+    },
+    "1305": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1305/download",
+      "sha256": "d639a77e8f576e7b7eddec0ac30ceb46722b72580199ea65ef7487896e7ed0cc"
+    },
+    "1310": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1310/download",
+      "sha256": "06bcf10c4ee193ead87e1b77ebd8c58d288d1c379ddb5d766f37a511036983e4"
+    },
+    "1306": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1306/download",
+      "sha256": "9ee852ed5c041916ae4b10718f17e01e3461b929c8226499469e1548006c8eaa"
+    },
+    "1309": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1309/download",
+      "sha256": "c174bf3967e999d456b991d7a963cd70776487eb9bcc2acb7e055b1c5aac8821"
+    },
+    "1311": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1311/download",
+      "sha256": "d382e76b6df638d020371531dbd47ebd8a65f7c525b2b8ee5fbbb1c2082970de"
+    },
+    "1314": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1314/download",
+      "sha256": "4f06b9dbcc84b1ebb8eb4ab634d95096504522f0f466fe8c53be80ebbe703887"
+    },
+    "1313": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1313/download",
+      "sha256": "ec5ff904c1d6b3e4ba51badf145bd69136e9d4e46477b1a7cb2ca12646676229"
+    },
+    "1315": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1315/download",
+      "sha256": "04ac07af74ea9a79fa4b753544cc830bf21d2db6e2bff14c40a9425a4b80d725"
+    },
+    "1308": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1308/download",
+      "sha256": "275feda37712b05254a0f1866f7c3d8e5c882113a187909e266e336be3918ed7"
+    },
+    "1317": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1317/download",
+      "sha256": "b11201785096c9ac8a644f61daa0a1a6acc93c71b13ead9c6a47fe51bc3526e8"
+    },
+    "1316": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1316/download",
+      "sha256": "e52a5204fbb998e7ad957d3c008389ebc84586c82b703bd5b8e110ed2a7530d2"
+    },
+    "1319": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1319/download",
+      "sha256": "651adeb3c2d86ca33914132cf66bcdcb82fb6851acdc722275f57ba50e770711"
+    },
+    "1320": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1320/download",
+      "sha256": "c17e0e4949c6e7267e816f019ccb6085fbd0738bb92563f28531104371393b20"
+    },
+    "1321": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1321/download",
+      "sha256": "d67edfad3f8df0d12a2e252d2a9364bbb6468a9e868715fa30d6290cd767354d"
+    },
+    "1323": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1323/download",
+      "sha256": "5d294ea0b3fb49348a3b4dc5fcced5ae5660e16900d98fa123731bad8384b4c1"
+    },
+    "1318": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1318/download",
+      "sha256": "3ae49ebe9e95b466275b5ff997349a94597ac63e84a642f01586c7f966b6d241"
+    },
+    "1326": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1326/download",
+      "sha256": "dda726c6f999c58bd21656196726a23b77b83793d8c2e741cc43d5a3d6899faa"
+    },
+    "1322": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1322/download",
+      "sha256": "c21f4edf9d75461286efcb23efc84fd4077d55b3811cc98809f89b8a1ec9dfa0"
+    },
+    "1327": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1327/download",
+      "sha256": "60032457265fc8822ad0da3c7696ca959b5366a9a9eadfb6039b7472459ad657"
+    },
+    "1328": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1328/download",
+      "sha256": "bbed6587dff5b95cff2e5345247de9dc36e1f8a0302f1ce649a006a85c66e5a7"
+    },
+    "1325": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1325/download",
+      "sha256": "3dc61fe85317585c09ba3619bf0f328a4791856cd4e9749e35f92af9893a04c2"
+    },
+    "1331": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1331/download",
+      "sha256": "849c1dc59b9a91701d4fd29613eb553f2c1cc94e72cd476286a95e4335413ff5"
+    },
+    "1329": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1329/download",
+      "sha256": "44e7838bacf0374798f032364b4748b94bd626257f0469876a11098d4fbd9c89"
+    },
+    "1330": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1330/download",
+      "sha256": "6fef92f1f3609fa70d1b04e08841d61bc6e75c2e648cc50e7a2c41857eadf654"
+    },
+    "1332": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1332/download",
+      "sha256": "49464eaf5a92f0406aa92b2145cefc722fb3b553d6df1761fccf77ae733f59f8"
+    },
+    "1334": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1334/download",
+      "sha256": "45b95aa8496698cbd440b34ff8c9e63bd1b357331826392cd0f78d833ff7b9e4"
+    },
+    "1333": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1333/download",
+      "sha256": "34eac7c56e96768a03201c9ba70e448db3da2504260f1c59cac19a86e85b5f81"
+    },
+    "1324": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1324/download",
+      "sha256": "b2a419af8b7c22b4e02db91c0c7367fd72752fb1a1b1035f936b91a19be1cb0a"
+    },
+    "1336": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1336/download",
+      "sha256": "2532dc885b61fe6b1f79772eb525d7a24a982a96b4f028ea47907f1d293098b6"
+    },
+    "1335": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1335/download",
+      "sha256": "5c00027abd30b69dd2971291c4ce20086c9a55c8711f5a5dca667bbbcd48f8a1"
+    },
+    "1337": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1337/download",
+      "sha256": "e661a20c6bc04224bb8113ac48a927332c10c9423f6a3c2f30b51b4bc42e5f3d"
+    },
+    "1339": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1339/download",
+      "sha256": "0afe4c5833c6709eff5d27e0d1404ef7baa8cb80291b968d3202befd9852cd1e"
+    },
+    "1343": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1343/download",
+      "sha256": "ee6bca2d0ebf388e1aa7fe60653b903b0a8c965721949710efd29afbbeabfb88"
+    },
+    "1340": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1340/download",
+      "sha256": "5ee31ad06f6544b1f7488972940fe88521827798d28ed8ed327b9c6a81e16945"
+    },
+    "1342": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1342/download",
+      "sha256": "21264b3ec61619b364c9b800c39664e5cd6bd7860b87d86aa7269e53f4d3e40a"
+    },
+    "1338": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1338/download",
+      "sha256": "79a2ea231fac32d254592bc2215a63d7d1358d47df6ff0b8e6236e8ce2940f6c"
+    },
+    "1347": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1347/download",
+      "sha256": "a4fe5a0ce99c79255017e2f0c69d5c8df10cbcde39b06d8a1cb212966c7664e4"
+    },
+    "1346": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1346/download",
+      "sha256": "505349d467d7814ed2cc222e93f17f26c2e551a80e721176cd45484a7321802c"
+    },
+    "1345": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1345/download",
+      "sha256": "c2612d7fa4417d9a3d17605094b128db10af134b1ad2664e9d4ced6f22058363"
+    },
+    "1349": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1349/download",
+      "sha256": "2b8cc73e34d6dbb6b9f7b90f726d8f5ec3094162202624cf34b130c558497b50"
+    },
+    "1350": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1350/download",
+      "sha256": "9d61fcbc0264ef40e24baa357763a816e97c02b924994835d9e9f0ce6a4eb1fa"
+    },
+    "1348": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1348/download",
+      "sha256": "3e9ad479d8514569bffee274c328449da068373d3e5bd1633fdf7f0ba2d6d7e2"
+    },
+    "1352": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1352/download",
+      "sha256": "da03159f2ef63f1014a2df9d578768a0c02b54e14e4a0c3fad80e9c83584fbda"
+    },
+    "1341": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1341/download",
+      "sha256": "04a9dc4cbc3f2c01061a68bf2a68a0a976e9aa4de67e02dbe196e454b627b0aa"
+    },
+    "1354": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1354/download",
+      "sha256": "1877306015da9ef24b409ce97b02107a6b3d437b7e0bfd613d4fa7c57a6805bd"
+    },
+    "1351": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1351/download",
+      "sha256": "71886df64f2f5e39c69c2eca2dc3b4127ff45c0fbca598c3c4fea8c4c4558808"
+    },
+    "1353": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1353/download",
+      "sha256": "0c1976de079188c2e52e405cbab435ffbbd27191a70aa3e9d92195aebd30fe94"
+    },
+    "1355": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1355/download",
+      "sha256": "c73d3942fdbd97c065f7b6ec49a019d911b039a0230af3506a68234e6f3b7e43"
+    },
+    "1356": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1356/download",
+      "sha256": "1b27f15fd6eebe1280991affc8ef4185ab03bc945844e67a5f4e0b913265efd1"
+    },
+    "1357": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1357/download",
+      "sha256": "74f91bd06fe433d5dd34caa505964753e697ed94d3fb267706bfcd4f193896b3"
+    },
+    "1358": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1358/download",
+      "sha256": "f4007b2d8d5ce45bd925c122543718aea8c36e672040532e8dcf25749233d8a5"
+    },
+    "1359": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1359/download",
+      "sha256": "91ca22562bdd3dd123d3d6e6dbb4478c45b28fb2142de53b6259a48dd56391fe"
+    },
+    "1362": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1362/download",
+      "sha256": "bbce3514f1bbda90ff994045d48371aa3227d0dc33d1095a5edfae859c4435db"
+    },
+    "1363": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1363/download",
+      "sha256": "2a3993073d76b46cde0e68b9fb72ee3621022ec3b809fe02ae38163253f95014"
+    },
+    "1361": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1361/download",
+      "sha256": "443a04af030fc977573604a45b8e71ff70c2d3b5ef5d61da4a735544c3b8a2f6"
+    },
+    "1344": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1344/download",
+      "sha256": "62f030872fa23e33ac454e332991ad09c626e5cb548602fbe7983c069a202a96"
+    },
+    "1360": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1360/download",
+      "sha256": "3db8a3ee372338e1bbcf7cfb4a86526e03801449e2139221dd0d2fb1b60d19e9"
+    },
+    "1364": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1364/download",
+      "sha256": "b00fad0aaa42aa3913d92db5c0a80160dc0b6f1e7052dced853254370c6a3e23"
+    },
+    "1366": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1366/download",
+      "sha256": "81eb0e80b8ad090c2a6a9a3a8e1a46e61d00570e0c11232c5f4bf1be742e6385"
+    },
+    "1367": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1367/download",
+      "sha256": "5904f62a0baf9389a530ec68aa0a9aec381c8dd89334ba3fa6cecad64c6d67d0"
+    },
+    "1368": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1368/download",
+      "sha256": "497a5fb3e3914af010d428c8039b24d157ce90ed20d0b52c55edcdf582d8ba14"
+    },
+    "1371": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1371/download",
+      "sha256": "80b6fabeda5cd8f8372ad19df55f81bd1342ebee8d909b1b141d397d4b557af5"
+    },
+    "1369": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1369/download",
+      "sha256": "1d560927215189c682917b42d785ac11695a0ae21e01b327af313ce649ef5ae4"
+    },
+    "1372": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1372/download",
+      "sha256": "1e9af8f3da671c87476b9861af3e82d01dd5a6359164aec59b72076021ecb368"
+    },
+    "1370": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1370/download",
+      "sha256": "139df4a2ad82965668c1dbbdbff0f5dd44786deb8f1901b2235e33eab5086e4d"
+    },
+    "1365": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1365/download",
+      "sha256": "1b41ac1cfbe2b8d4ff66aeea437fffe6769dc576aadf4a3b7a0d05e740365c28"
+    },
+    "1374": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1374/download",
+      "sha256": "2e1625198afdfc45abc8091e2d3faf154ce5f6b9b422973986f2b9340fae6719"
+    },
+    "1375": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1375/download",
+      "sha256": "df549392244d215ac4cb9a6cac2bd2e291790603fe277d87b6cfb6231d16911b"
+    },
+    "1376": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1376/download",
+      "sha256": "9d2fbd83c4dcee712cc6660c6fa4ff098a2f9116ff16583b0af15473bc0a00d4"
+    },
+    "1378": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1378/download",
+      "sha256": "bdb240d9f8a14e49646c38c1420ca703ea3dea13904015532daad9eedd9b0344"
+    },
+    "1382": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1382/download",
+      "sha256": "d8e4ea193f83c131abc0f0340074905fab1bd8baa09a994a0b8836fb36cc6247"
+    },
+    "1380": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1380/download",
+      "sha256": "65ab81662802cce5e699769d3317eb23fccee2cc7558c2a4440de9f022624375"
+    },
+    "1373": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1373/download",
+      "sha256": "01bd40bb3023558f3471f2fb0992abde0904865773ae350e994a002fb7257d19"
+    },
+    "1383": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1383/download",
+      "sha256": "b8ad24ef204c0c40b6733484caeac933e195fdba1791c62b894f317a86dd1167"
+    },
+    "1377": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1377/download",
+      "sha256": "3bc23f9fee0efa7ca28b1a1af7bed2675e3f37904058c85e71cf93d700168377"
+    },
+    "1385": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1385/download",
+      "sha256": "643021d54f3c06d0b4e631429b740e3144926d8435990e71985cd779cf647368"
+    },
+    "1379": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1379/download",
+      "sha256": "fc6997412c16875d9d5a61c2e375290828708ffd3bc2bc2f3d3967aa19ab61db"
+    },
+    "1384": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1384/download",
+      "sha256": "3a7a8532f99fdf0b72de85765b3f4428566d0b73aec1ba377de2a25b5eea59cd"
+    },
+    "1387": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1387/download",
+      "sha256": "643021d54f3c06d0b4e631429b740e3144926d8435990e71985cd779cf647368"
+    },
+    "1386": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1386/download",
+      "sha256": "643021d54f3c06d0b4e631429b740e3144926d8435990e71985cd779cf647368"
+    },
+    "1389": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1389/download",
+      "sha256": "ebf22a1d44f38b8b8230f4979dcb9f570ae776abe3a5f17f71c5744d55b449a0"
+    },
+    "1388": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1388/download",
+      "sha256": "643021d54f3c06d0b4e631429b740e3144926d8435990e71985cd779cf647368"
+    },
+    "1390": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1390/download",
+      "sha256": "f39c2f79aff12063ebf9a63a5f47da7f903fdff93287ca9dbe0e620f708b550b"
+    },
+    "1393": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1393/download",
+      "sha256": "d348d914a16bc8e00f70cb81de2dc6fc23825ffd906fe07c9dd2a386cb15da6d"
+    },
+    "1392": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1392/download",
+      "sha256": "fe0dfd332fc4389e2cd6b566c9f53c67dc68cf0807959f4db56a892fb2038a53"
+    },
+    "1381": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1381/download",
+      "sha256": "e81ce06f42dacb75565e5f83b44492b7f44256775e65c266777303577cb34ec3"
+    },
+    "1394": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1394/download",
+      "sha256": "3cab3456f360833f41fece1cb350ae0655bf557c56e0a17b1012130c695e7ed3"
+    },
+    "1396": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1396/download",
+      "sha256": "0f3a35c49b16bcc55feb0f5cacddc9e0f031472875d3c6a1bb55805072ef4e71"
+    },
+    "1397": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1397/download",
+      "sha256": "b4004e9f90297ff8488a96aecabcc27c47dde28fc1b1af851955b6d99f089b89"
+    },
+    "1395": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1395/download",
+      "sha256": "dfb8bbe870ac4ed0826ef80971348c1ca7a10b97fe7bc9cccc8641656c401910"
+    },
+    "1391": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1391/download",
+      "sha256": "de625f9d3f3e44842921152fd93ea9c5500f6119b4469b966f1585f27d161d7d"
+    },
+    "1398": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1398/download",
+      "sha256": "d1b11a9e8b40367bdc6e562d73a8edd7885baac4451f29ac5448fcf36361a378"
+    },
+    "1399": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1399/download",
+      "sha256": "280ed6e638efc81a746b937dc39dd5aca03554ccb22ee1dce972dcab60bd14ef"
+    },
+    "1402": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1402/download",
+      "sha256": "da1e9529ea68bafbddc34650cae9ef8c5ec37ab8dba376f90673b4b8f3b892b7"
+    },
+    "1404": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1404/download",
+      "sha256": "573c9e082330aa131b90968968985a7968d717eb2d986403d55bc2119542bf59"
+    },
+    "1407": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1407/download",
+      "sha256": "281dc585af8969ad092b8d8ed470af4dff54f6a2ed1067ea1d6ac7d037248820"
+    },
+    "1406": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1406/download",
+      "sha256": "976806088def30ff6a5db1b663a9470c0df815425c167cb7b32bc47cb4a898aa"
+    },
+    "1403": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1403/download",
+      "sha256": "db9efeb59be0119c2e81931a96c043fea3c4c7def03b6f0d83a97253438d21ce"
+    },
+    "1405": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1405/download",
+      "sha256": "c3c15f5b6676281a00eb31ac0c7e64c54da02ff4bfb7cfbce47841cb4a85ff5d"
+    },
+    "1400": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1400/download",
+      "sha256": "10a3d0ca80606ba8557762fa034f9b8710db8331ce6792e296e04586e1c88195"
+    },
+    "1411": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1411/download",
+      "sha256": "ea3714ad39cc9334a72300a353a20334eca0bf9c76d6671382c0905e6c5d8d0b"
+    },
+    "1412": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1412/download",
+      "sha256": "584ad1679ba1373cb700012a4725ab8a6741841ff93e379ae998160e4f26e7e4"
+    },
+    "1410": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1410/download",
+      "sha256": "12f1bfff35422fb122498100da15d39a316e98653f266e42c933d7c153504f80"
+    },
+    "1414": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1414/download",
+      "sha256": "e1e7d9ca1f7fa7ab5b01daea41f91f88ed5cc9401bbb4c6f81b23c06ece9f9c7"
+    },
+    "1413": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1413/download",
+      "sha256": "5b33e0d04b235bdf1a589c17640c1a91f74bb51a268a306fc4d28435a90a7278"
+    },
+    "1408": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1408/download",
+      "sha256": "de18d823ae90c6663e38414d4c630865caffe3182a4d52aedf4763b05f488be9"
+    },
+    "1416": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1416/download",
+      "sha256": "f28f90f2d9ef493ba435fc0d85ac33cc395f43e71e59e8e2c8932a9d6709e6f3"
+    },
+    "1415": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1415/download",
+      "sha256": "7e5d851e6da9a4fa4af035ea1f2e538fef457a8340b1e437e45ed206a14cc598"
+    },
+    "1418": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1418/download",
+      "sha256": "d3286937f6ce844a0811c79d8794510ffce974730e8e4c46c40f1db41acf2f99"
+    },
+    "1419": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1419/download",
+      "sha256": "3cf1d66054bd310ebc56943ecef842e8b47aef03333722854dbac936d2ed2c16"
+    },
+    "1421": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1421/download",
+      "sha256": "ad411b1a94e573bdbd5a1a56eb4e7ee6b598b668ce5c21eb2fbfe7ae366fea94"
+    },
+    "1425": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1425/download",
+      "sha256": "70156c1a2a4ae3227af0a8f151bd89a99647b634774bbf69010e342c2f3e52c4"
+    },
+    "1423": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1423/download",
+      "sha256": "30c0bbe00075ac7ad5a40cf78abaf2b7009d04775daba1bcbb95d23badecc393"
+    },
+    "1409": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1409/download",
+      "sha256": "58596db2f052d03e048e90f1ebe8e68d26df4e502570c18013eaa82a5092c2b6"
+    },
+    "1427": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1427/download",
+      "sha256": "81f04fbe6f0f2f43f14df4ada84603e6c46af30faa4364ab02965fc34dbbbd5b"
+    },
+    "1417": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1417/download",
+      "sha256": "887b2da5ddd96d59f2196e2764ee4e0b8f986929f73f40567a229a6f82eceedb"
+    },
+    "1426": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1426/download",
+      "sha256": "01819936885022d6e2e2de19f214d31bf9a523950255a345242b5d2525a3ae64"
+    },
+    "1424": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.17.1/1424/download",
+      "sha256": "9739f3726717e76db60905aa706ac6313b1fe8ecb12385b15ecb3e5d90eb989e"
+    }
+  },
+  "1.18": {
+    "1433": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18/1433/download",
+      "sha256": "ee2625b06e9c3788c8f3b6b0856552dcef659298008c9466bd073bd0b3371264"
+    },
+    "1429": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18/1429/download",
+      "sha256": "8153d82dd3dbc8b8df2441f7c6a33f79f00083ebc7830e0fddd524baa79fe787"
+    },
+    "1430": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18/1430/download",
+      "sha256": "ef52fe758cdeab9d08d54561151535865b2ca84cac5582bab92175d26c50660b"
+    },
+    "1431": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18/1431/download",
+      "sha256": "cbf53fbfc6e4ef284806043c8319d62b6076776151af26ab5eb4e142d9d2935f"
+    },
+    "1432": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18/1432/download",
+      "sha256": "18b1418c5056e8ff94512259bc05b97c78974bc4e3986f9bfbe4e80882d62250"
+    }
+  },
+  "1.18.1": {
+    "1566": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1566/download",
+      "sha256": "aca14f0fc5f597111d1dd616da1c164a438ed31ef0d5116101f1625a541eb29b"
+    },
+    "1435": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1435/download",
+      "sha256": "a06823204d28746c0097d6a62be66d3ce381ff217a8182d21a8c7a8c420e2d9a"
+    },
+    "1434": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1434/download",
+      "sha256": "5b56baa24d69e3199cfea106503e8e15e55d9d612c34e6c6d618538db52b6ae1"
+    },
+    "1436": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1436/download",
+      "sha256": "f103d53ec36556546d1ba9c64f1c9a9faa04a10964349abd376c33cbfe60a369"
+    },
+    "1438": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1438/download",
+      "sha256": "7d464c786a3e2b7f9d84550e6510925c1ac44e70e0c918903ff72be1740757e9"
+    },
+    "1441": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1441/download",
+      "sha256": "cf83a54a6b3858ee0f9ab6ce7b8884ae3d0e6f9b7655d49dc2137db61c8802b8"
+    },
+    "1440": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1440/download",
+      "sha256": "8d2fd01f97b9297c687c1d08c901974a50bbaaf172eda62598fefa65e8ef1b10"
+    },
+    "1442": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1442/download",
+      "sha256": "d3bfa5aa3cd350d3cded7b72d357a9b1f8684bc2ea389d2eda9a7b7746a89af9"
+    },
+    "1437": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1437/download",
+      "sha256": "86f0272646ad7bc2094bdea63ca3619a4225d751bafa780d39034f6ff22ca8f6"
+    },
+    "1444": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1444/download",
+      "sha256": "87297befea6157fd429dd318ead845e5aa4e54389af78ad4cff776c59f033d53"
+    },
+    "1443": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1443/download",
+      "sha256": "287a8760bf77faeabb8eb6a406db0dfcc0cef41e52c3692dadcbdf731296841c"
+    },
+    "1446": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1446/download",
+      "sha256": "2db0af95a09f7463e172b977f14bf1fabfa7d0579b4bda4723ddb35f926462f8"
+    },
+    "1447": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1447/download",
+      "sha256": "56d190152faf9943a1a5de9a04437a126f6546a13accf2a8a0327b53f01d0046"
+    },
+    "1445": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1445/download",
+      "sha256": "6449755daa2c9010149c8b9b86fdba5ec05aedd3d96d8d884abb5b8f5fa1896a"
+    },
+    "1439": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1439/download",
+      "sha256": "ee60481bd6d0fc6f69fdff474f8ffa049000786a38bc911cb131b942912d1e77"
+    },
+    "1449": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1449/download",
+      "sha256": "e15abeb2d260ee0a99c3b8c7bdc971ea7cd7685c9b4fa8ded278296a5360fdd1"
+    },
+    "1448": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1448/download",
+      "sha256": "873a5afa7462444188dc719ec5bed19cb950d6fe6e9ce05fc91ebc6d316a610e"
+    },
+    "1450": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1450/download",
+      "sha256": "6e0302f919cd4d92c5e50f0f3735eea1b923792de28de4696d1720105459d8c9"
+    },
+    "1451": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1451/download",
+      "sha256": "dac7d6238ce26870346e8153ad21304a0633e5bdde4ae89e91224535e96fb20a"
+    },
+    "1453": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1453/download",
+      "sha256": "c21df917e05234941ada18127dd93d6bd784a8d91988c42d3064010c03113de6"
+    },
+    "1454": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1454/download",
+      "sha256": "1a7b23e9a1692a75e6f02386c5333e09110c606d0a25a8be7889c14ca1d7a0a6"
+    },
+    "1456": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1456/download",
+      "sha256": "749fc9f1a93d880d9e7c608c6c07d35a8aa82ef270631dd20a423a55f4fdfcc4"
+    },
+    "1452": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1452/download",
+      "sha256": "cf2034531603817c6ae970977f50f9a9057c193a50f2d4025c2884c88eab1664"
+    },
+    "1461": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1461/download",
+      "sha256": "46ae4f8076983a683fd62ccced2d333bad79eb27c5a340b32b8f7b0ef91d3640"
+    },
+    "1462": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1462/download",
+      "sha256": "b5a175217fdfb914031d4ea9d03722e48f11150e0e1c4b383d2972bcefd5b3ee"
+    },
+    "1455": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1455/download",
+      "sha256": "097e7e05d51812d4a7ef8346c41c2235fcea7fff5cf54fd5d43c11975b911d00"
+    },
+    "1460": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1460/download",
+      "sha256": "1a7f8f70ea79744d8e725e357cde168c68d165fed342c29a6973fadbf3ab703d"
+    },
+    "1458": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1458/download",
+      "sha256": "c3d6541092201f99729e83141f2bebc6aff0ceb3a8b21ee9830cb779d9c1b8f2"
+    },
+    "1464": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1464/download",
+      "sha256": "8e0d791651feaa21becf63b2567e891f659d20d8ffa62c90021ae9b0edbbb49a"
+    },
+    "1459": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1459/download",
+      "sha256": "a41435cf22f78f7342ee292382e33d5012dce25ab6ca2f31755b9ef41e831f5b"
+    },
+    "1463": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1463/download",
+      "sha256": "259dd16ea7df5416de9c9e13f1f5c08d2d98f9dfc3c2cc907f09bb06e0065846"
+    },
+    "1465": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1465/download",
+      "sha256": "890279938e922218b5d2ce61a560d86e84d3d7f06abc78a465f95000050e6b04"
+    },
+    "1466": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1466/download",
+      "sha256": "5a63c646670bcf0f64c6c8487ebc2180670b42e9abda97c2881d6cbade91af24"
+    },
+    "1467": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1467/download",
+      "sha256": "86de4b6f08d2fd47dd8621810253bb628eaf358b344fde89af7947c6d2cb9ebe"
+    },
+    "1469": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1469/download",
+      "sha256": "7b67428b5b81ec4f8a270c7b88e7cbf7ecda320d00339451fcc070b041ced0fd"
+    },
+    "1470": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1470/download",
+      "sha256": "b868d7c353dc3163f448329151447a3971ec62e9786dec609c97e26a5743808b"
+    },
+    "1471": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1471/download",
+      "sha256": "4c5f4a4d2a44f2aaf7810e65cc3a950cea9a27f89b246799024cb05e97bb971a"
+    },
+    "1472": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1472/download",
+      "sha256": "dc0672bbb5c507d7052c5a105ab65dc14e0a3eea6d13047bd28ccfe961272b05"
+    },
+    "1476": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1476/download",
+      "sha256": "d7c9f3a97c4b70c11c86b6a4483de26b3fbe48b0d6db8e01884c8c638c05cc24"
+    },
+    "1468": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1468/download",
+      "sha256": "9d9c57b5caffa5ade1b4280b5e7d842a188a974c88eb23641ee05af259f663e2"
+    },
+    "1474": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1474/download",
+      "sha256": "bea407cac5122fe34819d36d66ee6bf5a65ec335374adad82f6c9df4de6b6558"
+    },
+    "1477": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1477/download",
+      "sha256": "111e176289a97c7b9447dc34ecce3e0ac263b466693fa197efe89cb410c1c304"
+    },
+    "1473": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1473/download",
+      "sha256": "36d42121a5b6483a540532b38e1838c6c9ef367b465689ad1277802cc045a1bb"
+    },
+    "1475": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1475/download",
+      "sha256": "119e9ae81abda08e333a38405075f1fefbebd8b9dfe6a3470b1b126224b91475"
+    },
+    "1479": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1479/download",
+      "sha256": "993e053fc9595dda63b876362772055a80519f4306bc878f436df69ae0a04025"
+    },
+    "1483": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1483/download",
+      "sha256": "2690943b7c77a03e8c74336e8887abecf73514896401aa33516099303ec60892"
+    },
+    "1480": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1480/download",
+      "sha256": "98cd24553ec228fc006aaab6b13d73a35c19e5dc85732400d5fb8890b3909ea5"
+    },
+    "1482": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1482/download",
+      "sha256": "2cc7c918a2d9feeb4ec81fd4586cfc603bd8cd543edbf8556919b7efac3c0ee1"
+    },
+    "1484": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1484/download",
+      "sha256": "54b771fe1921b65b2a5d7d1d6ce5eda182e73ab7cae2ddce83729bbbe94d279e"
+    },
+    "1485": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1485/download",
+      "sha256": "5b419f9f90b47396ff132b88fed9c3c8875c8ee413774ecc750f3d2fcf970020"
+    },
+    "1486": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1486/download",
+      "sha256": "540e4408dbae47ff250b2a95a73c7cd4f2397fee1806bae1515099669384d76d"
+    },
+    "1481": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1481/download",
+      "sha256": "7ae1ddb41b0c93a521331ed981296f6dd9f7023d5ed6368dd593dd706f8db044"
+    },
+    "1478": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1478/download",
+      "sha256": "952316e68e84513d1ac57d6df932e868945f010acaf6fa3d0664477e49a3a383"
+    },
+    "1487": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1487/download",
+      "sha256": "2331e4f652d85d7adffdf24c7627449653a923015847d13e2683c60c56a0dfa0"
+    },
+    "1488": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1488/download",
+      "sha256": "d028d7ac7542dd070d1bc9d4937d778a25899d7bc429f4885378bf08457adedd"
+    },
+    "1489": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1489/download",
+      "sha256": "cb181bf151b635cf9b4586fdef5b07c93dbe94101d93ca8759cfede76cfb4c6a"
+    },
+    "1492": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1492/download",
+      "sha256": "9ccdd1fd5b941c2796359d1b94c0e61143d6efdfc92387ddb8f2c5b7ba861db9"
+    },
+    "1493": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1493/download",
+      "sha256": "a0edeb3ba39111154371df16fe5c9edc64a54b79f5040a82caae86f9bb36a5b8"
+    },
+    "1494": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1494/download",
+      "sha256": "96e57ddbd708f9fbe4cef7ead5dde3789f814854cd60f4579c3b889438110c15"
+    },
+    "1502": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1502/download",
+      "sha256": "c0d6fabba39159d045555e1fae2dd368078499057472c644137dc2e63b2474b0"
+    },
+    "1497": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1497/download",
+      "sha256": "c2fdb11624a4070d7d8778adc899e6f8270f9c86e3a4d26a28af07f93b5bc7ce"
+    },
+    "1498": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1498/download",
+      "sha256": "a89fce9647b6a87ad71baf635f21783ca61d154b4ffc2b5477cafae01d16a18c"
+    },
+    "1496": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1496/download",
+      "sha256": "b56ae38254a5f20056d80a9e16a3f61d02a4173e19a234e261cb2539d91afbcb"
+    },
+    "1501": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1501/download",
+      "sha256": "f3cf4b9695cab314d91968584816f318ba1f1f27c122f006f4058addecdf75fe"
+    },
+    "1500": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1500/download",
+      "sha256": "de07670a49ece36eb43128567055ccfc4dfd71ba36812c7b2b0fc97f776b3eb0"
+    },
+    "1495": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1495/download",
+      "sha256": "987c34171bf1f039a819c3174e9961b46a8f342438f5e9a2f067e64fd2a6a998"
+    },
+    "1499": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1499/download",
+      "sha256": "8fda81eeccc5aa82a9c4446ad9d6c205f8092d5dd5f2b8505eadaa2b6b814a82"
+    },
+    "1507": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1507/download",
+      "sha256": "c445ed555bff39a36c59abc92784838019dab8516ccb18afcdacea9e1b465179"
+    },
+    "1506": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1506/download",
+      "sha256": "f4a6b26e219f83c18828506c5706b52022a8124eb857ba547621ff8db28f8977"
+    },
+    "1505": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1505/download",
+      "sha256": "5d235ec7ca3e6634a4902453ebe9bac343917b45f9429abe298f129e22d7947e"
+    },
+    "1504": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1504/download",
+      "sha256": "5a3756b45eb92a20b7095b171b37a13a4519cb8ba5c1c2b9ab52afde97305f65"
+    },
+    "1510": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1510/download",
+      "sha256": "c8ec85f3c4716b260680c83a6cb291bb52c5941909ef30a75afe29d9bd3880e0"
+    },
+    "1508": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1508/download",
+      "sha256": "8b1f5348f52bbc4c7e78147f72d1e7624137b96aaeaed8edcb2232f486e6e1d2"
+    },
+    "1512": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1512/download",
+      "sha256": "4d90dbc6424b39db333f35e01360acecbc2ef3282b32d90e57ce1bffb9f82cc4"
+    },
+    "1503": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1503/download",
+      "sha256": "3be60906d7ec40409dd9ecfeb8b9616fb2d3f0e654cd88f80ee3530375a0d34e"
+    },
+    "1513": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1513/download",
+      "sha256": "6d5d46504b18321b364d2668451146d1df52ecc0f83e4cad3f1c17f43884d324"
+    },
+    "1515": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1515/download",
+      "sha256": "439065ebbd1bc7901dbf6798f9dbc4e08e6ca6e9e54eac79c7f10ccc75598b01"
+    },
+    "1514": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1514/download",
+      "sha256": "aa3eb1ad766362080960ccc9dfec5d57e6fe2e7de9b71c224fa67e3f2c8dbdd2"
+    },
+    "1516": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1516/download",
+      "sha256": "67005def1a0987858ad43b302b14c21e668be009f18d6a0f4e0a6eacc981117e"
+    },
+    "1518": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1518/download",
+      "sha256": "4df6931cb6f42b0eaf22fdb7c551661c49f69826b76baa1395d8748951536b07"
+    },
+    "1517": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1517/download",
+      "sha256": "c78659f25e1e6aa5d752e3ccc899c16651fd9dc5aa427a555f4f2b488753b35e"
+    },
+    "1520": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1520/download",
+      "sha256": "304de4311a561eeeb1e547f5867890d8a5244b8e341f4a09e179076a27669ee9"
+    },
+    "1519": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1519/download",
+      "sha256": "90a2e2c289ce8938cfeecab1a035f35a0f60c34594959cbc704c1cec946e92e3"
+    },
+    "1523": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1523/download",
+      "sha256": "28eefd633390a665027a6e62bbfe1ab9983fc11d15e048c530bc3f81936d8281"
+    },
+    "1511": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1511/download",
+      "sha256": "514324689629aa173e5a1ceb685e9f68024666b9aca9a89068a221d880248fb0"
+    },
+    "1524": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1524/download",
+      "sha256": "813ece75aeb38e4a8e294a2417c0a25369eb8f46a1650669151fee6a6ca8eac1"
+    },
+    "1521": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1521/download",
+      "sha256": "5550015b0ac3597a1b4bab21612aa16a0882c7ab3076c8868c313178cc7a8a22"
+    },
+    "1526": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1526/download",
+      "sha256": "d2803b0a86d46f769e55059fa7c66b8b4928683a72c3189dca22cc81c29829f5"
+    },
+    "1522": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1522/download",
+      "sha256": "556321d85eb024a079488ea36a14f59f1156adde41517e4803a31ace9c76c080"
+    },
+    "1525": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1525/download",
+      "sha256": "12305f4210021522fbedf63641bf8a265233971b47f7dd5fe0a2b59d59e2d393"
+    },
+    "1528": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1528/download",
+      "sha256": "bd18431d1c136454ec00cd7080c8d5f70e9081e40659301a388f0f89e5555412"
+    },
+    "1530": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1530/download",
+      "sha256": "4988b6275746fedd499dc08d614499ca5da5c401a7a285791b1573fba252db7f"
+    },
+    "1531": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1531/download",
+      "sha256": "cb02983cd0fdab3946ab86a1b1293316c5106a93cebd79a320ecc50906d75666"
+    },
+    "1533": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1533/download",
+      "sha256": "f45235fe2eef9d378524a7c581dba1ed51f5f1becf80866d5b068ad452409a13"
+    },
+    "1532": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1532/download",
+      "sha256": "fdce0bcafba9731d4e95766b2984ff4af17c50db3306d1d032456122a6d53172"
+    },
+    "1509": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1509/download",
+      "sha256": "c78cf9e2b74cb42ecc458adedfbe537ef66cbe8dca44448d4b9ce9d349e0dca1"
+    },
+    "1534": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1534/download",
+      "sha256": "58d2ccfbf197406396490d918f2856937757cb99264e8e336f65a397f4d91719"
+    },
+    "1538": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1538/download",
+      "sha256": "25ac04d6f9f3f6478ef74a99eb59be15190fe11a51a4d3e9aa33d735698ff1e9"
+    },
+    "1527": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1527/download",
+      "sha256": "839cca9ac84140765ce0e4e18c3e9782f76122856e8e9c9859cc2640679c0613"
+    },
+    "1537": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1537/download",
+      "sha256": "67121df588885059e2adb986412eae44e5778f666df1bc144883f9b92680806e"
+    },
+    "1529": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1529/download",
+      "sha256": "a7bc3ce5e0820f1561f68df6d65759460c8460cda3bdea804b139bd7a88cb447"
+    },
+    "1539": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1539/download",
+      "sha256": "91493d93977f6740e7844e3299b6c4ebd326b8ec32aeed365848b729de198cc7"
+    },
+    "1540": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1540/download",
+      "sha256": "0ec4eb5981c7d088e5d89cc5f014aa0dbb101c754076687042c6a6acd81e6703"
+    },
+    "1541": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1541/download",
+      "sha256": "0d0d711424b3afec74dde53ca4d0fe27a6e11cc9f1af48ba9f9c4e8ca3e431c5"
+    },
+    "1542": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1542/download",
+      "sha256": "4b6e6f69419acef84fda894612249bf29c5ea4f2eb8498ad2729606dc2c9ce09"
+    },
+    "1549": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1549/download",
+      "sha256": "5db2d9fded5e3b0d2d1c00e6cf10f4b2e55f826a6de28818d96bfb3c1dd760f5"
+    },
+    "1543": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1543/download",
+      "sha256": "93fcd50a71dd74f02b92d0d28aef696d013233c01d378c6c1c331837667259cb"
+    },
+    "1546": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1546/download",
+      "sha256": "e4ead12f4d81821ee6ac919cd1ae551798a6c96b6ee146014b9e0f1811e7a91a"
+    },
+    "1545": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1545/download",
+      "sha256": "e745f31f0f28a634086a6200d9e81d69fb6b0dbe17e66df7f752ba1da0858752"
+    },
+    "1544": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1544/download",
+      "sha256": "efce03c068a518ec430ee9aedbcb37a939c456b76c9834489b9dfdac8addbd4d"
+    },
+    "1547": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1547/download",
+      "sha256": "f4755e13e9b1fff45649bc46a32eb777b2985d3e5d9d21ab9029b14ed4f317ac"
+    },
+    "1548": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1548/download",
+      "sha256": "997dddd91a9706b6fa69ffa94a241dacdf8eafa72c9f4e06083845b41b3559d8"
+    },
+    "1550": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1550/download",
+      "sha256": "e29c474199b1a56e1fbeeec6e88766358cccb9ab99012328834337f73d0a20ea"
+    },
+    "1552": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1552/download",
+      "sha256": "d08ddb2e170ebd440fd973cfa1cd2d3bc7edb2f6358da4b96cf351af2e366f2b"
+    },
+    "1554": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1554/download",
+      "sha256": "d3782fb445dca141d318ed8e6f6900d15aa2c8cd1cba2e9ee2299bb45e9bad55"
+    },
+    "1555": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1555/download",
+      "sha256": "60f6b417c18d8d639dee31285ad545476169cf448009c25aee169048bd435b58"
+    },
+    "1557": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1557/download",
+      "sha256": "7afbcb99f57868c9c05c42837f545c214d81e9ec03dbcdd910e08459cb9f7dd9"
+    },
+    "1551": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1551/download",
+      "sha256": "5d86e70d8a0b2cab72f4f2b14068563b0b89a7733d30caebc60ebc3bfc628576"
+    },
+    "1558": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1558/download",
+      "sha256": "a6055c11475b4eb941477f671fd8fdcef9597c78c49c85614fef26887dff4281"
+    },
+    "1556": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1556/download",
+      "sha256": "c40b069b01e3d6b3d55e7dca9fb7e1cdba2d3fbde1af493b5fed52a152162346"
+    },
+    "1559": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1559/download",
+      "sha256": "3f5c447a18835fe0487b0c66a1eaa608d8ab7c9f63c2d57605c607e88793a1ff"
+    },
+    "1560": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1560/download",
+      "sha256": "036967587ec47e8c5378d697e8fc668ed91b22839aba9e22cf853017a1f7eef2"
+    },
+    "1562": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1562/download",
+      "sha256": "8ba08ec0532ac45182a977f990f859a16c0c6f198ff57d9a5502068b22bc0a0b"
+    },
+    "1561": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1561/download",
+      "sha256": "61c6b78bf586c794422ba78e8af75301af435661ae0d3e2ede5f1e6d0a7383c9"
+    },
+    "1564": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1564/download",
+      "sha256": "34ef6e4fec9f6d8103fce05eb5156c18ad9517e7d00f540b1fedd3f0fa5db90f"
+    },
+    "1565": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1565/download",
+      "sha256": "f9d1f071a18f1eab22c588a5cadb1a4d286ebd0ffd06529b2c8cef7f18d865e8"
+    },
+    "1563": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.1/1563/download",
+      "sha256": "89140bfb32be210ee0b4a606cbf6e7e6bab462d099012ab194e947b753944b87"
+    }
+  },
+  "1.18.2": {
+    "1632": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1632/download",
+      "sha256": "d95e92082a83ac999695e07968f2acbf288243bc410cdd807b8f043b17fbe39e"
+    },
+    "1567": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1567/download",
+      "sha256": "56c2dcee47b163b6464ac3b7d57fabb18749ed5e07605dc97cc729c8e493afdb"
+    },
+    "1568": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1568/download",
+      "sha256": "2b93dfb998ea2c1059920f0806cca310e8e5e7cc92ac5780463da22634bcbebe"
+    },
+    "1570": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1570/download",
+      "sha256": "ad05f9a16346421a89f0dd34e0fb493ce10ec2cb747ada604bd7d0456abe53f4"
+    },
+    "1572": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1572/download",
+      "sha256": "44f4ae088d1977db76d4216035bcc652efc193b883315f0c22b4ee7a77222fdb"
+    },
+    "1571": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1571/download",
+      "sha256": "ab80b31525e3afc85f961263d0b1c9936314f9d684020708901f73ca5aac71e7"
+    },
+    "1569": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1569/download",
+      "sha256": "e1cb414f91a590159bcd998cd61f9c3fe5e04e9b54d431e22b3eef4b9dc2d6bf"
+    },
+    "1576": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1576/download",
+      "sha256": "e19962bf223ebda3fa880688db33b6c180ebd73c10e3d60483cb6529089a6243"
+    },
+    "1574": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1574/download",
+      "sha256": "1e8adf8a47fc8c8c146b6c72d4b0f3ffe1562d2731c11b0c1cf15c9335abbe08"
+    },
+    "1573": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1573/download",
+      "sha256": "15ad1e8ede601b94ea38282fab5de43b7c7ee471cff40c9a7ad77e956e00c616"
+    },
+    "1578": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1578/download",
+      "sha256": "8eb7cf1439883ec4246dd80722386ca70696f44bf4fb6f03661e588587ffc584"
+    },
+    "1579": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1579/download",
+      "sha256": "3b442e4f694fef4edaf658f939297fae677635f2f8d9af1f725cb16b83b1d64c"
+    },
+    "1575": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1575/download",
+      "sha256": "37b5173575245376908b88cc1c583b4fdac4371a218443dff01ce642a50d7b5d"
+    },
+    "1580": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1580/download",
+      "sha256": "95acf8b97d1d94c5e089037c6490985a609a2684f61f95b9c7dd5fbc0c1f0c09"
+    },
+    "1581": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1581/download",
+      "sha256": "c93232eb69d39021ab5757b522ab8a1f1a5a950888299fbdf32a6febab4d7efd"
+    },
+    "1583": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1583/download",
+      "sha256": "9a44f6e478eaa1edf5b8748ced04df64e62dfc3af97099c61ce7cac868dd4884"
+    },
+    "1577": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1577/download",
+      "sha256": "f094e4c434294d222a6882cfac67101f6f732579b2e9d89cddd6ddd722702ee1"
+    },
+    "1582": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1582/download",
+      "sha256": "a1c336f04c9eafce38e228eef4fb566ef0a6f93a30e495813050df762132ad3b"
+    },
+    "1585": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1585/download",
+      "sha256": "4d0b3f81caef4839f1ee10a272d9b9ef7c50fb57842ca6842026049c485a9a04"
+    },
+    "1584": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1584/download",
+      "sha256": "ebb1509df8446a4bcbb90e140ffe9e4205362b740672bf66a6fd748de9cbc3a1"
+    },
+    "1587": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1587/download",
+      "sha256": "6160ae3bacc420b6f4840d66141da1422e617e126aac9998e71bdcd4c450085e"
+    },
+    "1588": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1588/download",
+      "sha256": "08372b9b3cb81e8d8d58910fc1963a167ab049172407cd09c6397b3bfe7b7ad3"
+    },
+    "1586": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1586/download",
+      "sha256": "f051ce7b8d907a98e01b282ff1f5982a5a7601d2cadfc1a0712f6a584e3f42c4"
+    },
+    "1591": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1591/download",
+      "sha256": "cf71dea103de1781865bc2ce601c190197201c12ff977c91f30eaa871a87a60f"
+    },
+    "1593": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1593/download",
+      "sha256": "baf6a89c1cdf3464ab632c0eb242f5e3603922cd5894b92f4bd7019464250135"
+    },
+    "1590": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1590/download",
+      "sha256": "90146c3c6a7afbc331e0382a360ee3a2489fe7f8596d8961df1afc1eedd8b2ff"
+    },
+    "1594": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1594/download",
+      "sha256": "83802e47b787e2dea7be5dc00524292d46fdead922ac7292da7ddb647aed1645"
+    },
+    "1592": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1592/download",
+      "sha256": "77c84a05aa2b7a9b2621b56c4cbb8d06328ada1e344cf9bea6b2480b0fe84701"
+    },
+    "1589": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1589/download",
+      "sha256": "437ad513fa8213b45c20701239df59fb2df6c7bfd209e3149d7e532355d256c8"
+    },
+    "1597": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1597/download",
+      "sha256": "bd7041112f422b202ddc887efac43d476fd3f535ca332f15f4f14f7f2c3ea1e6"
+    },
+    "1596": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1596/download",
+      "sha256": "708ee7258a605c745a6f3e0c60283dc2b9e863724ff174958c99b3a60cdfe5e5"
+    },
+    "1600": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1600/download",
+      "sha256": "4acd58804ca41b765f9df25351fcabf9b7fcf667dbeb44336a915e3358fd8b48"
+    },
+    "1598": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1598/download",
+      "sha256": "a9c2d08ac873874c50aa7b72e62622634d12dd57b720e8812adbca4e8eb95959"
+    },
+    "1599": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1599/download",
+      "sha256": "3bee1eec117ef5a9b8df9bb17486165f1927b589ec3209489769f9681e8615f3"
+    },
+    "1595": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1595/download",
+      "sha256": "98eb5b533db5c5be3e3c5e37a9e64b39034eba788d8f738a8710078e8f0e4e9a"
+    },
+    "1601": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1601/download",
+      "sha256": "aebd2e09b80a4de968ab63f7da04d29c40c19e611c5a1aa10901a3b483e2ad5a"
+    },
+    "1604": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1604/download",
+      "sha256": "a79c9c17c75fbe6201fb70b1cbfc3781c8288d68202faab954539a313a11501d"
+    },
+    "1602": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1602/download",
+      "sha256": "7b2edd14586bff1a78cf44ce9f4edaa5eb95689ebb248bf6378089e6d9856dcf"
+    },
+    "1603": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1603/download",
+      "sha256": "4890cc9ffcd70dae365922c4bd231f2cf77d61aaba3e42724a14b3a99051c1d9"
+    },
+    "1607": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1607/download",
+      "sha256": "27020e8866c5e0ef8c5c5373031f9639f049d9214de0d2e0f40fcae9fe222324"
+    },
+    "1606": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1606/download",
+      "sha256": "327ed8ca2ca7af4cc7ebe3e57959a1343ae3a38d7be361b743fff7a347237d34"
+    },
+    "1611": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1611/download",
+      "sha256": "f5deb0d8eeb69b4004b095776c81907c4c4e95a3537387dfa9737cccdcd60b8b"
+    },
+    "1605": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1605/download",
+      "sha256": "969c419d4c7e3376a80fccf8ab8b126fb28bca1db1dcdc98621d53e0dd8ece1c"
+    },
+    "1610": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1610/download",
+      "sha256": "e86f7ef213fc76901f40d61e322985ef8e0a460f921c427b078dab9aa3898862"
+    },
+    "1608": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1608/download",
+      "sha256": "edec21197fa64bffaec52003a43f8910ac9be299c6a21f1b1859d9664281820f"
+    },
+    "1612": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1612/download",
+      "sha256": "ea5523b0e84ae27f6ce147198aa18cc34f0adf43180ccbe3394d4ef8e3ee3cce"
+    },
+    "1609": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1609/download",
+      "sha256": "fa6c5992e6187e8bdc9fefb43712f6ae1fd9f859667e674de97bc1dfb0766fa8"
+    },
+    "1615": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1615/download",
+      "sha256": "6038d852380d3207364369537cce1719c76cb8556938cd43740c8c61f43a38e0"
+    },
+    "1613": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1613/download",
+      "sha256": "c22b07b6f944ae3a127aa53111ce2db87f1b6afe81a36ecf9f148a723ba43757"
+    },
+    "1614": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1614/download",
+      "sha256": "c7f151912a7a8126511d4f9798d70cc64ca55b43d270b3ca78208de295067263"
+    },
+    "1616": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1616/download",
+      "sha256": "0f92f5b9e4b7a3855bb318507beff216793e4b78141864fbc221677beda8ab6a"
+    },
+    "1619": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1619/download",
+      "sha256": "73cfb7df250efaa87409e415a9c0a91f2c2229d35e8efb1857c6fe4cf77a54bf"
+    },
+    "1621": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1621/download",
+      "sha256": "3fc292df78c0ff959664bd06b10cb8957dee75dc97cb08473493a9c5f255b08f"
+    },
+    "1620": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1620/download",
+      "sha256": "99097b9b1f0d7bef25be381f880598c92b8d1786ff9a26c04ba64e1909cf85bb"
+    },
+    "1623": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1623/download",
+      "sha256": "22390ed82041e0f5abdd01d472c332e40812a3ac626c2d5052b0dcf546215e25"
+    },
+    "1622": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1622/download",
+      "sha256": "3abe9b9875d2ac89e1d5366670423efaba4f811457a0808396e463b7cebcf44e"
+    },
+    "1624": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1624/download",
+      "sha256": "46fd6aa99efab196827b808e9738a39d568e81505596ea66c1674e525e892053"
+    },
+    "1625": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1625/download",
+      "sha256": "160a3f0deee45f07460fb5f5c297987a914ece8b6f21ed83dd07aa72db50a329"
+    },
+    "1626": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1626/download",
+      "sha256": "644c96279403a74bfb1f045af16fdfc9b7411628ce4f83004496b973ed0dfc94"
+    },
+    "1628": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1628/download",
+      "sha256": "24a51706d57015abac195ded9db3ad73a7fd459cf18f6f29610267437997cbbe"
+    },
+    "1631": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1631/download",
+      "sha256": "f4d5fa9ff0c600d6667ea46eaaf82dbb01778dd96f8771e6a6e86c9a55db07d2"
+    },
+    "1627": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1627/download",
+      "sha256": "3056933dd46906f846e368eb7df19205feba27dc326351e3e8f34299e343eb66"
+    },
+    "1630": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.18.2/1630/download",
+      "sha256": "61686aa8733149bc3ec8f91437c513f57b37fbc9152d54ecf191418a833dcde9"
+    }
+  },
+  "1.19": {
+    "1735": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1735/download",
+      "sha256": "f943dada19ecb6865d717c371e6efbbee15f57c7ceee785ee0687c99c0dd9113"
+    },
+    "1633": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1633/download",
+      "sha256": "5072ac394ce72ad6efae8ea66e40afee1b7dbb4ece3e561474e88d319cc45364"
+    },
+    "1634": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1634/download",
+      "sha256": "301b5ee177c801752193007dc4393086f6425a9ed1f26cefef5b26e4c34ce6c1"
+    },
+    "1637": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1637/download",
+      "sha256": "d4a2ea1cf868fd4dcbd43bb49156545b4fffc1bd608bd26225363a55e18b2287"
+    },
+    "1636": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1636/download",
+      "sha256": "79807bc02ee05bb18478925a5e9894881a5d4e107818f70f8640527281ee7679"
+    },
+    "1635": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1635/download",
+      "sha256": "3f8a9112cd8c9f3bdfffececef83e848119f206a86dc2d4c81bfc221ef0eb584"
+    },
+    "1638": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1638/download",
+      "sha256": "a0285d3b026e788ace281bb72420c272c4c8dc08d6aa9bd650ee5d04e007148a"
+    },
+    "1639": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1639/download",
+      "sha256": "ad4ac00678187f777c6a3540ae072126a1263d5c7393b0a976bdf73543d37339"
+    },
+    "1640": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1640/download",
+      "sha256": "84c8e39c896ba56bc39c1ee26f9c117436426faf437fc6b9f195999d82c4ba34"
+    },
+    "1642": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1642/download",
+      "sha256": "4de437f795b40fe99b320b24d117b095954e7aaaf19d28085f461ead7d79a767"
+    },
+    "1648": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1648/download",
+      "sha256": "3f2cd66b6a64cdb9b59ec91485497387330de74091681eaa8ee0556564757ae5"
+    },
+    "1646": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1646/download",
+      "sha256": "6dd4538c5bdccae17e0477fa526fbb8eacdda36b44a66079effa8360c6739bf6"
+    },
+    "1647": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1647/download",
+      "sha256": "3576b99b72e14530d19a9b266df0ff977185fdd3f60f08412bd1ba700a4e1356"
+    },
+    "1641": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1641/download",
+      "sha256": "860b137b123da22a0421d147efc0e66c843728fe4936883ea7d6bae60c148118"
+    },
+    "1645": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1645/download",
+      "sha256": "740bce97971db3f43445850363fb4710ce14a3c14dd286fb9c42d319d83a175f"
+    },
+    "1649": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1649/download",
+      "sha256": "a1793d0ecbbb7d15f6cf318af3a8be8fee1f81b27287e15a9170b0ee32feef59"
+    },
+    "1651": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1651/download",
+      "sha256": "348a9e68fc443a7095aa0f5b6e7dae78841b962d77db9b918bfeb22e44d4b760"
+    },
+    "1650": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1650/download",
+      "sha256": "868503f3f52b0ad9f17d6b71eafc5e7c5a114d5a678c5329b7dadf7659963d93"
+    },
+    "1655": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1655/download",
+      "sha256": "04eb188194383dc9b6118db398ac27644d78059ce38acafb9aab820c98bccb36"
+    },
+    "1654": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1654/download",
+      "sha256": "41dddb659d4dbbae2728a6e897d8b0a13f2b2a5a25a8c5cf15701f9a40602bad"
+    },
+    "1652": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1652/download",
+      "sha256": "2b28fcc74ed936b8c93babbf73b0aaea3ff8137c216713c7378ea2cc1c1dd49c"
+    },
+    "1656": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1656/download",
+      "sha256": "24701540978f488d814acc769150b8298ad03bf8a20d8b467de899d0210f07b3"
+    },
+    "1659": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1659/download",
+      "sha256": "f0ab094d1dd22aead6792cdb5e29af992fcc367193c38b85bbd410ead3d45e02"
+    },
+    "1657": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1657/download",
+      "sha256": "9a91846bdc7a7937022a92c2c1a3670a290bde4876ddd88b61dbfbf178f0e6e4"
+    },
+    "1661": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1661/download",
+      "sha256": "b1bb17457728f0675ea56dcdcb9a02aaf20fa5934a9d959f4863c124ab8b2668"
+    },
+    "1663": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1663/download",
+      "sha256": "1239acdffab89f838bdc4d1c6b06c35db0bad391888e366184dba8a632372c08"
+    },
+    "1662": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1662/download",
+      "sha256": "768a73d5b688e38ae43d05ee45a27ad5b3a7820ccffcc143cebdf752f691b95d"
+    },
+    "1653": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1653/download",
+      "sha256": "caa60bab59481679d55a8ce81c4c28cfa37f4e0b51e2f9c9e0aa143d2ceda750"
+    },
+    "1660": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1660/download",
+      "sha256": "d6375b1d64360c39b92a9c472462e90f1e0d11b773462ead2755d100edd064eb"
+    },
+    "1665": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1665/download",
+      "sha256": "ea00a2dbe2fa3c0d109d3ac13cd6bee77d60badb6608d6c8518bb399a920c377"
+    },
+    "1664": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1664/download",
+      "sha256": "67e48e8cf3af448967d2c5152730a9c40e9032c294fca575fa969228a5474445"
+    },
+    "1667": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1667/download",
+      "sha256": "04cd97ece0a159d4cf866a5c2f9a543af223b08df4e22b15ba59db5049ba1c50"
+    },
+    "1666": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1666/download",
+      "sha256": "8ac519e620cab556df04e96756adefafaa17752da1fee9e4c344f37c2747baba"
+    },
+    "1670": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1670/download",
+      "sha256": "1a28f1ac4225a39032f0e5e836ab359d58d401b4b94a948e1b08fe4fa220db86"
+    },
+    "1669": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1669/download",
+      "sha256": "cf80812976b47d8e96874ccf5d81884d2e2813ac67b768774794f19525be240c"
+    },
+    "1675": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1675/download",
+      "sha256": "42bd51a70902c28bd84859ede5790d7d4c9dd7a27211afdb0b02fde22734ba84"
+    },
+    "1668": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1668/download",
+      "sha256": "2aa6288e4c6fb0bc2dae7978ef96c87ee410761a9f3b416fb4c0d2d5bec49fe8"
+    },
+    "1671": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1671/download",
+      "sha256": "79bf342f27374e0faa5fb8cd3240cf5b134fb6eaa999103d724d43314434448c"
+    },
+    "1676": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1676/download",
+      "sha256": "1b06c879c084336789ab72add0def17d894ff6ffa6841fe4f5d03524dcd60eb6"
+    },
+    "1672": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1672/download",
+      "sha256": "59e80efc93dc7298e8b7ed62d046f18180a168aa9161281efda60fd8965ce40f"
+    },
+    "1677": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1677/download",
+      "sha256": "8e2bf6a9fb4d619f7e3ada3d03530c0d3c2444c3ad2f970c828f8e66f9cf0940"
+    },
+    "1678": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1678/download",
+      "sha256": "877ac5b9f540a11dc6ca772dc570b1f2e6622d0d4977d8344bcfb010cf04ddfe"
+    },
+    "1679": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1679/download",
+      "sha256": "73c4eebe79b856ac545571fca2e56e1d3427072404f9994bf7e331e896219061"
+    },
+    "1682": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1682/download",
+      "sha256": "c1ea508c89e45e073696ea8587e140a98d7891820a562182d17a84dbcd2a9d9c"
+    },
+    "1681": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1681/download",
+      "sha256": "66dd915f8ac828f43340dbf8f59d25e35da4068b2292511a45656a45f629fcf0"
+    },
+    "1685": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1685/download",
+      "sha256": "33d9133e1d5d72ddf656ee6d371d680c98c6a5178949e4023837146c0fc9266e"
+    },
+    "1689": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1689/download",
+      "sha256": "76390b68b5d6f44c10db0a9fadcb454a00524e334e170ed1146b00a7b6b66157"
+    },
+    "1684": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1684/download",
+      "sha256": "e13e2295b6deaaeeb33c74449aa837c2494a14c22b4af7bca53eb1ad8c74ad6a"
+    },
+    "1690": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1690/download",
+      "sha256": "af98d8a03307dc0450be11289b5d745c923689123369a06ecbcd7db53b56bfc3"
+    },
+    "1683": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1683/download",
+      "sha256": "05bc6044564ec9b0e16ff337cb21dd72792fc780aafc894adac7429c8d2af8bb"
+    },
+    "1691": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1691/download",
+      "sha256": "ba963c3059dcf0a7537c21db5fed72a83770f15fdb4fffb9c522cd6e4645417a"
+    },
+    "1692": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1692/download",
+      "sha256": "6132119cfd7d1fa18599e1c0e5362d8debdd08c548b039c18aa7fd73b79dea13"
+    },
+    "1693": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1693/download",
+      "sha256": "63ee3b6ece95b633da9240293c47514d1bc4dd08c03a12ada42e9566a96e5b40"
+    },
+    "1680": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1680/download",
+      "sha256": "c4b3a3a47c7623c35f8c7cf8301fac608583c395584bc3a76289a7aac5b775e8"
+    },
+    "1695": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1695/download",
+      "sha256": "b1d34f7af97da2ac585dd6d37ed68465df62b4fd09e3334cfce6bb9e358b7db2"
+    },
+    "1694": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1694/download",
+      "sha256": "8fe1b0fe20b34a58660e9b1eaf0e14b341cb3d1bdf3e488ecb33e8873a2a4786"
+    },
+    "1696": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1696/download",
+      "sha256": "89d2dffdcd49f6a32424d91cd60fb73833b54d2e5692d318604aede1f0b8701f"
+    },
+    "1698": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1698/download",
+      "sha256": "642a2a3c3eaece1b326ed61e0a88945c43a8580d0953f5c984a8efbd616d1fb8"
+    },
+    "1697": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1697/download",
+      "sha256": "7c991e58199c04e652aaa822ecc36a44b8c200e86aff832b01a7f88b28f9d18b"
+    },
+    "1699": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1699/download",
+      "sha256": "942b4f7a669488869644ebcc0fb677b1beaa0a88819dff6adeb7e21728143a3a"
+    },
+    "1700": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1700/download",
+      "sha256": "b4c9821d3d097e173ca3af68671096e2b48fd8448e6189d5f347837e78e3640a"
+    },
+    "1703": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1703/download",
+      "sha256": "818886789891c2f29732db38a751c8af115e69663dfd2175c2c1348505603663"
+    },
+    "1704": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1704/download",
+      "sha256": "489b24b327653b62e3b4f7bcb0cb566f1546b372477736939dfc90e7f032fafe"
+    },
+    "1706": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1706/download",
+      "sha256": "3b74c31e791b22199b18cb64edd2bbfc9868a90b09ff10b6dade08e65bb00603"
+    },
+    "1705": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1705/download",
+      "sha256": "517492d0a10302a3bb8b6dbefa8be001ed0fb1c56f05863e70dd986d45d9de71"
+    },
+    "1701": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1701/download",
+      "sha256": "09cf8e296ecf4cf5102dfb5123e5381cc2cd087dc7836c37fcd389f62f250b6c"
+    },
+    "1702": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1702/download",
+      "sha256": "43ad7ceb6db78a24588dc19e8d3090b496722559a1de90e665a78b5ca5b74687"
+    },
+    "1711": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1711/download",
+      "sha256": "dbac74c1d7ce72ee145baebb163615f487122eaf3370443fd549e8c1f445c77c"
+    },
+    "1712": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1712/download",
+      "sha256": "f4af3f915f39c6354e5bc97fcfadb999b7a0d9696ca42b49ac8809ba6587ce07"
+    },
+    "1710": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1710/download",
+      "sha256": "6b797c29e38f1032992657b5f34e2e63ba744ee3b0ff4acfff782cc6438b793b"
+    },
+    "1709": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1709/download",
+      "sha256": "2aa0827dbc746989473bdff40ab65d598ddcef0d18681fdb547b6192f7d67b33"
+    },
+    "1708": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1708/download",
+      "sha256": "fffaac3d1cf3c0e39ea1de491584a9a8104d821899b7693141a4b5f21deedb02"
+    },
+    "1715": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1715/download",
+      "sha256": "67bfb5b56db6ccd255c8b7704d75d2ee4fab2812e32c50b1b6fad424a548e828"
+    },
+    "1714": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1714/download",
+      "sha256": "ee61479e3c3615324078aa9bba21b2ce957412afa0382c7343f59d50824c8083"
+    },
+    "1716": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1716/download",
+      "sha256": "8adb239518b8fc2acb93da7dd0e60bde672738c2cb66c1da6ea3e69efbeabdec"
+    },
+    "1713": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1713/download",
+      "sha256": "e8b6f2e7bc4aabff37906cc745649cbe5420ce58371e3645cd30ec4e7a8c6d73"
+    },
+    "1718": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1718/download",
+      "sha256": "ed20fdf9928b600c7eafb1ed7e85e7d0f62114795b2c238b1888c7a4b47076c4"
+    },
+    "1721": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1721/download",
+      "sha256": "cc2c8d930cfe2d881b6f419a20b48361a5da922ca9ad9b0bcf232727003d65d8"
+    },
+    "1720": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1720/download",
+      "sha256": "c0832713d3a15cd6a6cd339a755e48028ed17b98ba06e2541570e4dae206cd2d"
+    },
+    "1722": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1722/download",
+      "sha256": "8acb81ccc80584a7a2eafdc754e7a4b4a296cb8829ecf446e10513efc66aaba1"
+    },
+    "1719": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1719/download",
+      "sha256": "00cb42a46f0e49d93ad8223949328111e447149598a8de80fdcac7d7c2e7a23f"
+    },
+    "1717": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1717/download",
+      "sha256": "edc628f0e47793b2ba1c3fc3a5b37ddd6716c3e71becff0187f495933d9e524b"
+    },
+    "1725": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1725/download",
+      "sha256": "61f94c0340e0379399eabcf32a48e54ec15dc3d429347d75f666f741fb159ac1"
+    },
+    "1723": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1723/download",
+      "sha256": "7e1ec6f550643d558471526da3f9d4e3c4b25d9e9c213a3710bab04c8085e8f5"
+    },
+    "1726": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1726/download",
+      "sha256": "55a65685c8d8e428014707cabca8de8ba6deea3dc64e5b7417a361b970dfb2bd"
+    },
+    "1729": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1729/download",
+      "sha256": "77114b9087d5db24ed6f4c3d734c747b1db657f78446efdfcdfa43b6d373078e"
+    },
+    "1731": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1731/download",
+      "sha256": "ad62d1ade1e05ccad9bd4ee4806d702d00ec113d7fd4b3fd8765d299e42b84e2"
+    },
+    "1730": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1730/download",
+      "sha256": "ad47763ce78f7d7f8a60e45e7692cbd9311507d0ffff0234130ce3a8545b030f"
+    },
+    "1724": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1724/download",
+      "sha256": "f443f8bed07cb2b9aa5537ed404821a2255507f73f21ff9f7b0365b07f1da13c"
+    },
+    "1732": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1732/download",
+      "sha256": "67afdeb65c8863b350e55c80ae82e6094dfc09aa3278295d2172034f04498e05"
+    },
+    "1727": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1727/download",
+      "sha256": "fe0eea47187f8402da8a2cafed87df083c87d29bbffa9b25459b230ff9d3b83c"
+    },
+    "1733": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1733/download",
+      "sha256": "f6bea237692d46e78549a02889897366d01e6d788a8689cc7a2b879e7ae0a75e"
+    },
+    "1734": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19/1734/download",
+      "sha256": "0042f99e03aa8c4fb80696a16a979b8c679b3d9c835e10a87471fb2a1fb83df1"
+    }
+  },
+  "1.19.1": {
+    "1751": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.1/1751/download",
+      "sha256": "2b22f4cd3f7e097250b497de77c5e81d38181e0a3e69ecc4607b9a235beab355"
+    },
+    "1737": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.1/1737/download",
+      "sha256": "d0f0fe3972919b5940b24a418bcffe51dddb95291e637fcd450d9a3a6042db09"
+    },
+    "1736": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.1/1736/download",
+      "sha256": "94dbc3c190ae0ee290d4fcc0b167f683ad5e0fd063703cd8491489c42fc1e5c5"
+    },
+    "1739": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.1/1739/download",
+      "sha256": "0198dbb94adea451252f3f4d13e053d69abcba08482f1ffd083bc6e525cf8610"
+    },
+    "1742": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.1/1742/download",
+      "sha256": "51a2bf4f3e66262dc25c349bcb3c7cb6e61f59d85e9d15a739855dfbfa1675b4"
+    },
+    "1743": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.1/1743/download",
+      "sha256": "7c99036ed883833f54653dd4f613b3219facd6796bbc4617577b47384d56c4ff"
+    },
+    "1738": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.1/1738/download",
+      "sha256": "fb282b3f3088f715adedf1b282b0c52210a482edfe1c5009cf3d4e738ddfb786"
+    },
+    "1740": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.1/1740/download",
+      "sha256": "36ed8027f1239cf05e6084504cae686078c0fcca9b8c08a485571c563ddc8482"
+    },
+    "1741": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.1/1741/download",
+      "sha256": "bb10da3406a2fefc7843d3e01e0a9db47481ed512704a26235e4f235a16ca42b"
+    },
+    "1744": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.1/1744/download",
+      "sha256": "2880259a935309a2ef645be8f30dadf824e344187f71bcbf722ea8bb45c9a5e9"
+    },
+    "1746": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.1/1746/download",
+      "sha256": "82a1e058604bfd4098486caf60adf16971fd74165b5098941e1cca9879dab29f"
+    },
+    "1748": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.1/1748/download",
+      "sha256": "2724046f7f2c3b44d1e00fbf149595f30b4ebb33af75a206830b359900aa46e1"
+    },
+    "1745": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.1/1745/download",
+      "sha256": "d4e6f58d5ccd50f9b83482b8f914065fb9238763df8287d1db99e489414b1638"
+    },
+    "1749": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.1/1749/download",
+      "sha256": "f312350e1e202996fc0b5239c45c6df087a7a8da80925e3209de4bc7b6e6990e"
+    },
+    "1747": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.1/1747/download",
+      "sha256": "826089a687cc697f5d97bb6083983461f40a02f896208a758970c087059db2ae"
+    },
+    "1750": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.1/1750/download",
+      "sha256": "86af0f96a2306847f2e9cd830a66bf9c59f06ebe344244b1b1e33128cc017193"
+    }
+  },
+  "1.19.2": {
+    "1858": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1858/download",
+      "sha256": "57eb7f25b5ba46efbe2f0f086aa9c6acc3de27f7e5177fffcb1bb61631dd7689"
+    },
+    "1752": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1752/download",
+      "sha256": "637e5daa7a682357c9710c4c8f3d0fe1344fae07efedd1bf26b9cc5dd5f9dc23"
+    },
+    "1756": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1756/download",
+      "sha256": "e4b416f17d1202b22331841790ff814f116b5cc4ff410638a7dd7fe4ee4ccda9"
+    },
+    "1755": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1755/download",
+      "sha256": "41008643913605c2af2c9d134d866c4ce6b5b0a63591cb3288e6da42817a0dd2"
+    },
+    "1753": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1753/download",
+      "sha256": "fbf47f062c5b670db57bb870cb9b0adc0669bb2975c746ca39e1e40de303884e"
+    },
+    "1757": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1757/download",
+      "sha256": "1a604cfddb2819d362f75338a11f439fcd148cd4c69e84769117d6ccf48e5245"
+    },
+    "1754": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1754/download",
+      "sha256": "c0e0fa9a0018576b363feee63dada9f87b38eef982a06f4e2b7dfb06751572f3"
+    },
+    "1759": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1759/download",
+      "sha256": "150765a31536acb862f758b4b6267e268f6986b9337b4abbf270b86294aaa3fb"
+    },
+    "1761": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1761/download",
+      "sha256": "9182fcd0a660c47c3d9ba9a775e9f393a313dc1895f59e846855419567df4596"
+    },
+    "1760": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1760/download",
+      "sha256": "e6b28e3d9ec49cd7597fcebeef45752a6c6a15b087a540c1ae847ab0a402db9b"
+    },
+    "1758": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1758/download",
+      "sha256": "4aaa3dbc5a67019d0e5a3131d3daa8bce2d25d1241dff1e915d9b380e598fcee"
+    },
+    "1763": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1763/download",
+      "sha256": "eb0702c15206577d98425801e7baad872eae5adb9718de06f12eee000815c831"
+    },
+    "1762": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1762/download",
+      "sha256": "77891f6d064e35b9b254c37b5db811b3f4e8cc22c096f951a3ec2d5fbbb80bee"
+    },
+    "1764": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1764/download",
+      "sha256": "99515f4e5616fd86224111a515cb75b72d1776db26090f6f5409c4ea1076259c"
+    },
+    "1767": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1767/download",
+      "sha256": "50f366289d00d910343513d7ded840ad773a7482f2c9653b61a3cacb8d6493a1"
+    },
+    "1765": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1765/download",
+      "sha256": "8a989063e6849361f79731641687b178f811c76d4228cc64291a6d701ee7bbd9"
+    },
+    "1766": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1766/download",
+      "sha256": "d13264f21918cbb99c1efe16ed46223b8590f7944e7430dc4aaab96e48da96a8"
+    },
+    "1769": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1769/download",
+      "sha256": "47431538373a9fa3277b1ff943e53f420bbd0d2ba48d091ea900a2592a162874"
+    },
+    "1770": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1770/download",
+      "sha256": "1aaf58207c5a5d1e8954ec130a317b94eea701bb9b15e57bde0208e8d3395655"
+    },
+    "1768": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1768/download",
+      "sha256": "1e5025152ca7a091eb2626d8dcc10732dbe1862a040e726ff00c317e58cdd2d3"
+    },
+    "1772": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1772/download",
+      "sha256": "d77123fffe7f32971bcf8a4a2e1336cb97dc4656f4586cf3c4544ee25afb6a9c"
+    },
+    "1771": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1771/download",
+      "sha256": "d100391e5a56f769019f5f91d5cda9ab414e3c7eeedf33bf28ba2e4481d578cc"
+    },
+    "1773": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1773/download",
+      "sha256": "d0862542146e6f82f6eafef8c4dd32fa3724ba0a7f554b684459d15f48102e49"
+    },
+    "1775": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1775/download",
+      "sha256": "17c12fa97cdcfe20153cbb84a9d05980118ff28d1c1cf16c9e9dfe8a00936373"
+    },
+    "1778": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1778/download",
+      "sha256": "44e2bfa42657b509f6f070832c6f130f0fc254b465e4c4c7600d33d26b6b4c38"
+    },
+    "1776": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1776/download",
+      "sha256": "39c263fbb49f7fa8567f4e67c6b80fb258826347543916e43528fdcc438a1e5a"
+    },
+    "1779": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1779/download",
+      "sha256": "3b14d6afc200e7610645e24b0e58a5f2dca984bc39f8a448588f6fed60d31f71"
+    },
+    "1774": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1774/download",
+      "sha256": "b46f4df30e337f67cf5ca6e1b548feee924ab890a6e663cf77bb8ca55c5b300d"
+    },
+    "1777": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1777/download",
+      "sha256": "ab6df63903c10f6d0e3e151f6083ba924a5122ce202d6fe2d35850413942d567"
+    },
+    "1780": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1780/download",
+      "sha256": "59c36dd5810ebef442007911247f4a42e3d6d48d0a1fb2b2dfb5bfb7e9d2f0e3"
+    },
+    "1783": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1783/download",
+      "sha256": "a279ddc11138cd7f1732454a6c145da1f4d06982121c67ba9592bf048321350a"
+    },
+    "1781": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1781/download",
+      "sha256": "a87a5626950bd347bd91fc2e340bfe59b0410f87e327bb2d45d273f9def9b7be"
+    },
+    "1782": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1782/download",
+      "sha256": "82195fc8f83a2ae167b0ec9fa794922d572597ae3aa03429c049e3be5dcfc02f"
+    },
+    "1784": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1784/download",
+      "sha256": "4e2ff5888f7c6097a5253ccbd29895e1701b0b3623e7288ba40e5fbc1b3a4258"
+    },
+    "1786": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1786/download",
+      "sha256": "15f57090f20c4ad76b5e91521e5fae43fbbc8814568ba1bdd8919b4d786db18c"
+    },
+    "1787": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1787/download",
+      "sha256": "a32f25ab3347e836a03fabdd740e82d03729f074b60b06e5b08a52d5a35bd8b6"
+    },
+    "1788": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1788/download",
+      "sha256": "200bd2a9bdf7eb1940b578ff3e91b808fb5f54ef764f1507fa0b38cceefea768"
+    },
+    "1789": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1789/download",
+      "sha256": "f15158a563f14c5998fcc019d405838f9ad373516f83d9dcb3d547103db250af"
+    },
+    "1785": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1785/download",
+      "sha256": "c6550ee2084027c4a07427f5d72b67269ca1291d90873f19e86aad60d92350a3"
+    },
+    "1790": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1790/download",
+      "sha256": "08acae02cccebd2e685445564cc48b41e1eee2799f865f3826155ca0ca3a4897"
+    },
+    "1792": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1792/download",
+      "sha256": "3fe01d5ddcec72ae9cd055c8c90e045a38a168a75b9cf8ad15e79bd0bef6ccd0"
+    },
+    "1794": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1794/download",
+      "sha256": "dd4952278e96973830f25efe3e57e37534bb00c9237eda17c30d31e5fd599ca3"
+    },
+    "1793": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1793/download",
+      "sha256": "ad8ee8ff8d6f66b31b6dce9d89ba50d9ab77c3c7c5cc4cf121074cd0fccdb4e1"
+    },
+    "1791": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1791/download",
+      "sha256": "f54427df96ba959767dad20a7c536c133e1ab82a04e40ad6d720a7f3c77655aa"
+    },
+    "1796": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1796/download",
+      "sha256": "abedc74e68e13921f804841aa2913e8ceaf44fc8386d767b7d679d7b39a441ad"
+    },
+    "1798": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1798/download",
+      "sha256": "a432f6fab3062a519218a6406cc770934ef9dd36884e86016fc7babbaf2bc6ed"
+    },
+    "1799": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1799/download",
+      "sha256": "ef8731ad0be0db6c47425d32eb0df44780c2a4581b27390494f1c7055f328a52"
+    },
+    "1795": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1795/download",
+      "sha256": "fbf486854d7db922020fc9574e499c4dc8bff5ba968835d07586ae766dded83d"
+    },
+    "1800": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1800/download",
+      "sha256": "b9ca91aebe36a087f01016292d79739020327c26a416ded380396fb9d855357f"
+    },
+    "1802": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1802/download",
+      "sha256": "79b1ae56dff34618b2bb22f191ff8b30a28b5d35a450c94bfbaa3e52d40db582"
+    },
+    "1803": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1803/download",
+      "sha256": "d5be7cbb08a673847dffc3405927bb5f8f523b8ef3993ea4fdf1b1458de8272e"
+    },
+    "1810": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1810/download",
+      "sha256": "94a0f4a6c44c52eedb7a1b862aa155c65c03a76ee3ed6870960f3f14de0f23c8"
+    },
+    "1805": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1805/download",
+      "sha256": "e1306ffd8bc8f95bdf351ae5f39e55627da4e11e1a5056219111e39ff3aed46b"
+    },
+    "1806": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1806/download",
+      "sha256": "817fa5291770091d0878e4dce1114816b3e990da4ddd51482def0343ce6b7213"
+    },
+    "1804": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1804/download",
+      "sha256": "1129095540bca48538fdb92c5cb872ff1fa73c0936408b77eca27baeb220f058"
+    },
+    "1797": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1797/download",
+      "sha256": "77917e2ee6ec778b145739fb12499b83c9ffc51234918fe4368a95e8067a88ae"
+    },
+    "1809": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1809/download",
+      "sha256": "c9cffb49d6e20554aaa4ce0f80247650d1f9801d0da1020642fb0a8b64461ef6"
+    },
+    "1808": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1808/download",
+      "sha256": "a76a6ebd5fa37b251984310832c3aa2b232b7aa784089d904351cc6eed9de702"
+    },
+    "1811": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1811/download",
+      "sha256": "64947919aa15a85d1eb1b7c049c47a1b2fd482d789216bc0f259b8ee2ec36448"
+    },
+    "1812": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1812/download",
+      "sha256": "3257e5de320ee8de1bc693e27fcf54fd5e8123ff077cb81ba1087ef5a804ef8f"
+    },
+    "1807": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1807/download",
+      "sha256": "9e75ceecd3b9236d8f1213c623ca9ce687a30ce16a3ccf474a3b5cfd79b49ced"
+    },
+    "1815": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1815/download",
+      "sha256": "231b642d8fd1524956b096e0691960816521f2a286d3aeb05830256b00e07803"
+    },
+    "1814": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1814/download",
+      "sha256": "ce223fee3c9c7a9ef5f18294aedc499913a9556e4a1d2c1b078e914ae2f83b5b"
+    },
+    "1816": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1816/download",
+      "sha256": "ffaedf66dc0a34fd6ab83fc3e0eca06992bc2f70bf716d5539664f5807d7a339"
+    },
+    "1818": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1818/download",
+      "sha256": "a689cfc83cf3bad822d72aacb05864b6b6f9050d3a947802815ea0730059cf07"
+    },
+    "1813": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1813/download",
+      "sha256": "0d4c32a9de78dfe524d9fcd5f9d5cc73938e29182aff391b0fc9970dc37a2958"
+    },
+    "1819": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1819/download",
+      "sha256": "139d2213c65cf6fb7640d22f6f579b47d29e675414d908729f3b95e4526f1016"
+    },
+    "1821": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1821/download",
+      "sha256": "a127e75a06c12c33cbc79c94438a944baef6f9ac26c3fa893f010c5093aa2e84"
+    },
+    "1801": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1801/download",
+      "sha256": "f4d565ccfd8475e8863a6d605e0807cc73939ed64e34497f764903c62a7bfe9e"
+    },
+    "1824": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1824/download",
+      "sha256": "65d867e7ff9f5c05bf4c3a586f2f1157396b334acfb5922e648b61cda0c1c263"
+    },
+    "1822": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1822/download",
+      "sha256": "17070502d93c3e4fc8c2382e8c43b704c95c25e575fce89ecfa68144523eb51d"
+    },
+    "1823": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1823/download",
+      "sha256": "1e200812d8f00d9eeb73c09669a65ea5bc82ade3e67f1c687cb6a807ea93bb3e"
+    },
+    "1826": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1826/download",
+      "sha256": "de660d5770b564bc3b88fc2c41800a10d19a1aa77e6bfe700877da293a7dbccc"
+    },
+    "1825": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1825/download",
+      "sha256": "47da1cb01c2cc76c07b6b0c5b8948c9370652c86f695a3558dbb82cefc7f5d2f"
+    },
+    "1820": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1820/download",
+      "sha256": "bec20d3b0547eb20c4b59a95a3aa224cf023640aad583a66bc234920ccf1720f"
+    },
+    "1827": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1827/download",
+      "sha256": "ea086d57662acb0204cf8b61ed2e56e2de9202fbe3a83799cc4466cdcb029277"
+    },
+    "1830": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1830/download",
+      "sha256": "9cd1cc35aa4146eeacc90958327801ec48b5f60da96b3a336b604eee59310825"
+    },
+    "1829": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1829/download",
+      "sha256": "9cb51519b09728f7710a2a9e913f279c587aa1f03d7222ce173b50689657a4c1"
+    },
+    "1828": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1828/download",
+      "sha256": "c6aef01236ac2bf6f05a6b9b562fe9ba7470d900bbb8e56e284be5a3f6285d08"
+    },
+    "1835": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1835/download",
+      "sha256": "7efbd9435c42f78f75800ba0587834811b3a51cc2a747dcae74a2773a469a9c0"
+    },
+    "1831": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1831/download",
+      "sha256": "f3a788136c6e1bb8e4d3735f86dbca65f988aa524a779d98a82be486ae72a9c0"
+    },
+    "1832": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1832/download",
+      "sha256": "bf89abbcf6de2be1dd8f65dc32c3baa63663873aa6e89454c9f3cf24ac5f40c0"
+    },
+    "1834": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1834/download",
+      "sha256": "201fc98e19ca4dbb52e6a00a0e818c91f33b53879aac8abb07628681dd1780f3"
+    },
+    "1817": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1817/download",
+      "sha256": "658927b7739cc3d6d5db649648dd1079be96f84e9e2c9e284fcd51f91d26b578"
+    },
+    "1839": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1839/download",
+      "sha256": "151e28b9471c3a77c5bdbdf69bc1bc33aa6f8f9e1a3aff102bb28fbc3f5d8dc6"
+    },
+    "1833": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1833/download",
+      "sha256": "d659d1856b8ad464a59daa5496de0eb8e8ebb471ba3511729768ee967d9a22a7"
+    },
+    "1838": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1838/download",
+      "sha256": "81665bd795fc7fdd1d091264d6ba8e1ba1b278bd6f51b4c7e9a8670c76b93cdb"
+    },
+    "1836": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1836/download",
+      "sha256": "3c302a9b039ec06315a9df3a1ea74059e74166a5b192a04b06d87526c3b49c3a"
+    },
+    "1840": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1840/download",
+      "sha256": "04891acad30d6c9c3818b604296d74bb8a3d62ef51c328d1b2e1305c4f8a10be"
+    },
+    "1841": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1841/download",
+      "sha256": "8041a568fcaf05bf4be20ea68d593eef071870bf177ee33a61008371fc23b9ce"
+    },
+    "1842": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1842/download",
+      "sha256": "f8ed9d232209a1e4afd9056ad1c7821091c5b79b32852216f15d7df16bcd8c33"
+    },
+    "1843": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1843/download",
+      "sha256": "e6c55942e8cd7c571edfe213970f2ddeb15eb4b4466cba1f8b8334e2b280d677"
+    },
+    "1845": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1845/download",
+      "sha256": "b6813505a7f7553c71467499c8ace71a46c8f0c4fe29895b9641eca34d8d8a8e"
+    },
+    "1848": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1848/download",
+      "sha256": "b27c8549146896f94e74c9bb63c439db50e3118ce7b33bbbc8e82eea1ba19ed5"
+    },
+    "1847": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1847/download",
+      "sha256": "103466d616d6301351ed9af06090584b2e7bb2f58e92601cb1540c45927fa9ee"
+    },
+    "1849": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1849/download",
+      "sha256": "38624c23bf2828fd449c5a79d07832b3ea9d296d3ac2999eb3c3fc897a4f4f97"
+    },
+    "1844": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1844/download",
+      "sha256": "38ac28039b2a2489a73c59fa1a4dea33e4f630cf54d98e02342b55c11c28d95c"
+    },
+    "1851": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1851/download",
+      "sha256": "46ab9447c0fcc68dee66dcd7628e90b46b2329de879dc436333ac652d0ff21a6"
+    },
+    "1856": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1856/download",
+      "sha256": "13da870880fcacde034fe3876b9096b7422f7e7cd292e3d5ea7fe086528b4510"
+    },
+    "1852": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1852/download",
+      "sha256": "677d819f68c651aa0137f8a1ab8b101460247733635bd94ce749c236b9619bd7"
+    },
+    "1850": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1850/download",
+      "sha256": "6e0b2c2279cdeba4f7a9b661ec6bc9454f802e17e016d493ec6cd3e17c21638f"
+    },
+    "1855": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1855/download",
+      "sha256": "f3ed70a08e89433bc0468e99abdede5991cbabf8c3a9372d2d2e3553efaefc4d"
+    },
+    "1854": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1854/download",
+      "sha256": "889db043fbf33d61fcde7372d582022daa964aadc2d2dda557cd81cfa3ba5934"
+    },
+    "1853": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1853/download",
+      "sha256": "523208813ac8b5104068dceadfd71b6ac31cb61cb95b0392c9eb3802e1607b69"
+    },
+    "1857": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.2/1857/download",
+      "sha256": "6cb959e4a83db82e9e0331ad7d77a783260942c037140a45ce6eab9e7e09e038"
+    }
+  },
+  "1.19.3": {
+    "1933": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1933/download",
+      "sha256": "b4f4a6b1342cecc9225d5b832d0f2f20a486c97129d4af3d57ee9569e1ce24d7"
+    },
+    "1860": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1860/download",
+      "sha256": "4b3ee23a0feaa6b7e008602e7d23f0cd741c431239fbdb5eaa30cc730d6fe275"
+    },
+    "1862": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1862/download",
+      "sha256": "fc66798b68d821fe1dfc2ee8ceac6afcd694b71036365600fe5e9659e19f5061"
+    },
+    "1863": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1863/download",
+      "sha256": "89de3269b093c2bb82dd19d4bc4f85e16a9bea175d1c63fc3db9096ffd9b7e94"
+    },
+    "1865": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1865/download",
+      "sha256": "37e63f54f36e3e32c2ba841ecce023e6f8288caf553835da0b1ca841a1697faf"
+    },
+    "1864": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1864/download",
+      "sha256": "0e8c7721162aa37815ff341da17907f9dd53a1d161003ce3e12718674ff1fb42"
+    },
+    "1859": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1859/download",
+      "sha256": "baa04b241f780ee3b639ad2554b679cc2df52cc3fa437249cabc4b47cb45703e"
+    },
+    "1868": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1868/download",
+      "sha256": "d31c85a8517e2ddf7a657620a3256e1c4d1f17335e47361a7cd504e0083f5fd5"
+    },
+    "1866": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1866/download",
+      "sha256": "150981e9d71797cfc5714ea46695a5a31437b123657da7b3f01209ffc4dff735"
+    },
+    "1867": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1867/download",
+      "sha256": "639ee3d9fdbdf8adf2f9bfa5c9406233ee94239354471ebeb3b69c88fe341614"
+    },
+    "1861": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1861/download",
+      "sha256": "5599e5fe9f278d6f3c571de0802e6e4741868358635d679daa471f10f1515585"
+    },
+    "1869": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1869/download",
+      "sha256": "d91e86da1d09e9388d1f50c57527548fc6ddcf11bf6cec1fcfdfe592b669b104"
+    },
+    "1873": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1873/download",
+      "sha256": "c91798f7ad83c6eb42ed25da8de4d44eb858e3655551dd510903b331e9f909c3"
+    },
+    "1871": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1871/download",
+      "sha256": "65211a2b1e29ede5b3fee771b84aa4e04373bef4a093f23e2861934ff5e8de66"
+    },
+    "1872": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1872/download",
+      "sha256": "df271b017ed6af83c4a644cae808f9fc756f7f17fe77354ce652b7317a31c86a"
+    },
+    "1875": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1875/download",
+      "sha256": "762433ddb172f0cbc0e2a5ec1eb0508ebca9f10628ad8fc219fb5970c33eb4ba"
+    },
+    "1877": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1877/download",
+      "sha256": "337a8336122891220b8f452b6634bae738c478eeea33071320efa465e6626816"
+    },
+    "1874": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1874/download",
+      "sha256": "8f018c0ead0b5427ef647269b0704cf06539d8e058a7816589d3d264b1a89d63"
+    },
+    "1876": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1876/download",
+      "sha256": "789f83ed72e1c2b6804a6931e1865e4ad35039dfd393e9bc1270ff7a82f9f2f2"
+    },
+    "1878": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1878/download",
+      "sha256": "2d718451b297f876034687a09e6cd33197317467091c02867bfc8a8de50ac352"
+    },
+    "1870": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1870/download",
+      "sha256": "6fa80204ae3ed824e131ba6a149bf2f0af58d585c375fc3f1b4115e5de17c017"
+    },
+    "1879": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1879/download",
+      "sha256": "0149b12b1ae8ca062efaa5014e51997f24c30da2c4379a6e849348334b551d50"
+    },
+    "1881": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1881/download",
+      "sha256": "626fc76a74c9e98b85164a39821abe20759138cb2126ea11a60b3dd71bb3ba8e"
+    },
+    "1880": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1880/download",
+      "sha256": "857ed3311fba2616708e15a2cb896984884ebcb8055b558d50853b02827c3239"
+    },
+    "1882": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1882/download",
+      "sha256": "570d009b633ee231cdf1d6dbf757157871523673138f897a71868f3a789a7d0e"
+    },
+    "1884": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1884/download",
+      "sha256": "03b901f3198b25c3d11bf8debeb26fd693a0c43a6e6eb6651de02ea216a8ff15"
+    },
+    "1885": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1885/download",
+      "sha256": "be2832f0ed3f8db24ce2e48a4020f61d313b343579189401434b59a6a4a60df6"
+    },
+    "1886": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1886/download",
+      "sha256": "5719938464e0778bcd8228bb4536005891fbf5a75c30766b295ab6675862e7ba"
+    },
+    "1890": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1890/download",
+      "sha256": "ef7bccbb2bbab57d6d443744c452ab5962b19677a8b1b7aa4497f70174481409"
+    },
+    "1887": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1887/download",
+      "sha256": "0d1d1012887efe1b1986b40284ce722008822825c190119e2018b94a11627708"
+    },
+    "1889": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1889/download",
+      "sha256": "57c46b44f5f73375f45c56f198efc169cce6243956e77786f0dce901d8df46f5"
+    },
+    "1883": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1883/download",
+      "sha256": "0016454a34799b669b68782525e397422c24eeffb37f9dfef5a75250dd8b814c"
+    },
+    "1892": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1892/download",
+      "sha256": "bb5a80855d5ccfa69b6c3ac112eb66bf402107f1bee106dc6b586971b7189bf2"
+    },
+    "1891": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1891/download",
+      "sha256": "523a3885740db15394829a1b9472bfe335ee42c32d954a5941ec7d50d48f15a5"
+    },
+    "1888": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1888/download",
+      "sha256": "42b465652367ae75c1ef98900486c636ba491aaba8fb9f2ae6ec0ff8596c7398"
+    },
+    "1894": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1894/download",
+      "sha256": "4171265e5a9cb42cc7b8a188ab68f57cfb2b44b086f5ed367101ff1046d8f0c6"
+    },
+    "1895": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1895/download",
+      "sha256": "fb4c4f28fa50695f28d7290352022c468888506275b165f3a91cc7fee0890062"
+    },
+    "1898": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1898/download",
+      "sha256": "4e8366aa091e239c1fd18d9996ad7bde70784ce87ba2d6df6f2a4b483b1e50e9"
+    },
+    "1896": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1896/download",
+      "sha256": "d71f665652df80e13587a78d42417eb085021492c2cffa39488f4a21cc5b60ea"
+    },
+    "1899": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1899/download",
+      "sha256": "1585661ccc083d36ca136fdfe3dbd9791f7b472e80812c3bded025424aece972"
+    },
+    "1900": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1900/download",
+      "sha256": "d42a1ec847567182896df600271e6f9c5c334460d81447bb8e6382dfa8e87021"
+    },
+    "1901": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1901/download",
+      "sha256": "ea6d97745b66f7d9fe490c9ffdc58aac3c8495af2f46ce0def9fcc7dcac90b96"
+    },
+    "1902": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1902/download",
+      "sha256": "770d3df7ef7b65114178edcb3657ced8ec531e41a1d3199271c5b3623a710568"
+    },
+    "1897": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1897/download",
+      "sha256": "a9d059b73875695ba2ff64c9e6b978b0b24bcddf3ff2190986d2c1114210dbd3"
+    },
+    "1904": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1904/download",
+      "sha256": "fa4f47d3eadd3773bef0672319ae729abd9c6b7bf2d7435e4544db2ba6596d4a"
+    },
+    "1906": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1906/download",
+      "sha256": "be6da0970f5c69a784b731241bc29050ebfb344e66523e75359eedfc10644c47"
+    },
+    "1903": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1903/download",
+      "sha256": "c2a7c3ecbd5832a585576208586620d74c29d7c4ea1e561c40c9ecdc2381c933"
+    },
+    "1909": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1909/download",
+      "sha256": "91ef2cff517b1ab38c0bf3b92dcfeed827cc21493aff6f44c6523593f21b82e5"
+    },
+    "1907": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1907/download",
+      "sha256": "735b9e5fe14282d6ed2bf0576f3dd09746eef682ccbb46b6743dd7721cc0d6fc"
+    },
+    "1908": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1908/download",
+      "sha256": "44919d03df668a4c004913559bb4d90a69bb08e23c730e58e97e3d788ec7c460"
+    },
+    "1911": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1911/download",
+      "sha256": "cecde3ef58a151c382c5f19cd6ec4f979b47c6e7415c862b38d8d3f5d8554cb9"
+    },
+    "1905": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1905/download",
+      "sha256": "524b9609164757c27c27971c341cc65539bf9660ce9386503ed3fd30cee65ac0"
+    },
+    "1918": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1918/download",
+      "sha256": "51950fbc90ab3cb579e7d2fa72bb326074ba2182b256ee4e74f4464948a4b308"
+    },
+    "1913": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1913/download",
+      "sha256": "eedd939b0f1aacb45bfca109d20f48f3468bac3f7ae0ef36ef57b9ccd6e8f7a4"
+    },
+    "1915": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1915/download",
+      "sha256": "65bdf87e69cd50ec102be3d8b8ab02d289b501f407f967573a489425d9f33b12"
+    },
+    "1916": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1916/download",
+      "sha256": "f86cdcd1c5df0d0de33bec7349dace4929d76450e566f50babfb83d9c240173f"
+    },
+    "1912": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1912/download",
+      "sha256": "2bcc2623056fac1e7b213c87ac9b68f37f9c12a3cf9eeb909377dd58d348d7a8"
+    },
+    "1920": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1920/download",
+      "sha256": "4bef26ae7def79359beff623badd0abc14dab627de814832204715653101893d"
+    },
+    "1922": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1922/download",
+      "sha256": "e72175133bd9623750c679bd538ff184829b77a4144f00775bb595e3917491ca"
+    },
+    "1919": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1919/download",
+      "sha256": "80397e6dc20c36c2a69e66000f390cc222374f6f91b5a5275cdb19a979eeedaf"
+    },
+    "1910": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1910/download",
+      "sha256": "4cfc5cb801c89028a54553501ecbdaee0d21199bae75e4ddb9ddc780992bb9f8"
+    },
+    "1923": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1923/download",
+      "sha256": "bbbe991d2b488227461af12f599e94196b81d0568a72af0cc9de32cf7ede61b4"
+    },
+    "1926": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1926/download",
+      "sha256": "b8d81e29c847a3fa111821b7157b909f0ff2ce87be116185cc7628a39b17cef5"
+    },
+    "1925": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1925/download",
+      "sha256": "7d1e0f3db5aabd052f25f9d200efeb311a61ba6432429403b4f18d584dea5461"
+    },
+    "1917": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1917/download",
+      "sha256": "622e9ab71e9018255b284d3caffb14c01a9b930e171da86c2405bd5607fe4af6"
+    },
+    "1921": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1921/download",
+      "sha256": "d70c859d454210a0694614c90bab5e08102efe945c3885259678473b85dd47e0"
+    },
+    "1927": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1927/download",
+      "sha256": "81eddff990e84bd1ffdd64f20eb91ac682eb948ed87358edfc9e2417e667bb14"
+    },
+    "1929": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1929/download",
+      "sha256": "4ad0a6823c9e4ea8c4c29500fc08a1b6425a59818c6e17d30cf653c5f9c91214"
+    },
+    "1930": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1930/download",
+      "sha256": "c6b4e266f4a64cbc8af8e99f85b016b8a9f6d5a1c1addf57e798113f1cdf3c49"
+    },
+    "1932": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1932/download",
+      "sha256": "2787b4d5a2af16111d0bf92a52cb125f4020c8f5b124ce31d288b7483ef80273"
+    },
+    "1931": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1931/download",
+      "sha256": "69ba63143b81c65147352e037c37281b6ac91ac8d6e9e63a93e050395ea8da06"
+    },
+    "1924": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.3/1924/download",
+      "sha256": "03a31f92ac933de830dc7153e5629f6359277b914e5a8ba9feb073c0cfc8fd33"
+    }
+  },
+  "1.19.4": {
+    "1985": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1985/download",
+      "sha256": "424f51086c9e9090287812a4c21b65d8d69245e7e7dc3729970f12fbf5b366ad"
+    },
+    "1935": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1935/download",
+      "sha256": "97c7a6f59855f184ef7af8774608b4d2ac9b28b2e171d87992813a02708e592a"
+    },
+    "1937": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1937/download",
+      "sha256": "952319bbf17688d0621e03a51d3f3b780f72ad8b77440919dce5113b36d0365c"
+    },
+    "1938": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1938/download",
+      "sha256": "d0043afa93e334ec11c3ac59b8dc67a5462542948cccf45487bb2a06de8e6a6e"
+    },
+    "1939": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1939/download",
+      "sha256": "80cdd6337456dfb041b5ad5e7d1b1e2a75d944839fdc6cd67fd2fe6f80c86c81"
+    },
+    "1940": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1940/download",
+      "sha256": "c1e85418bb46e9bc64c7a1915f7124fb25834f2408ec75f0cf6af9e4ed40da69"
+    },
+    "1941": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1941/download",
+      "sha256": "4002b918f9e81b7475c1c338b45f51444f9c9bdd4f918eccc4a6c2ab4b69b2e6"
+    },
+    "1942": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1942/download",
+      "sha256": "b2f857359cb17a75053f582f94bbc8418d3d8dd63c102d04ef7e0dca4e56f738"
+    },
+    "1944": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1944/download",
+      "sha256": "1b3b7355dbdd531a2392185c13fc2443f1a6b83ccfed27e54199b8ea69f39926"
+    },
+    "1943": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1943/download",
+      "sha256": "e9f8488aeecc69b3619275a2e5d672624af19aca6075cdddd70e49c257f19265"
+    },
+    "1934": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1934/download",
+      "sha256": "1d5f68e5a8b3c6f0c5706cc0bb0ef5ea5d14a255112f5403e8bd55f3717314ee"
+    },
+    "1946": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1946/download",
+      "sha256": "7743415a21f9a2834b87d42e24b2a57c588794151da7f928fad1481d7e70e4b1"
+    },
+    "1948": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1948/download",
+      "sha256": "5806e3a90191886e33a9f6db92a76f0f4550bfa4c6884f92a171ee267b1f8380"
+    },
+    "1949": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1949/download",
+      "sha256": "8269201de9b13b6c93eb0145c9bc0e1056b90119ecec3820b390ebd9dee35a91"
+    },
+    "1947": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1947/download",
+      "sha256": "1133356e82e852ed94955252a3ef49700bf9a0b1fd9895b394dc3257982e0f42"
+    },
+    "1950": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1950/download",
+      "sha256": "0aa0eaca29e2abca5b2734e6878c738ac2cecfb86cf1e5e5476dd737ee385bed"
+    },
+    "1945": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1945/download",
+      "sha256": "537089ae508dfd3bcfd9af49cc81aba4d00990eee9c3c5af62d4f353647fbce9"
+    },
+    "1951": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1951/download",
+      "sha256": "e33e0f39ee4910d79494b041d891aede38595c11e8aa77834cdfbaa1cbdb64cd"
+    },
+    "1952": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1952/download",
+      "sha256": "0d42f19e5feee9a8bb8a972dec857520bfcf61ade6996c0f9d15cc5572771fb8"
+    },
+    "1953": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1953/download",
+      "sha256": "f71a9064f3b3d44d680a6b99e85e858940d182bb081c968b67738a691d4d0875"
+    },
+    "1954": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1954/download",
+      "sha256": "b31a1dd71f2fb79c009ab3d50e3f8ac9dbf4c541e0e4cf9bbe591299494c57d7"
+    },
+    "1956": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1956/download",
+      "sha256": "f6840a8b66675db195343ac25021d62f78dd11ff71dda863db202fc38b541eb1"
+    },
+    "1955": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1955/download",
+      "sha256": "1c86dd6ea961ce01f99632177807438a19a0085e2528011bc3e1afa676bc95c1"
+    },
+    "1958": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1958/download",
+      "sha256": "8c08fd8478e76d8695be142c690c69bb3e07449a553e5e3388b059c7ed4d7c23"
+    },
+    "1963": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1963/download",
+      "sha256": "4b27bee12a0612679d5389f9490a8943f4539d0d4bdde3a1f4d0f2bc91381cc8"
+    },
+    "1959": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1959/download",
+      "sha256": "d472ee9ff9a03585418bb2cfaebbb4eea4ee727cb6331b79b0f68709ab6352d1"
+    },
+    "1962": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1962/download",
+      "sha256": "3f1ab6923a42a57a7ab0e549910c2d36d55bb01d7ae7ddc9dbe4118e02cf62e3"
+    },
+    "1965": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1965/download",
+      "sha256": "7be4317c828c3eda25819d3fcca5beacd5f094ec4bdfeafb80c7bc44bf18670f"
+    },
+    "1964": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1964/download",
+      "sha256": "0fb26356333189da98b1404262c21f5608bafddd0572e1de7352d464d8386464"
+    },
+    "1966": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1966/download",
+      "sha256": "8691feef547813a9432efe44227937671d4a520beb9a12aa43a2d11549171d7d"
+    },
+    "1961": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1961/download",
+      "sha256": "47005a4b806047fe9a62494a518c04967f794fddcadd925f8496ab3f43597870"
+    },
+    "1957": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1957/download",
+      "sha256": "8f5ac38c0ca98a67ee340b8d88e3307842b33bb96439f6573a96b433d5a8dff5"
+    },
+    "1967": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1967/download",
+      "sha256": "d5c17b67cc81d4be91a80394d86b21e9749dafb9b64e0648cea9c59154f0f4ad"
+    },
+    "1969": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1969/download",
+      "sha256": "332250bbfbccb0111ba170a4f75f640db13de05a8e230661d680fe7a84bfbb26"
+    },
+    "1970": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1970/download",
+      "sha256": "5394162c084a74cc1deded745a869d385a568d683d73a7de1597cd87819e26cb"
+    },
+    "1971": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1971/download",
+      "sha256": "465032f6dbfe3824a353c78ff6db146537571162547221ef17c71a4884865609"
+    },
+    "1973": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1973/download",
+      "sha256": "c78af2fdf066973adb8473be2f70c98ffa4edb716aeec7367cadbe87dd2f6b07"
+    },
+    "1977": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1977/download",
+      "sha256": "e4748fde1845c12d3ced3441f73dbbed88c8bd8d53a67e9f56d9d4497172cc63"
+    },
+    "1976": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1976/download",
+      "sha256": "7987bd44e40e1ad92eaf96f9f626e768a2427a3fe0f7ace914009b4cecdbbf53"
+    },
+    "1972": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1972/download",
+      "sha256": "c174d0b311e6591daa71bad669bd37395a48a7e7c7cf476b76aa49e686680ac3"
+    },
+    "1974": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1974/download",
+      "sha256": "d683663c7c0a588ff50ab4720bcc14759907f602734afd65acaf915af7715882"
+    },
+    "1975": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1975/download",
+      "sha256": "dec44365ce83228cff825d0558d22845114631124e36346d234f8e102cea5f85"
+    },
+    "1978": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1978/download",
+      "sha256": "9b1acc37ae350ee8ee9c5099329e9586f5ae7952027a7f87444017126dff7e39"
+    },
+    "1979": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1979/download",
+      "sha256": "453de3a6d05d910da38a60108e83ad82554cc5d12ddfe9e1a8392b785b6bdb0a"
+    },
+    "1982": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1982/download",
+      "sha256": "b9184c9d78af68dc17fb3050f75f34bcd93cf62a405f815dff90932c5d715da6"
+    },
+    "1981": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1981/download",
+      "sha256": "537a5ba025af94613dac70a55c99917707e74f214f518e714151c5439d1ea27c"
+    },
+    "1983": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1983/download",
+      "sha256": "c0f553b7c48102f2d90bc5cc08b91c967e55140b2d1f587c0ae501aa517fdfdf"
+    },
+    "1968": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1968/download",
+      "sha256": "cfe5fbb4e06d03bc6c45f48fc7c0f4436139c50cc9cf286734b8a6fff24be442"
+    },
+    "1980": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1980/download",
+      "sha256": "90129bf0d70a9866513ab31e8eb211ddea6071040ca75764fb1dc265f9508c04"
+    },
+    "1984": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.19.4/1984/download",
+      "sha256": "12768a9fe3e43b01ef14130ba35de48e4e7ab5e0af6e1cd1f8bbcf8e172222e6"
+    }
+  },
+  "1.20": {
+    "1990": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20/1990/download",
+      "sha256": "2cebd6f0729b29486cc0b6329de07f45a609f5660d3199bc06b98cf540e57f72"
+    },
+    "1987": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20/1987/download",
+      "sha256": "eae916e97f54e0270547736028501a753e5134ff852290791524f2d25f4dd3bb"
+    },
+    "1988": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20/1988/download",
+      "sha256": "1cdf7a226ed684bf198d23742d1c7e35eb9d9cd7438038fcd10f2d23e0c3bea0"
+    },
+    "1986": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20/1986/download",
+      "sha256": "9f617548408a4ff78deba67d4cea49a0ea579cc70947fe4a06556ef3422fc564"
+    }
+  },
+  "1.20.1": {
+    "2062": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2062/download",
+      "sha256": "238e64b33e5c7c9b87506cf1a23f239e6ce7fb71edd9d31837f229c94f4dfa1a"
+    },
+    "1992": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/1992/download",
+      "sha256": "61d7446b9e508c1e7b94140054002a7517b593b1fea6995815c5c51aec915c92"
+    },
+    "1991": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/1991/download",
+      "sha256": "70148f4f08134b61f7ed383b84ba8eeaa7ea6661d89b48cb725d59f76fcf110b"
+    },
+    "1993": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/1993/download",
+      "sha256": "a3f56addcfe8d63eca272246beedfdd12c979e1c76f00d67f2be1dbe35529165"
+    },
+    "1997": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/1997/download",
+      "sha256": "0c2d551f361aa7e6e3f0b04433dd009dd09de6afe10fa1943465949c9ed7267c"
+    },
+    "1996": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/1996/download",
+      "sha256": "c3d6017de97c9e2500da9d72294f01a0959ff41b2cc30ae3354eb5ffc29dcffc"
+    },
+    "1995": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/1995/download",
+      "sha256": "a1ee46cc177e3e91e168826a2eb2eff360e2f8ed909ba47888ac47ea97cf3479"
+    },
+    "1994": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/1994/download",
+      "sha256": "efcb35782074d6185b4955f6ca818951672c0c22703694ac71f4ed01c61cb3dc"
+    },
+    "1998": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/1998/download",
+      "sha256": "e36d46aba465ce123112d6ae973ef80eff609cec93351aa648c42c85cafe3b20"
+    },
+    "2000": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2000/download",
+      "sha256": "654f5af98d55c3858d28085ce2582e88ef510fbd943e7763f18e25f61875b781"
+    },
+    "1999": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/1999/download",
+      "sha256": "e6a27c67fcc9e7fe185773b49034fa7018b8555fe73deaeff2aa2e9f47c8a0e6"
+    },
+    "2001": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2001/download",
+      "sha256": "9a267884e5b0335f84ff4b02aacf24474e977369d7e65f0c697e1c714ad21e03"
+    },
+    "2002": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2002/download",
+      "sha256": "5579c1cadc73759bd835c6bf8bcef8d69b0239c4fe0e2a517f030194df202505"
+    },
+    "2006": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2006/download",
+      "sha256": "b127a1e8ef778fcb7a128ce685ff59ddfdbf6b19b9ddc805c5db8a47d2e915f6"
+    },
+    "2003": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2003/download",
+      "sha256": "acd71b69b3ad72ec38ebece62196e8225b4efe7940314de04ce0989327fadc1d"
+    },
+    "2005": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2005/download",
+      "sha256": "396913a150f6aa4bb4698ec76c878c6b13587cd59db5d40628a639d03eb28958"
+    },
+    "2004": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2004/download",
+      "sha256": "6fe9937976daf47cae6c37927cce77b5ac4def997b324f6631fc0dffd30b7196"
+    },
+    "2008": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2008/download",
+      "sha256": "f1dd5640b068099d754f4e8e405a36500c8cad12904bac6da7bb2d2781bef873"
+    },
+    "2009": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2009/download",
+      "sha256": "24d19053e99b54cccfa6b14e07fb553fb4d7d8111dd0c660f00cf69c94def4d9"
+    },
+    "2010": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2010/download",
+      "sha256": "a63e7f379b5e2cf70989439bac689ad441a94f80b1313403205f6e550b90ef3c"
+    },
+    "2013": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2013/download",
+      "sha256": "0c7f2cd05bdb2dfd4cd841375df2ab0ba7c86aeef36bf5f05b859f346bf92cb6"
+    },
+    "2015": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2015/download",
+      "sha256": "021ab6068fc26ef2207b3a37255970c12e84996f38274327ae6599847f8ac421"
+    },
+    "2017": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2017/download",
+      "sha256": "0a064d832c4a1e774e330a195a67f8322d43f44f87ba398cf9bc6efbec3adc83"
+    },
+    "2014": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2014/download",
+      "sha256": "ad8a3b66521a5016cb830df7fbebcae91545771303b459b4ae38807e25d6e16e"
+    },
+    "2016": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2016/download",
+      "sha256": "a9d4d28b95221d13a45c175c066124c8148a0719665c17ab8f9b6ea48f2e8976"
+    },
+    "2011": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2011/download",
+      "sha256": "17a641864d50d58bf6a7e2f78dcce7e5577386920e77bd1b3015517861b221a3"
+    },
+    "2019": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2019/download",
+      "sha256": "3a3cb3bc7a4a3fbb576e345b9d6ffed428e934dfa589aab07b0e0ed5844895a7"
+    },
+    "2022": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2022/download",
+      "sha256": "992b9e55b7d9f30aaf37c337643b8e9470f46cee1da6a95ed8f791c9d686a687"
+    },
+    "2020": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2020/download",
+      "sha256": "80590e402e8f13b64975f0398a0836f37f8f4e61670bddb0d31cc95b31d51e71"
+    },
+    "2025": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2025/download",
+      "sha256": "02c6b8a98e07e3642932df79e2dbb8379a31c1d254cf69dc2fc504cda76180f7"
+    },
+    "2024": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2024/download",
+      "sha256": "ec5b679c7f1f114d23b01a195b156a5a36406733499f21c16a4e87704b08653c"
+    },
+    "2018": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2018/download",
+      "sha256": "adc19ba78153c5ca08165320e2fa398c66972067f409e26ff8cbdab329456eb9"
+    },
+    "2026": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2026/download",
+      "sha256": "fefc23fd32b5d9721a42a5468ae449f646ff2a694ea85bb5e29a4647c9acf690"
+    },
+    "2027": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2027/download",
+      "sha256": "9d84d653c650d3ba13f3d5a8a93ebc0efa5d13753e58baf90ba8828829e5d2de"
+    },
+    "2029": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2029/download",
+      "sha256": "9907de26fe053392d34796da8e2990be3c1bd0545d83982dd674aeedc74db3c5"
+    },
+    "2030": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2030/download",
+      "sha256": "be4a38e18f0cc70de76fd222868af678b9273263eba2b81db7ea0850403c5986"
+    },
+    "2028": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2028/download",
+      "sha256": "406ccb2e12c79d9e08b8188f4092cda24a4bc95a35e2630cf325b94aabff5027"
+    },
+    "2031": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2031/download",
+      "sha256": "7fb1610944a7e7e701d0e39cff7482ba14f9523b348622fe94916293c8c9618e"
+    },
+    "2034": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2034/download",
+      "sha256": "481ad54c7849b8cd9bdcef84b20a4f47b3db4591ba497d5b79971c3169dc5593"
+    },
+    "2033": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2033/download",
+      "sha256": "b1710d950f111de92e061aa8ae6cb05029b977d638e18283bbe2fff1b6c9b2b6"
+    },
+    "2036": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2036/download",
+      "sha256": "984b0ee3011729b26fe63191853d1b43692bac03ff492e86c26299ea27f20dd2"
+    },
+    "2038": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2038/download",
+      "sha256": "f313957be9103cbf5dbf4a0017ba388dd733def025acd51d1c80ee6af3758c0a"
+    },
+    "2021": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2021/download",
+      "sha256": "46fa7cd734c2f56c40a20d949acebf5f2f4f0959585f85043702b47b86aadf8d"
+    },
+    "2035": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2035/download",
+      "sha256": "0bf0bb625565e3f32f351b4f58b529728dbd3b6b9a4b6f3f7a45f3b2ffb0d1d7"
+    },
+    "2039": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2039/download",
+      "sha256": "8dc92d184b09fb2be38c82f029a55ea40dac771b33bf8483aea433aec40e74c5"
+    },
+    "2012": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2012/download",
+      "sha256": "74879e3929563228ad4f6894102203e288ed66fa9b8c5b37d9e05f7eb4d3964b"
+    },
+    "2040": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2040/download",
+      "sha256": "a62d87ede5d8bf8b9bdd72829ecdd39fc4ce07f188cc844fea1ccac6f4871625"
+    },
+    "2041": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2041/download",
+      "sha256": "e8d0ce4f7eeabf888dbb35d923515bf76fcf0e9ebe8b27b157874b3036ccdbe3"
+    },
+    "2032": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2032/download",
+      "sha256": "e0ab05cf9b2f3e983483c2f09e8feddb09eab6a21bebea10795bb04adc86e8ae"
+    },
+    "2042": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2042/download",
+      "sha256": "ac1388bffa2ae98a2818aeb2a63c10960933756d97020ec8cfc4d2c515e22da8"
+    },
+    "2043": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2043/download",
+      "sha256": "b9a33facade78acc2a223df3158aa8ebbb9d4710ad09c72da9e99a5b915b513d"
+    },
+    "2045": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2045/download",
+      "sha256": "39cd6b3f9b0586ca39bb2db3cdd787e3a8758275613457744b1f6857a45e2545"
+    },
+    "2046": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2046/download",
+      "sha256": "93ca662d664e86b6fcbc84de39a7a2307d1c320c4f3beb032285202f20dff6d9"
+    },
+    "2044": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2044/download",
+      "sha256": "50bdb33e984caa40c7cb2c8a790b825ab69901884a56fc13b795212590bcb75c"
+    },
+    "2050": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2050/download",
+      "sha256": "5b122669956c2edf768bbdfebaf4bf85129ddd8a2e7119b38eb4dd2c5e303ad9"
+    },
+    "2047": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2047/download",
+      "sha256": "24448c750dec4b67ff2dbb73544ab73a2c70e307dc552d9ff411425adca9737b"
+    },
+    "2049": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2049/download",
+      "sha256": "d4b197b35e1e2b9651547313e68df361baf576067565b3d90d6bc749cf18a6a9"
+    },
+    "2048": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2048/download",
+      "sha256": "5ba722133e0aaf3db4a0ce89916c32799fe8acb307707d9fe39e3a57cd9a5d63"
+    },
+    "2052": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2052/download",
+      "sha256": "535296ae713d921e416d1ef33a7f490e1b815dc0adb87ed46ab083b3ed704d87"
+    },
+    "2051": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2051/download",
+      "sha256": "68f4bd1e7abd13b5cebb3614e74cf8e532e34eb386d2cbbe3d253a537e695234"
+    },
+    "2053": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2053/download",
+      "sha256": "907dc45d97e7ee7ca6ae03b80864b74febad4392aa625e39ac9e4d5a40d3eb1e"
+    },
+    "2055": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2055/download",
+      "sha256": "546d1e491e4d146365f4b10ced6dfc8e8ef205706b6d03583e2c6242239d1a57"
+    },
+    "2060": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2060/download",
+      "sha256": "2c18ba97b543a24da9d0bfc84a6dde52a442d467fbde6af283951e3e13dacdae"
+    },
+    "2058": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2058/download",
+      "sha256": "799852a89a66613dff8f42df30a587bbdad6cb6d43d8c92aa4f02660f540d8fb"
+    },
+    "2057": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2057/download",
+      "sha256": "de2b9a190ab4e4cdac7ef0c711861a3e256a267fb518d6749ab88dc2af088e24"
+    },
+    "2054": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2054/download",
+      "sha256": "cb3008b57acc0c943e4da446650ee4464c783c69340531addebc531ac5bf1bab"
+    },
+    "2056": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2056/download",
+      "sha256": "782b93732a9555456dabcfa8186b3751fffb2206d07ba276538ee611d591dbbf"
+    },
+    "2023": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.1/2023/download",
+      "sha256": "15ae46210d9ae01b21a83c3b038e25b372c3891b243ed0b4f89e657396b29c28"
+    }
+  },
+  "1.20.2": {
+    "2095": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2095/download",
+      "sha256": "395e92bda4a61e5677210da6ec8a86e0ef4d76ae255d1b09d995aa068fb6bd94"
+    },
+    "2064": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2064/download",
+      "sha256": "6c54b1d2f005997a5711a33dc1becd91a682a6afe09505113048dab98a7b8a40"
+    },
+    "2065": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2065/download",
+      "sha256": "91c3a589612baace4cbf1755d21e5b7d66fb36fd8a560dee0e4c1656c7b7be3e"
+    },
+    "2072": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2072/download",
+      "sha256": "971830e63b2472ee68a35efcf3f20a9771f9b9d5e08ff424c559009e069bdecd"
+    },
+    "2067": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2067/download",
+      "sha256": "6342730d590cb44d814053fae54644da10c0270410a297a52133a5cc343a1b01"
+    },
+    "2068": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2068/download",
+      "sha256": "805371037458f57f9563a294f271913ece985ec1a076a69557f2362e9954f9be"
+    },
+    "2073": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2073/download",
+      "sha256": "1557e2c9c3516cedf69ef2bebed95800cb15fd24fa3c8f12997451369a107e4b"
+    },
+    "2076": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2076/download",
+      "sha256": "2703b1b3469d10da80a872fed5041f8d61c1ab4e8f2a124234c47dcccf840baf"
+    },
+    "2074": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2074/download",
+      "sha256": "dfe98d574609b9f33dd455f24cf7060843e595abd9577099e68ae1ae11d8aa30"
+    },
+    "2077": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2077/download",
+      "sha256": "22f85d61c4fef29b73a4029983e15d28ebcf3446105ffc4ad121cff94c3a170d"
+    },
+    "2078": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2078/download",
+      "sha256": "b1e6f14c535c6ec61e916c9f3ce67c1d3b8e7fcdf9bba34bd7c37f61aa40b0a2"
+    },
+    "2079": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2079/download",
+      "sha256": "fae2ac7c2aeafc066740af065431a76c9cd4e815a4a75af770d45576de902b48"
+    },
+    "2083": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2083/download",
+      "sha256": "920fef55ed5d534b1407437b97a5ecbc14c25c5df93584934def00d720db64eb"
+    },
+    "2081": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2081/download",
+      "sha256": "322d8a6afb82bc32570cb214f82fc23e77d20c1b60790c93e1ae8a38fa33a031"
+    },
+    "2082": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2082/download",
+      "sha256": "f841c25dfcabc7417e83ed3a01f253d27dd40591ccc31b8bab35a8b55d107b56"
+    },
+    "2086": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2086/download",
+      "sha256": "7e59c6c1899766d461337346c1c74ca5a4d3a3283f738754b6ca8549140a960a"
+    },
+    "2080": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2080/download",
+      "sha256": "ddb8b1b4608c45022fed41b98c265a5b4a6f653e3add19c83004d7557a9aa03a"
+    },
+    "2084": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2084/download",
+      "sha256": "1b32923a1db617b73ac764839be6f2de00c0ea1853ce7d381eaf05960a97efb2"
+    },
+    "2090": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2090/download",
+      "sha256": "6984b0c25957122223c679c08858d9911950516c115412c8cf18eda5cac00df7"
+    },
+    "2087": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2087/download",
+      "sha256": "db324b42db8981b9543bf34f8bbb69428f2bb10271a85290293d00e4e3b125d6"
+    },
+    "2088": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2088/download",
+      "sha256": "3cd70ed2e10fb21e85633b7f4fb147ba570a1f8e47cfd319c9316ff2d4572ed3"
+    },
+    "2089": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2089/download",
+      "sha256": "6f55a3393a432f29f4031901621bdfb32dab19b62c83ab376a53ad2d9797d26b"
+    },
+    "2092": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2092/download",
+      "sha256": "716cdb335e07d40d7358d59ea86844a96455d23cdd89f0fb8a53d4b6b8dccdd2"
+    },
+    "2091": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2091/download",
+      "sha256": "a30803a5e3c9631f35f9d65083a0bfb32dd458529ffce42546861e916d885314"
+    },
+    "2094": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.2/2094/download",
+      "sha256": "e0eb31e94b23ca395854440f7f481bdd286bbb476bd7d94478ddd4141ac551e2"
+    }
+  },
+  "1.20.4": {
+    "2176": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2176/download",
+      "sha256": "c8593c0b2760f6ea5bea5a633dfa91eb79005e81453ffd0383ab626f087b5441"
+    },
+    "2098": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2098/download",
+      "sha256": "f6f2a09767bf753ad324d3116621f66cd0170ea38fc487d35ba82956d324a8ea"
+    },
+    "2100": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2100/download",
+      "sha256": "fe28d3d0935429a9599f8d561221a8b5c6c967610ece89842d9f4f21b9e91065"
+    },
+    "2101": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2101/download",
+      "sha256": "2e326fe3fff294717d57f69c4402d8ce8fbe225bc5f33dc6000dc8f1a6956663"
+    },
+    "2097": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2097/download",
+      "sha256": "d751f7326cb1c5f09232fa1892213f166f3992c193e9a7108c0037dc0541368e"
+    },
+    "2105": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2105/download",
+      "sha256": "7ae7f7352886b69d3543c62131f8bc27ecc811e8a4c16d2db34b18b50ca0fc15"
+    },
+    "2107": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2107/download",
+      "sha256": "533a3bef8cfbc811e1f90ab23e5e27e4d08951c603c526d090562086fb00c981"
+    },
+    "2106": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2106/download",
+      "sha256": "f981c35503e330cd41f2c770277a509ea0463fc9e704994ce803b11002630d1c"
+    },
+    "2103": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2103/download",
+      "sha256": "d932e368210a42661866b73eb430385ea935d4a35b3afafd7fe77d73403a3b8b"
+    },
+    "2102": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2102/download",
+      "sha256": "be3355e9a5a2e1a5d52a5835cb2172a1ca811e0c40dbdbd030116cf3ec76ac18"
+    },
+    "2104": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2104/download",
+      "sha256": "72cfb29e5a0c76d9636581d7bcb7a77d78db6f64c3ef09bb3c7e4bea93406184"
+    },
+    "2099": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2099/download",
+      "sha256": "85c39245c88c77bcb31b934be3322aa080ae910135c089ab7bfaaea6b1610fa3"
+    },
+    "2108": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2108/download",
+      "sha256": "85791fab972509f7a70f687f71f9ffca02e8da5d17db7f9601232044c83fa364"
+    },
+    "2109": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2109/download",
+      "sha256": "cc977222696b0e14ce5f3455176b73bd89d598ba3955868ac358ef11db8acc4d"
+    },
+    "2110": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2110/download",
+      "sha256": "f235be6c03edd79f9e43f4ec7dac07851f209aedf9be2b68f2a73a9fd90e20da"
+    },
+    "2112": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2112/download",
+      "sha256": "dad00bec644bc4e58cbe804fda6a01afa86cfc7f809d1502203bed7d5362a3e7"
+    },
+    "2118": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2118/download",
+      "sha256": "94ba9adb1baa042cdb80b3bf273209a087ff0fb084005be1d63f87520b922156"
+    },
+    "2114": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2114/download",
+      "sha256": "3a08c60d3adc2b19add2adad3ffb2b9efbeb32203558b982dad657325e8b8a5e"
+    },
+    "2113": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2113/download",
+      "sha256": "16be20ba6004de83c2db59156a12aa1554270c1ec3230e9f06207edc947b3883"
+    },
+    "2117": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2117/download",
+      "sha256": "8dc141254a56d14a7486fb8632ddc78470e46351b9cb7624d425b9e47ac28ece"
+    },
+    "2120": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2120/download",
+      "sha256": "25e6f814afd75205917ade8c0b85e9c25c5ef850542cd1896eed155897f1fe8b"
+    },
+    "2119": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2119/download",
+      "sha256": "d7495049dd37a37b9c784b6f37535c876613501a35946bd2d4d4799e72e73de7"
+    },
+    "2124": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2124/download",
+      "sha256": "ac6eb963bbe3c84f7679f3a22b6df5463ef46944a994b8af502b8d90be3ed5f0"
+    },
+    "2111": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2111/download",
+      "sha256": "edfcc7a9f7dc9b41c8c965868c437c6c2270c7debb593cbec8f18a96a03ed109"
+    },
+    "2123": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2123/download",
+      "sha256": "bfdade209d6fb876c5ed3d62afcac7b1f5cf267d616c5ca4f118cc0652f8b3e0"
+    },
+    "2125": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2125/download",
+      "sha256": "697c82a670825b10570267f39a61b3ff7f32e1f1870d9df2437d40c450bd468b"
+    },
+    "2122": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2122/download",
+      "sha256": "d22fddfc9d9f6e54e080ba2e7ccc9adf5cff707a1ef8d4ed4f54db4020de0168"
+    },
+    "2130": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2130/download",
+      "sha256": "b1f3eeac53355d9ba5cf19e36abe8b2a30278c0e60942f3d07ac9ac9e4564951"
+    },
+    "2128": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2128/download",
+      "sha256": "55d925d90a32da907a262453064698b8e209eb6de6d9e225b476d1413a92d267"
+    },
+    "2121": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2121/download",
+      "sha256": "14e924ea7c2d2a456b59d1d9029a30269ecedfd4d631a7fe79d481ee294d1c30"
+    },
+    "2127": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2127/download",
+      "sha256": "7f259d5d5f1a24b52e67cb6fc30287baae90899c9591b722ca060a659122387e"
+    },
+    "2132": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2132/download",
+      "sha256": "0bf8a25a71324719b0d9428940b98d1bf14d7532ea78417ecc2218d0db726d6d"
+    },
+    "2131": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2131/download",
+      "sha256": "2c062837f65b9567e66d54f824053624bfc06e34fe769bc6048a04d1d5dc6062"
+    },
+    "2133": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2133/download",
+      "sha256": "40387e7b7978cac015cbac15f5b148d86b97fcd8a29d692d8e6dd2c0b722b247"
+    },
+    "2126": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2126/download",
+      "sha256": "32ec3811f9372ab717f3b27467de8b02626bd910abab3b3e64727fac66d60ffc"
+    },
+    "2134": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2134/download",
+      "sha256": "f8aa41efa1cc1e9a225e9859f7a3dd8965baf24e7c8b3e8ccd651d666c74593d"
+    },
+    "2135": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2135/download",
+      "sha256": "e5b92d4dc516ba56d7b3693701f87fbc39c5c68af79ba8b610263b75e679fd00"
+    },
+    "2136": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2136/download",
+      "sha256": "5ca8f3a4c8a3e63a3458ba7a67472dde3aa4a941d3e8d3fc974501fe16065b8e"
+    },
+    "2137": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2137/download",
+      "sha256": "69b8a16804218297c25dfb0ac9af08ad2b46ece036bc13eb3904c66c1503e05c"
+    },
+    "2138": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2138/download",
+      "sha256": "c032b2285dbede0b8fe97dfca5f95574b2ae3ad78efb214a303278e6836ce12a"
+    },
+    "2141": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2141/download",
+      "sha256": "bf2c9c3ddf131559bd18396648042e0ffd42c8df336b40bad1894b989896e071"
+    },
+    "2140": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2140/download",
+      "sha256": "683523ea3b63691e43a76641c2c4338a1b30c911dff4da9ff62215cd41d7c716"
+    },
+    "2139": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2139/download",
+      "sha256": "82b15fc414363072920955250349b5116305e58b8af9ec099e0c1f0d7eadaa5a"
+    },
+    "2143": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2143/download",
+      "sha256": "1a6ae2611e21b0821e896f8680ca8fd44a0ec5feba0e87899c011b26aeb424f4"
+    },
+    "2144": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2144/download",
+      "sha256": "935fb3148c133d26a4140d0579674c281a2a7c277a769e932b63a13fe66eb4c1"
+    },
+    "2146": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2146/download",
+      "sha256": "c914b54c7795a8c9a06ca0e8879fd1dfc3be7e6441a8f5b642ee3098be39b7e4"
+    },
+    "2142": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2142/download",
+      "sha256": "fef5220c498b7c833dda47aa1989ed2fb96e53d56a39d12af6638bb906361bf9"
+    },
+    "2149": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2149/download",
+      "sha256": "6d5b46a28131a00310630325405888dc58f2795662c2a76164aaac97868c6ef8"
+    },
+    "2147": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2147/download",
+      "sha256": "c5d23345436ad424678bfddb3e23612d0643019756cb64ac074365a3631399ed"
+    },
+    "2150": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2150/download",
+      "sha256": "c3e96051bbc391e7a45211bf93967f8a52b41408dc708089a16405a8d9bfc40c"
+    },
+    "2145": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2145/download",
+      "sha256": "e5b21e91841068de08187e21d27290b3a19ec80fbc2892ec1ee60beb3eb54322"
+    },
+    "2148": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2148/download",
+      "sha256": "8879e52618a103d1b6ff0febfd9ccbbe0e1b95c2caffdb08e4d7b25e17875a12"
+    },
+    "2153": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2153/download",
+      "sha256": "8f4cdcfa7750bf827fb71e3cf53f4423c4e492df2dde5fdd7289c45152e25050"
+    },
+    "2155": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2155/download",
+      "sha256": "6452b734170003792ad25b326d8098fdb4640e9bad6cc291ee5538347fdc5f88"
+    },
+    "2159": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2159/download",
+      "sha256": "f7727844d6abe611cd2a570030ded72474bb0cc02ccbea36f62e2756f5eeed3f"
+    },
+    "2158": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2158/download",
+      "sha256": "cc46000c16cf001f49477bb1a3beda8ba9c4cad0a6dcc7dc31a9f413535e0e92"
+    },
+    "2154": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2154/download",
+      "sha256": "b2148a078eea60ccbbcb2903a86a5d9a5e94f0d01e21cb66f563c01abc70776e"
+    },
+    "2162": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2162/download",
+      "sha256": "cdef554eae672f747315fb9977cee6c7577310865748638ae7a75c2c92999f67"
+    },
+    "2163": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2163/download",
+      "sha256": "7dfe9998cf3d99251b18f4cabd4ce949c2716228e3f700a83fdcbcf101f98959"
+    },
+    "2151": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2151/download",
+      "sha256": "53392b922b9c4c941a50b50a3a41a8972289ee34674ddd74bc6b9ba88e851bde"
+    },
+    "2166": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2166/download",
+      "sha256": "137f5825ae36b0fdf61a4351ca358f8344858fb6ca405d345c41c8c5c894ddcb"
+    },
+    "2165": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2165/download",
+      "sha256": "1c12d955432b038aa36740eaef51aba4e2c4fca7692e74a9dd7a067001143518"
+    },
+    "2157": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2157/download",
+      "sha256": "1c3659fcb384e5fd357e7ca846b6c4cd4ba917c7c6582a77bae1583d84cd209b"
+    },
+    "2169": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2169/download",
+      "sha256": "d20aecc1f696cabc0905971d55da0394da97264cafd759d4395deddf4d6e20dd"
+    },
+    "2171": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2171/download",
+      "sha256": "7eb095d37163a03a96a1b482221d28c21096233bcdb53ac6c9459a93e37d70ce"
+    },
+    "2152": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2152/download",
+      "sha256": "36cac59fd9365972e6e9f23ea56abf57b93f117da1d87742616b1aab4dcb271c"
+    },
+    "2172": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2172/download",
+      "sha256": "34d6d563697285777af850a7b0cc7294a301d0cca0657eb805e158bf06ea7a1c"
+    },
+    "2174": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2174/download",
+      "sha256": "d96b043d3332b8677a4be9d8f9984d812bd5cc90d831962d5d681bf773882d5a"
+    },
+    "2175": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2175/download",
+      "sha256": "a18af0aa7f859dcee2a2ef468f677c41052ce4abd941b77fa7a1cd4456b5c4d9"
+    },
+    "2160": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.4/2160/download",
+      "sha256": "38c029ee6f6fd0308fdb944c67dbd39828f17ed7f7095aeb2877c19fda1b7180"
+    }
+  },
+  "1.20.6": {
+    "2233": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2233/download",
+      "sha256": "7d5410a978360a46faa76a288b1eab353135d8db16e40329a154402ec1b12d91"
+    },
+    "2177": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2177/download",
+      "sha256": "94b672648861eab24232979b910227be81204a28f265ba8230d23daff99b00a0"
+    },
+    "2178": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2178/download",
+      "sha256": "b533070a76a55906f4dbf8003da53a8048c0b79edb3f507595fd39474476c991"
+    },
+    "2180": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2180/download",
+      "sha256": "39724a463f5cf392ef7aa3673816039e51c75cdd0c08f29a77d21d855369d2d9"
+    },
+    "2181": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2181/download",
+      "sha256": "4c3ccabc9af230d54290447b0c4bc36f63c43e1d8037c4c174260975bedfa7fa"
+    },
+    "2183": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2183/download",
+      "sha256": "6e29d8e0f0a625d43b4ab63d9bf36754cb2d349be79b7cb9fa054dc7e312e151"
+    },
+    "2179": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2179/download",
+      "sha256": "cce3fddf8d8832027dbab4c8957a1cef1f52fc76dbdb5cb1c76e4f21aa73a631"
+    },
+    "2188": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2188/download",
+      "sha256": "08bb7f6c8f580f86c372efe55c32540ac371ca15579b82505d7596d53694a998"
+    },
+    "2187": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2187/download",
+      "sha256": "55305877c34e5bdf39144ee7e221ba85cc34aeb1ca5b1b0d505da91b2007d699"
+    },
+    "2190": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2190/download",
+      "sha256": "3b14100a19a14a7ae90c4f7282e6ad3cd85cb45d1dc4ece89167d4bc02a99c52"
+    },
+    "2189": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2189/download",
+      "sha256": "f44d0133eb0c8a8d0f3d6fcb863ec0d4fd046010a852ba0efa0b6c30fc16c3b0"
+    },
+    "2191": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2191/download",
+      "sha256": "9160ed3d95b556c84f236fff9c002765b58320391610b7b7c09abb018e8b7c8a"
+    },
+    "2185": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2185/download",
+      "sha256": "2dcbfcfe1d87dbc326d4494e492851cd44652a605e4f0e755b7628d489e96ad3"
+    },
+    "2182": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2182/download",
+      "sha256": "a578971b159e4306078d71abd3dcd6e742aa468ef208d8466ed85ea9644bcb30"
+    },
+    "2193": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2193/download",
+      "sha256": "ad026552993cafd1f99964da3f4d152874b13423d654ac4c8832064dddef3182"
+    },
+    "2196": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2196/download",
+      "sha256": "ae31244a5b302e71e7bba3f0df05e5940263826b58fa7aee5b5aef80ec963e1b"
+    },
+    "2192": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2192/download",
+      "sha256": "fcc5fe07b04b7e3c643bf1a59426b2afea76533ae301d61f392df6a1623bb6e7"
+    },
+    "2195": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2195/download",
+      "sha256": "3536686a6cd9e65d64413578d78f2244423f44ba615f085e31ca0a1fa1277e12"
+    },
+    "2197": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2197/download",
+      "sha256": "f6f7e094cc982c5b65c4d04be62a962c117c97bd65b0b307c8774565ce77763c"
+    },
+    "2200": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2200/download",
+      "sha256": "d871d4e4fd80b3526a26b1d01a338aafdaaf041767f1af1bb2e2f6b65934a0fc"
+    },
+    "2201": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2201/download",
+      "sha256": "b2e34060423772529dc406d2d06500aef9ec820bcd4f7c942f5bbc02e570ef4f"
+    },
+    "2199": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2199/download",
+      "sha256": "ca284db318134a0b865a8d3bdf082bb8a5a6e41057c60dfc37f9af664a336f34"
+    },
+    "2186": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2186/download",
+      "sha256": "0f28c934181e4c4221a01f34567a69740a95fac397c16e007048b0fd04955d9a"
+    },
+    "2203": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2203/download",
+      "sha256": "89d72140deaa6d43b5179761f810657606f9c5adf7eec20ba72985cfd3c281e8"
+    },
+    "2204": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2204/download",
+      "sha256": "e43275ef284e218d37c2e0521ad07d555fd4b4cdfdf6834daec79c982cc86e3c"
+    },
+    "2206": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2206/download",
+      "sha256": "973050e2890cb52bedde34d58a5d8b093dad65cbba20a9203156993041466af5"
+    },
+    "2207": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2207/download",
+      "sha256": "56c4fd6dd6f0e222363297342407030d6f68954fdef3c567ae44489ad48454bd"
+    },
+    "2211": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2211/download",
+      "sha256": "769886b40f3cb790fcf81648c0e74324cbdc47b146f0df0502b92b020c9bc745"
+    },
+    "2209": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2209/download",
+      "sha256": "f75eefe24bf1a440e14b65b7608f2b6e5dc885c1530f60e02a081d42c660e20e"
+    },
+    "2202": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2202/download",
+      "sha256": "5ffb22e35971dfddbff68e728a3b601d9359ff942f1dcc7df5371db2faba7a54"
+    },
+    "2212": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2212/download",
+      "sha256": "75cc03867ba0c98004e350c8c7cebd322f0ba34052716257576a5ba40fe1b0d2"
+    },
+    "2213": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2213/download",
+      "sha256": "67b4cbf02d1a7d32165895a605255cdd6003b8af8fd29c9416df579536161ece"
+    },
+    "2208": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2208/download",
+      "sha256": "62a355f44aecdcf615d4c3e3614dc21ac4704a0a3ecfd9d3ec161797971c27b1"
+    },
+    "2215": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2215/download",
+      "sha256": "4972f4ba0f5dcd2276b5af2d47b040b8eb3b3aee4ff0ddd729d52483849aa2f8"
+    },
+    "2214": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2214/download",
+      "sha256": "79f49e3eba4a67c91e182aa8593515da71ce47abd99e9f174f16439ec97e671d"
+    },
+    "2218": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2218/download",
+      "sha256": "56da392fd77d6a00cccb660ce901458dfa27aa920307c76522006b5e323ea656"
+    },
+    "2217": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2217/download",
+      "sha256": "ff1f365aedce12519dae5efd873e9e904e272917be2fc5227d7ffa983f86205a"
+    },
+    "2221": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2221/download",
+      "sha256": "7f3bba3f41893f4ce0c9bb9439fac345b495f01f9ca52a842e78e5a312e61269"
+    },
+    "2220": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2220/download",
+      "sha256": "42c3b6e9207645d7cd80cf9b441e452cf960d5e6e388d5faedbae680342af3fd"
+    },
+    "2205": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2205/download",
+      "sha256": "830c4e55d6298c47ff6a8ad2a4a1040cc16d0c9418edcc31dc5dc71acdd3ed73"
+    },
+    "2224": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2224/download",
+      "sha256": "639bea1e948ce707f2bf33b9af1f19fb30e450687a63a6e47c8b373a5901185d"
+    },
+    "2219": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2219/download",
+      "sha256": "2b8c0d577ec74f249ce3e9b44ad84a5c86d3d18dd971e0e69573b0709055d05e"
+    },
+    "2227": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2227/download",
+      "sha256": "e45c834cbc8218038d7443ed64e31e49ebadef8627af55fc125a7e9878f0060a"
+    },
+    "2226": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2226/download",
+      "sha256": "7a9055de50fc52d4ab7e0309a0a1dd5c4728c29f6f8d577ed5b9ffd1318e9ead"
+    },
+    "2225": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2225/download",
+      "sha256": "23ee86af3af27528da8a624739edce095ec2895aa697ffa6a54c146664512110"
+    },
+    "2228": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2228/download",
+      "sha256": "92fa6d4d7f4899c69be8809695f3451befd42f849c5617649c129640973056fc"
+    },
+    "2229": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2229/download",
+      "sha256": "3c030dd5c6a6ce72266dbfac0d3114269d34eb974b78024415d9f8b551d7d784"
+    },
+    "2223": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2223/download",
+      "sha256": "cd57781b02386d35254397537f8ed905a60a93aee31c68c37b61b7e92a61c999"
+    },
+    "2232": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2232/download",
+      "sha256": "17660534390f4733b8d555882b762283e28007810a1abd2db3f423f2d7a209aa"
+    },
+    "2230": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.20.6/2230/download",
+      "sha256": "11e5cb7b4e297f741e7536370808182f0b5df957acc5ad265473f181f4950628"
+    }
+  },
+  "1.21": {
+    "2284": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2284/download",
+      "sha256": "12885008efdc4777eba85e4ec3e35f6b916ccbbb168a4453506b4596e028abcb"
+    },
+    "2235": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2235/download",
+      "sha256": "4fb33bdfacc817d36d67f7b5e36e6b9979c216a8c7d54f7c5d456f643068204b"
+    },
+    "2236": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2236/download",
+      "sha256": "600d3fa2da5778d4c63e263bc8a7109ab88c7f3794a125102e8d4c4ff6ea485b"
+    },
+    "2238": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2238/download",
+      "sha256": "4cdc17f326e728283ccf95066b0123b1aae3131c7a4cdfc6a51170cf77a4d889"
+    },
+    "2240": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2240/download",
+      "sha256": "83b1cdd04d71827196887e0d1865c54fb7d6079ee2f2688d4d9276f46603e144"
+    },
+    "2234": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2234/download",
+      "sha256": "653440bb774255fecab9b00f8fa3a2ab6675d04d027c7757668d55779e3bcc8e"
+    },
+    "2239": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2239/download",
+      "sha256": "da63b748c70884883d2c4407aad751c3c99fd7b13e2f59d2f3c161aaee6516ef"
+    },
+    "2241": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2241/download",
+      "sha256": "0092b68ad5851b55929555c08742ff0d380dc8a13418fce716b891a2bd8ae29e"
+    },
+    "2242": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2242/download",
+      "sha256": "6ecd5cb736382bf1896250f5b30ec57ab9151a405d82a07c909d5c3c5a8f2630"
+    },
+    "2244": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2244/download",
+      "sha256": "c034f3a8c3eb3be8d07394aec8f28f9ee63bd4e0d3b1edf00c7c50fddad57d07"
+    },
+    "2245": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2245/download",
+      "sha256": "7086b3d632867bf681316e04a379375e6f11439a407d888fa495636016697a10"
+    },
+    "2246": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2246/download",
+      "sha256": "535cd3714c10afa31afc7c139bfd49e968baa499c2fb4bed66d382f568a2e26e"
+    },
+    "2248": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2248/download",
+      "sha256": "ba4d9d4d9ee6221114305e62b06c62628a211330c7fdbcc50fac490125085063"
+    },
+    "2249": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2249/download",
+      "sha256": "e9115427f7896c5455402687cf8dc08c44b8ee9d3dc8bb0021814344609ab37c"
+    },
+    "2250": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2250/download",
+      "sha256": "e56c87c761e13352729615fc07b428f450e57b63f941450efba211f0b73865f6"
+    },
+    "2243": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2243/download",
+      "sha256": "f2bd1ae1b34635b851dc2bffcd23669bdad721556cd414a607469c9db19e3057"
+    },
+    "2247": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2247/download",
+      "sha256": "3f9edd6ed1165e3a2f4acbe46fb2561d9a77b6f6fa83a6e65f1a699d5a0a5d83"
+    },
+    "2252": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2252/download",
+      "sha256": "808e546164cf03d42956872f35fbada94640f7ff0113f5bd9a65f05cabee80cb"
+    },
+    "2253": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2253/download",
+      "sha256": "28b43b70de603798a5910ab70685ff3e88ced787e2aa4299c3e778351e923ba3"
+    },
+    "2251": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2251/download",
+      "sha256": "0820f39c16166d3bdae8c0cc5cad79d846c8f6af74d2929abfa2651f94a2f77f"
+    },
+    "2254": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2254/download",
+      "sha256": "830b4223049c01fc01421fb3d8db8218c8e3ce76d34cead36c35b673edc96fa2"
+    },
+    "2256": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2256/download",
+      "sha256": "44ab455adcfaa1208c5fb99b46c182e8b96742a565f1291e0ddc0f11ddeea340"
+    },
+    "2255": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2255/download",
+      "sha256": "fe2a9840f32cd06f55f9a7f57d1050817bcf77dcc5cd7a217ed6f4bead784ab6"
+    },
+    "2257": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2257/download",
+      "sha256": "d71ec76d992857ab7b0cfaad1461e69605c5df2102b5e2084a9667782fcc0da7"
+    },
+    "2259": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2259/download",
+      "sha256": "48ae93c3eedfe464dd8ce72e2dc9558692191b0c6510e0563c76e7c198213ac0"
+    },
+    "2260": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2260/download",
+      "sha256": "2a337bdf9ad96fe3062edd40da266b77296dfb5f974de0e7ff981b43e0125c27"
+    },
+    "2261": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2261/download",
+      "sha256": "b50bf1da95101780000ff7c0d8975c35714dcdc750135a197dde4954b8937fb1"
+    },
+    "2263": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2263/download",
+      "sha256": "e77fcd322533e7967f5e7c104afac9170c552a8e1d38717cb257773d6778fa4a"
+    },
+    "2258": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2258/download",
+      "sha256": "20386b7f05a254437f39bbf068a15cc852deb0c039e5da95fa8c1802bcb79c74"
+    },
+    "2266": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2266/download",
+      "sha256": "be75fba527352989d3c5a88ad8495cb9a60b649c3ed9110b36694a2b5003dd36"
+    },
+    "2268": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2268/download",
+      "sha256": "ff6b23fb588aaec90841f327177a26d754797e3b46b80d14c77bc74564712791"
+    },
+    "2269": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2269/download",
+      "sha256": "07012a3e3b7d6ac174c1d45aceddd1b73412c8f6c3727e07d6aa6934d71b6d59"
+    },
+    "2265": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2265/download",
+      "sha256": "0cadf9d4ff58ccf7b0536d2a265167d5f2e10d3319e4a85931b9582c27e6512a"
+    },
+    "2270": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2270/download",
+      "sha256": "535c0e90e9808356a4453180e23696f31d8a5fd71c7604217ce5312012129407"
+    },
+    "2264": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2264/download",
+      "sha256": "2f1aba7b0a1d7f1a93746b894818f12aa1c3c2d3ab64904a91b90fa55bcd82c2"
+    },
+    "2267": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2267/download",
+      "sha256": "265f0465099013157e0d5c27b1795712ff67f349f7996694171f792dff53d391"
+    },
+    "2262": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2262/download",
+      "sha256": "9a91a308fd381de6855d7a1a0a5a0395b8a2b322eb7f95fb070917a06e50c5a9"
+    },
+    "2271": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2271/download",
+      "sha256": "018dd4bcaa5e88246d77f306ee72aeaf08af7554cbd3fce41e349595003bc783"
+    },
+    "2274": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2274/download",
+      "sha256": "21bc69f596b16dde19558f90bb82743a4e24d87a0076488c028830736dfde145"
+    },
+    "2272": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2272/download",
+      "sha256": "0b32c3e5bd8c15837ccdcb3a78fc1b649ffdafcc186aa0d33e009c69918a5eda"
+    },
+    "2273": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2273/download",
+      "sha256": "ba2bb29714c9c31857e865cab5f96b0f5d6b586f421abf297c73f07031a24696"
+    },
+    "2275": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2275/download",
+      "sha256": "938d114ab9b6b1c2e8c0d90875c27d44a11884e1682b210956f0dc73c991aa50"
+    },
+    "2280": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2280/download",
+      "sha256": "db20859eedb4b414a7c1bad10537e6153bf0e1a3353727ae47a7439a8be58dec"
+    },
+    "2279": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2279/download",
+      "sha256": "f826b12d6887800e24c4af0242c4b5da6d39e28fad0648dbc99c9bbbfe7594ff"
+    },
+    "2276": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2276/download",
+      "sha256": "5e5290a24c2c31d1737c52d1e12bdfc2c03c73b36080cfddedf2d8eb80a87161"
+    },
+    "2277": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2277/download",
+      "sha256": "b6f489e7c51dc39bc782bb4cee49fd9076f55aac3da150f9ff15818d6e796a6e"
+    },
+    "2281": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2281/download",
+      "sha256": "f5b08c19bd2a3302e787dc97d0375e4d8760cffc4bf48b1ecf98853b3aa4f78f"
+    },
+    "2283": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2283/download",
+      "sha256": "878dab0d25928ac8f56c2fa3242a0badab21cf164d43e1524a8212d0fcf10061"
+    },
+    "2278": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2278/download",
+      "sha256": "339f492b0393461b74434d248d104f004e93d109174c0057deca6736ab18768d"
+    },
+    "2282": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21/2282/download",
+      "sha256": "07d15ff4ab5e2ba2352407b5d3f3937e4f1bacca80da6f3710c06371a45b6ec6"
+    }
+  },
+  "1.21.1": {
+    "2329": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2329/download",
+      "sha256": "30403cf54f981f16e1403f172645e82d3e4a59ad6c9f1d8e98df99edb1f8ae4c"
+    },
+    "2285": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2285/download",
+      "sha256": "3e9f7422d818829dc68e5a2323b50db9f82fa46e6cc060948b5139d78c0dc748"
+    },
+    "2286": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2286/download",
+      "sha256": "fbc2331a7fcb70e5cb9d2b218b964d96311d4f4f601378dc8e82039f9fd04aae"
+    },
+    "2288": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2288/download",
+      "sha256": "4e0030d1c0588c8425a5f94ec5970d7608988e471c8a881dc454f0af4bc76a36"
+    },
+    "2290": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2290/download",
+      "sha256": "728fb05a7a3473a08d8aa8b7977baf0018a11ebe0776eaee89fe116f271027c7"
+    },
+    "2291": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2291/download",
+      "sha256": "3947f70ac977a1398691626a6e0590f4d8ebe4bd050a7828497c63a5fd258eb8"
+    },
+    "2292": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2292/download",
+      "sha256": "783f5ace5ebd1d59a984c1b49ff1c40ab8bee1b780f0b26122547f0cc95467cf"
+    },
+    "2293": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2293/download",
+      "sha256": "3ce64a3d6600f8d10a644a22318199eba49665d625d90b44faad55c725fdb407"
+    },
+    "2287": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2287/download",
+      "sha256": "4e0c9a750ad4566119bf6b71d36bac3ad41245b499410b2ac346e2d5c73c310c"
+    },
+    "2294": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2294/download",
+      "sha256": "9f67b4540ae360eba1caf3f9476145fb6151c94350b911e9a5eaeb70f381c118"
+    },
+    "2289": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2289/download",
+      "sha256": "4fef137e0de9561b772582a257b83588fb1d39f8c014d76e681344b3fd08c551"
+    },
+    "2295": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2295/download",
+      "sha256": "4a975a1095f01123d56647e802f1066498132393c1f96ec557324ae76e7b9b83"
+    },
+    "2297": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2297/download",
+      "sha256": "92e95ad96aff14f47d185420073f98c726a7461bfb8e597c5123b6be58a3d73d"
+    },
+    "2296": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2296/download",
+      "sha256": "d7714ce23bf31f29391f5bab10b18904b499fd91123a63ed9bbbf423007af6a2"
+    },
+    "2298": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2298/download",
+      "sha256": "c96a95c46be425a8ba62aad5074d11ca0b7ee7e8eaf3d4dbac92c7a690a9d95c"
+    },
+    "2299": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2299/download",
+      "sha256": "7f160e53336e153eb41b36ae027dd84c1d2f68bb9e3dfbd8a2e257d83a9c039a"
+    },
+    "2302": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2302/download",
+      "sha256": "55635bd8a1f672a7660974b7ed6dcce813aab3d735e73fa23cb4632723ab638e"
+    },
+    "2301": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2301/download",
+      "sha256": "a9d7112d097ae23b6dbfbefc2b502e628ae37161ad01f5a2356a54d1e3999f04"
+    },
+    "2304": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2304/download",
+      "sha256": "191dff601ab93bff4e9c48b757124333f995b7c26ea4d18aadfffb2f87c120cd"
+    },
+    "2305": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2305/download",
+      "sha256": "80cc222f53dcfa19fd526963495fc579e8fba18a65a0e62402bed2afcf27589b"
+    },
+    "2307": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2307/download",
+      "sha256": "2c4cf272dc13ef78bf3cc1a03f2d3b31a45cdfcea0fb564c24440179882b8def"
+    },
+    "2308": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2308/download",
+      "sha256": "5f514126e51a8c051beeadcc60e4be00929e37533082509853d12370be9ddec9"
+    },
+    "2303": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2303/download",
+      "sha256": "0051e115b518e7cdea8e9d964146d7ac05459527f8cae7c1ee18ed2ec3aa0b0d"
+    },
+    "2306": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2306/download",
+      "sha256": "14ab99ae0b2aa9ba287e8648e11e3e0efa5b0cd71c155d9d1348f15053c8f066"
+    },
+    "2300": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2300/download",
+      "sha256": "cc874ef29492c4940209b6f1e33a778b124622866d88ccc95c865b4149fc9868"
+    },
+    "2310": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2310/download",
+      "sha256": "56fb15c0e5fd0fe09379afabd921563a07feba78e8788ecbad6c8201daeb8479"
+    },
+    "2309": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2309/download",
+      "sha256": "810b2c136927529d73513aa4bff6a30d1635dc815bc311b0b772f9c4ee52d849"
+    },
+    "2318": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2318/download",
+      "sha256": "e11cdcf95456277c3f4743cdcfd0afe5a26982a1bc1ea7816b0c2ec5037d3c91"
+    },
+    "2314": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2314/download",
+      "sha256": "25dc3f710b678f55062378ac409ded23e9b45a29346f526c77d81e9b049b2b65"
+    },
+    "2316": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2316/download",
+      "sha256": "1412e77c7658ee95ff1225a054937be41273bea15a9a8f6789466dae84c526be"
+    },
+    "2313": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2313/download",
+      "sha256": "2e445ec78d9001ab91548ff93d4d1874381ee6dda674706306797b9fc35a882f"
+    },
+    "2321": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2321/download",
+      "sha256": "635c1ac3c22a16067b0b42814c5b2057e37d8231457f5d83a824003c35cecf71"
+    },
+    "2311": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2311/download",
+      "sha256": "a47050b503888adfe7f52135d71fe960e3d55df6c3d3d14910ec1185fcbc9454"
+    },
+    "2312": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2312/download",
+      "sha256": "337d6f5c0e372b38ff850f3fd88b0d123f8062279775a5ebbcbb3229c3cb6ade"
+    },
+    "2322": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2322/download",
+      "sha256": "b01578a66937e1c2829300207074e30abf5a668738b4f626da20ea5d1b15c2da"
+    },
+    "2326": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2326/download",
+      "sha256": "26ed148aca6120afcc6e64a16444316386526eccc59b9c17b7548eaa5e459266"
+    },
+    "2323": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2323/download",
+      "sha256": "f0a43798a92515a56839da50df707b078d0843e7202d0219985fdfe02b464442"
+    },
+    "2324": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2324/download",
+      "sha256": "d8329802f8736a52bdd3476929732eac84f2ea0800ede07d2e701924dc52a358"
+    },
+    "2319": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2319/download",
+      "sha256": "78cd002bbbfd774a890c81dfdf9578fb0f44ae1edec7bf29d0c01a1a59b2060e"
+    },
+    "2315": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2315/download",
+      "sha256": "583a3c18b255958fcb5e9f48cff0e83d60469c937e8c651423ac39c24129d295"
+    },
+    "2325": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2325/download",
+      "sha256": "bf619f17b0cb9859f607875a0a49e974565664445b549a339497d0b286cf142b"
+    },
+    "2328": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2328/download",
+      "sha256": "0c158528fdb59c0460f935c2f318d536b16a973ecbdabd68f94f64c718144234"
+    },
+    "2327": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.1/2327/download",
+      "sha256": "c4182d1b47531bda9c7ca3b3e8e04043c683a2686de85a37d1540504f3221df4"
+    }
+  },
+  "1.21.3": {
+    "2358": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2358/download",
+      "sha256": "445acfeead6380a533b45e75f0703a2668f5a976b9d65d477a0307d7032be56e"
+    },
+    "2330": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2330/download",
+      "sha256": "1e9df588cc9f3ff53b4b2228670ec9430dc5e3e414acf617dec8c4b7a9c536a4"
+    },
+    "2331": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2331/download",
+      "sha256": "cca24d1677c31b979177fe8a52006c7231ebb1b6580992c810f48a5e6f02ae23"
+    },
+    "2332": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2332/download",
+      "sha256": "b41e0553988781091108ebda4f71dba023e15973f591d6a9fa97c6f2003f9097"
+    },
+    "2334": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2334/download",
+      "sha256": "2b9de9dfce976fc149a707c78e1724949c87452fe22246ad65b4e209e8a1dbcd"
+    },
+    "2337": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2337/download",
+      "sha256": "b77be0670185a4316d6901312867dd0f650a4c32c63392d4608a3ccd2fc97424"
+    },
+    "2340": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2340/download",
+      "sha256": "05f41105fe589d501a176433293cc1087922e3ccfb953d5a332a77c8365f6fa5"
+    },
+    "2335": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2335/download",
+      "sha256": "6e82a954b50b3671a8517af49179e15796302201c1104af385eb55fd74adf948"
+    },
+    "2339": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2339/download",
+      "sha256": "cd1945b2712757930727897ad54f27fd70697701e02614a5d8acbb920e2402fd"
+    },
+    "2341": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2341/download",
+      "sha256": "754b2175b04ca257844f457160c1793cb1d779d87de19a0846891c4063ae2fae"
+    },
+    "2342": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2342/download",
+      "sha256": "d5338f3d3c0dd2c413d4939a09c40c82dfe99e56e5bdb16fa81e02662eedd5a0"
+    },
+    "2343": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2343/download",
+      "sha256": "94094cfd828d366451ba526e689d410dfdd861793c9c4b39c7e7bc09d5a6ff15"
+    },
+    "2344": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2344/download",
+      "sha256": "cda2c1a3e20e3f646fe130bc1f8efe02be885be2a0e51e2350bacfd267b7919d"
+    },
+    "2345": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2345/download",
+      "sha256": "b31995ad2f7d4c3eab050ced6941f00360046dde9fcee3b2b553e1e6587905b1"
+    },
+    "2336": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2336/download",
+      "sha256": "43abd0a7dda1035f3316f66471f6f4d6e3d30acf0254bd08f777b874fc2fb2d5"
+    },
+    "2348": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2348/download",
+      "sha256": "213d273d3ae692a4e53dd89053a5096697ee333fe33d91b500b7e0e1010459b8"
+    },
+    "2347": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2347/download",
+      "sha256": "d082ee78895fdf931fd2c3dadc61142eae32a1b449aa5f28549d25f264840ac8"
+    },
+    "2349": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2349/download",
+      "sha256": "b29506a1f87673ecd3ed54bea1bdbde5a103ca60e6c7fa01ce86b0efd304aad9"
+    },
+    "2350": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2350/download",
+      "sha256": "7da541e7e186746725357c778ada772fb90863967ea8d5430d466e9ccdf0d440"
+    },
+    "2351": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2351/download",
+      "sha256": "6f2b929bc1b307aa88f3319becaec945e3aa4e9f0c2817967debb8c896833ec7"
+    },
+    "2353": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2353/download",
+      "sha256": "033c1eabbb81af8486738d2369b318628cedd561ab71c41e3513e8875d1fdb64"
+    },
+    "2346": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2346/download",
+      "sha256": "71c95839da442ee775880d2f5d214c4114cefdac1ee8fbc59d4f77a6c1c12b91"
+    },
+    "2333": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2333/download",
+      "sha256": "89faa9a9ff85d102d91e5b01bc6bec044b7d5592ddff52e3dbc5ce98e9cd5438"
+    },
+    "2354": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2354/download",
+      "sha256": "16b03a347ebefc707b84f1d2e79ec11df437a34059cf602b444ac7c66f7dd130"
+    },
+    "2355": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2355/download",
+      "sha256": "4d11163be6b6e83e41515eb7f0d5fae4e9c0baab032d8b62feb4b51e85f0e42b"
+    },
+    "2356": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2356/download",
+      "sha256": "f29f7c56339608f0aecd60474bd78e429733ac5d8416f884b307b0af91f20725"
+    },
+    "2352": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2352/download",
+      "sha256": "a83993ef72670f6ea622b8a0806e600c169a572c9b9d534e16632ec1ce776144"
+    },
+    "2357": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.3/2357/download",
+      "sha256": "c62b404160bcdf73a115ed838784377586122136594811e6c860f28fbbdf0c88"
+    }
+  },
+  "1.21.4": {
+    "2393": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2393/download",
+      "sha256": "97668fdbe29e1320b6ddcfd46e223bc4dbc28d6461b8c40d17f3726086fb0318"
+    },
+    "2363": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2363/download",
+      "sha256": "17c2356decb915c9e4e307187fccca190c53b427e533857e0ab55e6331d823de"
+    },
+    "2369": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2369/download",
+      "sha256": "eeb7b95f96c1cd0b49f23bb0624fd892e9e70b1be16260ffffc344bba1c5f168"
+    },
+    "2365": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2365/download",
+      "sha256": "00b68e7d6530baf7ffa4dac17d19d557272b058fea1d11760f4e38a4e56e04e6"
+    },
+    "2371": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2371/download",
+      "sha256": "8a9b682e74a025e4837e12e755e1e7db49394e3a08609b50602c406073c08f50"
+    },
+    "2370": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2370/download",
+      "sha256": "fc0239eb2a2d6497fb31b796b79beb6caeb7e66e959e5151936b1ef34de18bf1"
+    },
+    "2362": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2362/download",
+      "sha256": "6ec9bc5498272932a6a36efb8dab112dfb17f47a68015db95d86c45d1c711494"
+    },
+    "2367": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2367/download",
+      "sha256": "cac67edc7b004699547af5bc0be86aeb17712252c01de44fe281d6af63bbcc53"
+    },
+    "2376": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2376/download",
+      "sha256": "86eb086359c52ee64937652e91593a5318aa25bf1a2089265b64019afe8f7608"
+    },
+    "2378": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2378/download",
+      "sha256": "f9dc6d04d2cec8c0315543fefee7c68cfafa69d4725b3d1fe55ac4f50bffb2f6"
+    },
+    "2379": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2379/download",
+      "sha256": "27b2ede40d1b5186834fa42c4d4ed0e0a07dcbd67348753bb2efa4e9849d8159"
+    },
+    "2380": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2380/download",
+      "sha256": "e3ed2e2de7ff2829f67f8b70e887b7809921923d1072b972933226978a588d56"
+    },
+    "2381": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2381/download",
+      "sha256": "72243a39db68130336877aa33fba92230065ea01e35dc43d89d7979a0ea56e43"
+    },
+    "2382": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2382/download",
+      "sha256": "70496c24f62daadf56406f84bdd97759bc06171d88aa6781c30bd7d4deb75c08"
+    },
+    "2377": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2377/download",
+      "sha256": "eb155eca43ee505ca55ece77b95612c60021061cf61850964e33ea10f24b2dec"
+    },
+    "2384": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2384/download",
+      "sha256": "13174a8e8a550f4c489c000b9cd97c775fa943a02ff408030b7139baf5d85712"
+    },
+    "2372": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2372/download",
+      "sha256": "425924f18f9c044f0874890f3e7ab89f3777432e291d68d9dbf2e86765d2d955"
+    },
+    "2385": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2385/download",
+      "sha256": "3692c51d560cbf27bfe1f68cc258bc4126f4e7ea25def61ffb5820a3e5a4438a"
+    },
+    "2375": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2375/download",
+      "sha256": "f3dbd118aa398c50eb7c941d24873e90b93b6af8c434b9be8d21eb3c32ddd0db"
+    },
+    "2386": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2386/download",
+      "sha256": "d96c2587a31088d73147e11c61e5f09f50358986bf35ee9fb1c8428b0439d5f1"
+    },
+    "2388": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2388/download",
+      "sha256": "7e7554817a5c57bd0668253d0f1ac58c55ee04a4a905ecb3afc84917cca1a78b"
+    },
+    "2387": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2387/download",
+      "sha256": "8c23e411932c5e7dce569f147b42b995ef44d865cef22c9ae107c08340d00408"
+    },
+    "2383": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2383/download",
+      "sha256": "5a0b1ee1e7932f30894f12ed60c604b1120c3b729d55a16d927104e78e1bb7ed"
+    },
+    "2389": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2389/download",
+      "sha256": "95a4f9635ab8e6e7021f45e5c3e6b2c7e86373065b566463ed2894285455b3b2"
+    },
+    "2390": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2390/download",
+      "sha256": "bccb95bdc4918588e436ecc13b8c532630e26c5a363b5357985b285c84878c6f"
+    },
+    "2391": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2391/download",
+      "sha256": "1b1a880792ad5a5020a279b31279680498c8b8d42f519d1bdee6b59e0c4f1dfc"
+    },
+    "2392": {
+      "url": "https://api.purpurmc.org/v2/purpur/1.21.4/2392/download",
+      "sha256": "d46f11981fc646d07a81ab698bec503b255afcef53c7e5fad6cbbab027decbca"
+    }
+  }
+}

--- a/pkgs/purpur-servers/update.py
+++ b/pkgs/purpur-servers/update.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python3 -p python3Packages.requests python3Packages.aiohttp
+
+
+import json
+import asyncio
+import hashlib
+from pathlib import Path
+import aiohttp
+
+# API Endpoint
+ENDPOINT = "https://api.purpurmc.org/v2/purpur"
+
+# Configuration
+TIMEOUT = 60 # Increased timeout for slow requests
+RETRIES = 1  # Number of retry attempts
+MAX_CONCURRENT_REQUESTS = 5 # Controls API load 
+
+async def fetch_json(session, url):
+    """Fetch JSON data from a URL with retries and timeout handling."""
+    for attempt in range(RETRIES):
+        try:
+            async with session.get(url, timeout=TIMEOUT) as response:
+                response.raise_for_status()
+                return await response.json()
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            print(f"⚠️ Attempt {attempt + 1}: Failed to fetch {url}: {e}")
+            await asyncio.sleep(2 ** attempt)  # Exponential backoff
+    print(f"❌ Giving up on {url}")
+    return None
+
+async def get_game_versions(session):
+    """Fetch all available game versions."""
+    print("📥 Fetching game versions...")
+    data = await fetch_json(session, ENDPOINT)
+    return data["versions"] if data else []
+
+async def get_builds(version, session):
+    """Fetch all builds for a given version."""
+    print(f"📥 Fetching builds for {version}...")
+    data = await fetch_json(session, f"{ENDPOINT}/{version}")
+    return data["builds"]["all"] if data else []
+
+async def get_build_info(version, build, session):
+    """Fetch detailed info about a specific build."""
+    print(f"📥 Fetching build info for {version} - Build {build}...")
+    return await fetch_json(session, f"{ENDPOINT}/{version}/{build}")
+
+async def get_build_sha256(build_url, session):
+    """Download a file and compute its SHA-256 hash asynchronously."""
+    print(f"🔍 Getting SHA-256 for {build_url}...")
+
+    for attempt in range(RETRIES):
+        try:
+            async with session.get(build_url, timeout=TIMEOUT) as response:
+                response.raise_for_status()
+                sha256 = hashlib.sha256()
+                async for chunk in response.content.iter_chunked(8192):
+                    sha256.update(chunk)
+                return sha256.hexdigest()
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            print(f"⚠️ Attempt {attempt + 1}: Failed to fetch {build_url}: {e}")
+            await asyncio.sleep(2 ** attempt)
+
+    print(f"❌ Giving up on {build_url}")
+    return None
+
+async def update_build(build_number, version, data, session, semaphore):
+    """Update the build hash if it's missing, ensuring controlled concurrency."""
+    async with semaphore:  # Limit concurrent API calls
+        if build_number in data.get(version, {}):
+            print(f"✅ Skipping build {build_number} (already exists)")
+            return
+
+        build_info = await get_build_info(version, build_number, session)
+        if not build_info or build_info.get("result") == "FAILURE":
+            print(f"❌ Skipping build {build_number} (invalid)")
+            return
+
+        build_url = f"{ENDPOINT}/{version}/{build_number}/download"
+        build_sha256 = await get_build_sha256(build_url, session)
+
+        if build_sha256:
+            data.setdefault(version, {})[build_number] = {
+                "url": build_url,
+                "sha256": build_sha256,
+            }
+
+async def main(lock_path):
+    """Main function to orchestrate fetching and updating builds."""
+    print("🔓 Loading lock file...")
+    lock_path = Path(lock_path)
+    data = json.loads(lock_path.read_text()) if lock_path.exists() else {}
+
+    print("🚀 Starting fetch process...")
+    semaphore = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)  # Limits concurrent requests
+
+    async with aiohttp.ClientSession() as session:
+        versions = await get_game_versions(session)
+        print(f"📌 Found {len(versions)} versions")
+
+        tasks = []
+        for version in versions:
+            builds = await get_builds(version, session)
+            for build_number in builds:
+                tasks.append(update_build(build_number, version, data, session, semaphore))
+
+        await asyncio.gather(*tasks)  # Process builds with concurrency control
+
+    lock_path.write_text(json.dumps(data, indent=2) + "\n")
+
+if __name__ == "__main__":
+    folder = Path(__file__).parent
+    lock_path = folder / "lock.json"
+    asyncio.run(main(lock_path))


### PR DESCRIPTION
resolves  #37

## Things Done
- [x] Updated all purpur builds lock file
- [x] Updated Readme   
- [x]  `nix fmt`
- [x]  `nix flake check` 
- [x] Tested `pkgs.purpurServers.purpur` in own config
## Test code
```nix
{ inputs, pkgs, ... }:
{
  imports = [ inputs.nix-minecraft.nixosModules.minecraft-servers ];
  nixpkgs.overlays = [ inputs.nix-minecraft.overlay ];

  services.minecraft-servers = {
    enable = true;
    eula = true;
    servers = {
      purpur = {
        enable = true;
        package = pkgs.purpurServers.purpur;
      };
    };
  };
}

```

## Notes
- Purpur api doesn't store sha256
- Package is modified version of paper package
- `nix fmt` formatted other unrelated files