### PR TITLE
Add lazymc (on-demand) functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,10 @@ Integrates [lazymc](https://github.com/timvisee/lazymc) to manage the server's l
 *   **`enable`**: `boolean`, default `false`
     Whether to enable lazymc for this server instance. When enabled, lazymc will take over starting and stopping the Minecraft server process.
 
+*   **`package`**: `package`, default `pkgs.lazymc`
+    The specific `lazymc` package to use for this server instance. Allows overriding the default `lazymc` from `pkgs`.
+    You might have to change lazymc version according to your minecraft server version, for example lazymc v0.2.10 supports Minecraft Java Edition 1.7.2+, while for Minecraft Java Edition 1.20.3+ you'll need lazymc v0.2.11
+
 *   **`config`**: `attribute set`, default `{}`
     Allows overriding settings in the `lazymc.toml` configuration file that this module generates for lazymc. The structure of this attribute set directly mirrors the TOML structure of lazymc's configuration.
 
@@ -519,10 +523,9 @@ Integrates [lazymc](https://github.com/timvisee/lazymc) to manage the server's l
     *   `server.directory`: Automatically set.
     *   `rcon.enabled`: Automatically enabled in `lazymc.toml` if `enable-rcon = true;` is set in `serverProperties`.
     *   `rcon.port`: In `lazymc.toml`, this will be set to the port the Minecraft server's RCON is actually listening on or `25575` by default
-    *   `config.version`: Automatically set to the version of the `pkgs.lazymc` package.
 
     **Important Considerations:**
-    *   **Firewall:** When `lazymc.enable = true`, the `openFirewall` option for this server instance will open the port specified in `lazymc.config.public.address` (or its default), not the internal Minecraft server port.
+    *   **Firewall:** When `lazymc.enable = true`, the  `openFirewall` option for this server instance will open the port specified in `lazymc.config.public.address` (or its default), not the internal Minecraft server port.
     *   **`max-tick-time`:** Setting `max-tick-time=-1` in `server.properties` might help if you're experiencing issues.
 
     **Example:**
@@ -532,7 +535,7 @@ Integrates [lazymc](https://github.com/timvisee/lazymc) to manage the server's l
       services.minecraft-servers.servers.myPaperServer = {
         enable = true;
         eula = true;
-        package = pkgs.paperServers.paper-1_20_4;
+        package = pkgs.paperServers.paper-1_18_2;
         jvmOpts = "-Xmx4G -Xms2G";
         serverProperties = {
           "server-port" = 25565;
@@ -543,6 +546,13 @@ Integrates [lazymc](https://github.com/timvisee/lazymc) to manage the server's l
 
         lazymc = {
           enable = true;
+          package = let
+          # you can use https://lazamar.co.uk/nix-versions/
+            pkgs-with-lazymc_0_2_10 = import (builtins.fetchTarball {
+                url = "https://github.com/NixOS/nixpkgs/archive/336eda0d07dc5e2be1f923990ad9fdb6bc8e28e3.tar.gz";
+                sha256 = "sha256:0v8vnmgw7cifsp5irib1wkc0bpxzqcarlv8mdybk6dck5m7p10lr";
+            }) { inherit (pkgs) system; };
+          in pkgs-with-lazymc_0_2_10.lazymc;
           config = {
             # see lazymc config here: https://github.com/timvisee/lazymc/blob/master/res/lazymc.toml
 

--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ generates a legacy `white-list.txt` that is needed for older minecraft versions 
 
 #### `servers.<name>.lazymc`
 
-Integrates [lazymc](https://github.com/timvisee/lazymc) to manage the server's lifecycle, putting it to sleep when idle and waking it upon player connection.
+Integrates [lazymc](https://github.com/timvisee/lazymc) to manage the server's lifecycle, putting it to sleep when idle and waking it upon player connection. Because server startup is now handeled by lazymc, there is no tmux anymore, you'll need `rcon` or to disable `lazymc` to make a player`op`.
 
 *   **`enable`**: `boolean`, default `false`
     Whether to enable lazymc for this server instance. When enabled, lazymc will take over starting and stopping the Minecraft server process.

--- a/README.md
+++ b/README.md
@@ -492,52 +492,65 @@ generates a legacy `white-list.txt` that is needed for older minecraft versions 
 
 #### `servers.<name>.lazymc`
 
-`nix-minecraft` supports integrating [lazymc](https://github.com/timvisee/lazymc) to automatically put your Minecraft server to sleep when idle and wake it up when players connect. `lazymc` is available in Nixpkgs as `pkgs.lazymc`.
+Integrates [lazymc](https://github.com/timvisee/lazymc) to manage the server's lifecycle, putting it to sleep when idle and waking it upon player connection.
 
-To enable lazymc for a specific server instance, set `services.minecraft-servers.servers.<name>.lazymc.enable = true;`.
+*   **`enable`**: `boolean`, default `false`
+    Whether to enable lazymc for this server instance. When enabled, lazymc will take over starting and stopping the Minecraft server process.
 
-You can further customize lazymc's behavior using the `services.minecraft-servers.servers.<name>.lazymc.config` option. This attribute set directly mirrors the structure of lazymc's `lazymc.toml` configuration file. The module will automatically configure essential settings like the server start command, server directory, and internal ports for lazymc to manage the Minecraft server.
+*   **`config`**: `attribute set`, default `{}`
+    Allows overriding settings in the `lazymc.toml` configuration file that this module generates for lazymc. The structure of this attribute set directly mirrors the TOML structure of lazymc's configuration.
 
-For example:
+    **Automatic Configuration & Port Handling:**
 
-```nix
-# In your NixOS configuration (e.g., /etc/nixos/configuration.nix or a flake output)
-{ pkgs, ... }: {
-  services.minecraft-servers.servers.myFabricServer = {
-    enable = true;
-    eula = true; # You must agree to the EULA
-    package = pkgs.fabricServers.fabric-1_20_4; # Or any other server package
-    jvmOpts = "-Xmx4G -Xms2G";
-    serverProperties = {
-      "server-port" = 25565; # This will be the base for lazymc's public port by default
-      "enable-rcon" = true;
-      "rcon.port" = 25575;   # This will be the base for the internal RCON port for Minecraft
-      # other server.properties...
-    };
+    To provide a seamless "one-toggle" solution, when `lazymc.enable = true` and you *do not* explicitly set `lazymc.config.public.address` or `lazymc.config.server.address`:
+    *   The actual Minecraft server (as configured in `server.properties` by this module) will have its `server-port` set to the value from `services.minecraft-servers.servers.<name>.serverProperties."server-port"` (or its default `25565`) **minus 1**. For example, if `server-port` was `25565`, the Minecraft server will run on port `25564`.
+    *   Lazymc will then be configured with:
+        *   `public.address`: Defaults to `0.0.0.0:<original-server-port>` (e.g., `0.0.0.0:25565`). This is the port players connect to.
+        *   `server.address`: Defaults to `127.0.0.1:<original-server-port - 1>` (e.g., `127.0.0.1:25564`). This is the internal port lazymc uses to proxy to the actual Minecraft server.
+    * **Ensure the `<original-server-port - 1>` port is available and not used by another service.**
 
-    lazymc = {
-      enable = true;
-      config = {
-        # public.address defaults to 0.0.0.0:<serverProperties."server-port">
-        # If you need a specific IP or a different public port, set it here:
-        # public.address = "192.168.1.100:25565"; 
+    If you **do** set either `lazymc.config.public.address` or `lazymc.config.server.address`:
+    *   The automatic `-1` offset for the Minecraft server's `server-port` (in `server.properties`) is **not applied**. The Minecraft server will be configured to use the `server-port` directly from `services.minecraft-servers.servers.<name>.serverProperties."server-port"`.
+    *   Lazymc's `public.address` will be what you set, or default to `0.0.0.0:<original-server-port>`.
+    *   Lazymc's `server.address` will be what you set, or default to `127.0.0.1:<original-server-port>`.
 
-        # server.address (internal MC port) is auto-configured (e.g., 127.0.0.1:25566)
-        # server.command is auto-configured
-        # server.directory is auto-configured as "." (lazymc runs in the server's data directory)
+    **Other Auto-configured `lazymc.toml` settings:**
+    *   `server.command`: Automatically set to use the server `package` and `jvmOpts` defined for this nix-minecraft server instance.
+    *   `server.directory`: Automatically set.
+    *   `rcon.enabled`: Automatically enabled in `lazymc.toml` if `enable-rcon = true;` is set in `serverProperties`.
+    *   `rcon.port`: In `lazymc.toml`, this will be set to the port the Minecraft server's RCON is actually listening on or `25575` by default
+    *   `config.version`: Automatically set to the version of the `pkgs.lazymc` package.
 
-        # rcon.enabled is auto-configured based on serverProperties.enable-rcon
-        # rcon.port (internal MC RCON port for lazymc to use) is auto-configured (e.g., 25576)
+    **Important Considerations:**
+    *   **Firewall:** When `lazymc.enable = true`, the `openFirewall` option for this server instance will open the port specified in `lazymc.config.public.address` (or its default), not the internal Minecraft server port.
+    *   **`max-tick-time`:** Setting `max-tick-time=-1` in `server.properties` might help if you're experiencing issues.
 
-        # Example overrides for other lazymc settings:
-        server.forge = false; # Set to true if this is a Forge server
-        time.sleep_after = 1800; # Sleep after 30 minutes of inactivity
-        motd = {
-          sleeping = "💤 Server is sleeping, connect to wake it up!";
-          starting = "⚙️ Server is starting, please wait...";
+    **Example:**
+    ```nix
+    # In your NixOS configuration
+    { pkgs, ... }: {
+      services.minecraft-servers.servers.myPaperServer = {
+        enable = true;
+        eula = true;
+        package = pkgs.paperServers.paper-1_20_4;
+        jvmOpts = "-Xmx4G -Xms2G";
+        serverProperties = {
+          "server-port" = 25565;
+          "enable-rcon" = true;
+          "rcon.port" = 25575;
+          "max-tick-time" = -1; # Recommended with lazymc
         };
-        join.methods = ["hold", "kick"]; # How to handle players joining a sleeping server
+
+        lazymc = {
+          enable = true;
+          config = {
+            # see lazymc config here: https://github.com/timvisee/lazymc/blob/master/res/lazymc.toml
+
+            # Other lazymc options:
+            time.sleep_after = 900; # Sleep after 15 minutes
+            motd.sleeping = "💤 Server is napping! Connect to wake it.";
+          };
+        };
       };
-    };
-  };
-}
+    }
+    ```

--- a/modules/minecraft-servers.nix
+++ b/modules/minecraft-servers.nix
@@ -1,1090 +1,1131 @@
-    {
-      config,
-      lib,
-      options,
-      pkgs,
-      ...
-    }:
-    with lib;
+{
+  config,
+  lib,
+  options,
+  pkgs,
+  ...
+}:
+with lib;
+let
+  cfg = config.services.minecraft-servers;
+
+  mkOpt = type: default: mkOption { inherit type default; };
+
+  mkOpt' =
+    type: default: description:
+    mkOption { inherit type default description; };
+
+  mkBoolOpt =
+    default:
+    mkOption {
+      inherit default;
+      type = types.bool;
+      example = true;
+    };
+
+  mkBoolOpt' =
+    default: description:
+    mkOption {
+      inherit default description;
+      type = types.bool;
+      example = true;
+    };
+
+  normalizeFiles = files: mapAttrs configToPath (filterAttrs (_: nonEmptyValue) files);
+  nonEmptyValue = x: nonEmpty x && (x ? value -> nonEmpty x.value);
+  nonEmpty = x: x != { } && x != [ ];
+
+  configToPath =
+    name: config:
+    if
+      isStringLike config # Includes paths and packages
+    then
+      config
+    else
+      (getFormat name config).generate name config.value;
+  getFormat =
+    name: config: if config ? format && config.format != null then config.format else inferFormat name;
+  inferFormat =
+    name:
     let
-      cfg = config.services.minecraft-servers;
-
-      mkOpt = type: default: mkOption { inherit type default; };
-
-      mkOpt' =
-        type: default: description:
-        mkOption { inherit type default description; };
-
-      mkBoolOpt =
-        default:
-        mkOption {
-          inherit default;
-          type = types.bool;
-          example = true;
-        };
-
-      mkBoolOpt' =
-        default: description:
-        mkOption {
-          inherit default description;
-          type = types.bool;
-          example = true;
-        };
-
-      normalizeFiles = files: mapAttrs configToPath (filterAttrs (_: nonEmptyValue) files);
-      nonEmptyValue = x: nonEmpty x && (x ? value -> nonEmpty x.value);
-      nonEmpty = x: x != { } && x != [ ];
-
-      configToPath =
-        name: config:
-        if
-          isStringLike config # Includes paths and packages
-        then
-          config
-        else
-          (getFormat name config).generate name config.value;
-      getFormat =
-        name: config: if config ? format && config.format != null then config.format else inferFormat name;
-      inferFormat =
-        name:
-        let
-          error = throw "nix-minecraft: Could not infer format from file '${name}'. Specify one using 'format'.";
-          extension = builtins.match "[^.]*\\.(.+)" name;
-        in
-        if extension != null && extension != [ ] then
-          formatExtensions.${head extension} or error
-        else
-          error;
-
-      txtList =
-        { }:
-        {
-          type = with lib.types; listOf str;
-          generate = name: value: pkgs.writeText name (lib.concatStringsSep "\n" value);
-        };
-
-      formatExtensions = with pkgs.formats; {
-        "yml" = yaml { };
-        "yaml" = yaml { };
-        "json" = json { };
-        "props" = keyValue { };
-        "properties" = keyValue { };
-        "toml" = toml { };
-        "ini" = ini { };
-        "txt" = txtList { };
-      };
-
-      configType = types.submodule {
-        options = {
-          format = mkOption {
-            type = with types; nullOr attrs;
-            default = null;
-            description = ''
-              The format to use when converting "value" into a file. If set to
-              null (the default), we'll try to infer it from the file name.
-            '';
-            example = literalExpression "pkgs.formats.yaml { }";
-          };
-          value = mkOption {
-            type = with types; either (attrsOf anything) (listOf anything);
-            description = ''
-              A value that can be converted into the specified format.
-            '';
-          };
-        };
-      };
-
-      managementSystem = types.submodule {
-        options = {
-          tmux = {
-            enable = mkEnableOption "management via a TMUX socket";
-            socketPath = mkOption {
-              type = with types; functionTo path;
-              description = ''
-                Function from a server name to the path at which the server's tmux socket is placed.
-                To connect to the console, run `tmux -S <path to socket> attach`,
-                press `Ctrl + b` then `d` to detach.
-
-                Note that while currently the default respects <option>services.minecraft-servers.runDir</option>,
-                that option is deprecated and will be removed.
-                The default will then change to `name: "/run/minecraft/''${name}.sock`.
-              '';
-              default = name: "${cfg.runDir}/${name}.sock";
-              defaultText = literalExpression ''name: "''${cfg.runDir}/''${name}.sock"'';
-            };
-          };
-          systemd-socket = {
-            enable = mkEnableOpt "management through the systemd journal & a command socket";
-            stdinSocket = {
-              path = mkOption {
-                type = with types; functionTo path;
-                description = ''
-                  Function from a server name to the path at which the server's stdin socket is placed.
-                  You can send the server commands by writing to this socket,
-                  for example with shell redirection: `echo 'list' > <path to socket>`.
-
-                  Note that while currently the default respects <option>services.minecraft-servers.runDir</option>,
-                  that option is deprecated and will be removed.
-                  The default will then change to `name: "/run/minecraft/''${name}.stdin`.
-                '';
-                default = name: "${cfg.runDir}/${name}.stdin";
-                defaultText = literalExpression ''name: "''${cfg.runDir}/''${name}.stdin"'';
-              };
-              mode = mkOption {
-                type = types.strMatching "[0-7]{4}";
-                description = "Access mode of the socket file in octal notation";
-                default = "0660";
-              };
-            };
-          };
-        };
-      };
-
-      managementSystemConfig =
-        name: server:
-        let
-          ms = server.managementSystem;
-          tmux = "${getBin pkgs.tmux}/bin/tmux";
-        in
-        assert assertMsg (
-          !(ms.tmux.enable && ms.systemd-socket.enable)
-        ) "Only one server management system can be enabled at a time.";
-        if ms.tmux.enable then
-          let
-            sock = ms.tmux.socketPath name;
-          in
-          {
-            serviceConfig = {
-              Type = "forking";
-              GuessMainPID = true;
-            };
-            hooks = {
-              start = ''
-                ${tmux} -S ${sock} new -d ${getExe server.package} ${server.jvmOpts}
-
-                # HACK: PrivateUsers makes every user besides root/minecraft `nobody`, so this restores old tmux behavior
-                # See https://github.com/Infinidoge/nix-minecraft/issues/5
-                ${tmux} -S ${sock} server-access -aw nobody
-              '';
-              postStart = ''
-                ${pkgs.coreutils}/bin/chmod 660 ${sock}
-              '';
-              stop = ''
-                function server_running {
-                  ${tmux} -S ${sock} has-session
-                }
-
-                if ! server_running ; then
-                  exit 0
-                fi
-
-                ${tmux} -S ${sock} send-keys ${escapeShellArg server.stopCommand} Enter
-
-                while server_running; do sleep 1s; done
-              '';
-            };
-          }
-        else if ms.systemd-socket.enable then
-          {
-            serviceConfig = {
-              Type = "simple";
-              StandardInput = "socket";
-              StandardOutput = "journal";
-              StandardError = "journal";
-            };
-            hooks = {
-              start = ''
-                ${getExe server.package} ${server.jvmOpts}
-              '';
-              postStart = "";
-              stop = ''
-                ${optionalString (server.stopCommand != null) ''
-                  echo ${escapeShellArg server.stopCommand} > ${escapeShellArg (ms.systemd-socket.stdinSocket.path name)}
-
-                  while kill -0 "$1" 2> /dev/null; do sleep 1s; done
-                ''}
-              '';
-            };
-          }
-        else
-          builtins.throw "At least one server management system must be enabled.";
-
-      mkEnableOpt = description: mkBoolOpt' false description;
+      error = throw "nix-minecraft: Could not infer format from file '${name}'. Specify one using 'format'.";
+      extension = builtins.match "[^.]*\\.(.+)" name;
     in
+    if extension != null && extension != [ ] then
+      formatExtensions.${head extension} or error
+    else
+      error;
+
+  txtList =
+    { }:
     {
-      options.services.minecraft-servers = {
-        enable = mkEnableOpt ''
-          If enabled, the servers in <option>services.minecraft-servers.servers</option>
-          will be created and started as applicable.
-          The data for the servers will be loaded from and
-          saved to <option>services.minecraft-servers.dataDir</option>
+      type = with lib.types; listOf str;
+      generate = name: value: pkgs.writeText name (lib.concatStringsSep "\n" value);
+    };
+
+  formatExtensions = with pkgs.formats; {
+    "yml" = yaml { };
+    "yaml" = yaml { };
+    "json" = json { };
+    "props" = keyValue { };
+    "properties" = keyValue { };
+    "toml" = toml { };
+    "ini" = ini { };
+    "txt" = txtList { };
+  };
+
+  configType = types.submodule {
+    options = {
+      format = mkOption {
+        type = with types; nullOr attrs;
+        default = null;
+        description = ''
+          The format to use when converting "value" into a file. If set to
+          null (the default), we'll try to infer it from the file name.
         '';
-
-        eula = mkEnableOpt ''
-          Whether you agree to
-          <link xlink:href="https://account.mojang.com/documents/minecraft_eula">
-          Mojang's EULA</link>. This option must be set to
-          <literal>true</literal> to run Minecraft server.
+        example = literalExpression "pkgs.formats.yaml { }";
+      };
+      value = mkOption {
+        type = with types; either (attrsOf anything) (listOf anything);
+        description = ''
+          A value that can be converted into the specified format.
         '';
+      };
+    };
+  };
 
-        openFirewall = mkEnableOpt ''
-          Whether to open ports in the firewall for each server.
-          Sets the default for <option>services.minecraft-servers.servers.<name>.openFirewall</option>.
-        '';
-
-        dataDir = mkOpt' types.path "/srv/minecraft" ''
-          Directory to store the Minecraft servers.
-          Each server will be under a subdirectory named after
-          the server name in this directory, such as <literal>/srv/minecraft/servername</literal>.
-        '';
-
-        runDir = mkOpt' types.path "/run/minecraft" ''
-          Deprecated: Directory to place the runtime tmux sockets into.
-          Each server's console will be a tmux socket file in the form of <literal>servername.sock</literal>.
-          To connect to the console, run `tmux -S /run/minecraft/servername.sock attach`,
-          press `Ctrl + b` then `d` to detach.
-
-          Plase use <option>services.minecraft-servers.managementSystem.tmux.socketPath</option>` instead.
-        '';
-
-        user = mkOption {
-          type = types.str;
-          default = "minecraft";
+  managementSystem = types.submodule {
+    options = {
+      tmux = {
+        enable = mkEnableOption "management via a TMUX socket";
+        socketPath = mkOption {
+          type = with types; functionTo path;
           description = ''
-            Name of the user to create and run servers under.
-            It is recommended to leave this as the default, as it is
-            the same user as <option>services.minecraft-server</option>.
+            Function from a server name to the path at which the server's tmux socket is placed.
+            To connect to the console, run `tmux -S <path to socket> attach`,
+            press `Ctrl + b` then `d` to detach.
+
+            Note that while currently the default respects <option>services.minecraft-servers.runDir</option>,
+            that option is deprecated and will be removed.
+            The default will then change to `name: "/run/minecraft/''${name}.sock`.
           '';
-          internal = true;
-          visible = false;
+          default = name: "${cfg.runDir}/${name}.sock";
+          defaultText = literalExpression ''name: "''${cfg.runDir}/''${name}.sock"'';
         };
+      };
+      systemd-socket = {
+        enable = mkEnableOpt "management through the systemd journal & a command socket";
+        stdinSocket = {
+          path = mkOption {
+            type = with types; functionTo path;
+            description = ''
+              Function from a server name to the path at which the server's stdin socket is placed.
+              You can send the server commands by writing to this socket,
+              for example with shell redirection: `echo 'list' > <path to socket>`.
 
-        group = mkOption {
-          type = types.str;
-          default = "minecraft";
-          description = ''
-            Name of the group to create and run servers under.
-            In order to modify the server files your user must be a part of this
-            group. If you are using the tmux management system (the default), you also need to be a part of this group to attach to the tmux socket.
-            It is recommended to leave this as the default, as it is
-            the same group as <option>services.minecraft-server</option>.
-          '';
-        };
-
-        environmentFile = mkOpt' (types.nullOr types.path) null ''
-          File consisting of lines in the form varname=value to define environment
-          variables for the minecraft servers.
-
-          Secrets (database passwords, secret keys, etc.) can be provided to server
-          files without adding them to the Nix store by defining them in the
-          environment file and referring to them in option
-          <option>services.minecraft-servers.servers.<name>.files</option> with the
-          syntax @varname@.
-        '';
-
-        managementSystem = mkOption {
-          type = managementSystem;
-          description = ''
-            The default management system for all servers.
-          '';
-          default = {
-            tmux.enable = true;
+              Note that while currently the default respects <option>services.minecraft-servers.runDir</option>,
+              that option is deprecated and will be removed.
+              The default will then change to `name: "/run/minecraft/''${name}.stdin`.
+            '';
+            default = name: "${cfg.runDir}/${name}.stdin";
+            defaultText = literalExpression ''name: "''${cfg.runDir}/''${name}.stdin"'';
           };
-          example = ''
-            {
-              tmux.enable = false;
-              systemd-socket.enable = true;
+          mode = mkOption {
+            type = types.strMatching "[0-7]{4}";
+            description = "Access mode of the socket file in octal notation";
+            default = "0660";
+          };
+        };
+      };
+    };
+  };
+
+  managementSystemConfig =
+    name: server:
+    let
+      ms = server.managementSystem;
+      tmux = "${getBin pkgs.tmux}/bin/tmux";
+    in
+    assert assertMsg (
+      !(ms.tmux.enable && ms.systemd-socket.enable)
+    ) "Only one server management system can be enabled at a time.";
+    if ms.tmux.enable then
+      let
+        sock = ms.tmux.socketPath name;
+      in
+      {
+        serviceConfig = {
+          Type = "forking";
+          GuessMainPID = true;
+        };
+        hooks = {
+          start = ''
+            ${tmux} -S ${sock} new -d ${getExe server.package} ${server.jvmOpts}
+
+            # HACK: PrivateUsers makes every user besides root/minecraft `nobody`, so this restores old tmux behavior
+            # See https://github.com/Infinidoge/nix-minecraft/issues/5
+            ${tmux} -S ${sock} server-access -aw nobody
+          '';
+          postStart = ''
+            ${pkgs.coreutils}/bin/chmod 660 ${sock}
+          '';
+          stop = ''
+            function server_running {
+              ${tmux} -S ${sock} has-session
             }
+
+            if ! server_running ; then
+              exit 0
+            fi
+
+            ${tmux} -S ${sock} send-keys ${escapeShellArg server.stopCommand} Enter
+
+            while server_running; do sleep 1s; done
           '';
         };
-
-        servers = mkOption {
-          default = { };
-          description = ''
-            Servers to create and manage using this module.
-            Each server can be stopped with <literal>systemctl stop minecraft-server-servername</literal>.
-            ::: {.warning}
-            If the server is not stopped using `systemctl`, the service will automatically restart the server.
-            See <option>services.minecraft-servers.servers.<name>.restart</option>.
-            :::
+      }
+    else if ms.systemd-socket.enable then
+      {
+        serviceConfig = {
+          Type = "simple";
+          StandardInput = "socket";
+          StandardOutput = "journal";
+          StandardError = "journal";
+        };
+        hooks = {
+          start = ''
+            ${getExe server.package} ${server.jvmOpts}
           '';
-          type = types.attrsOf (
-            types.submodule (
-              { name, ... }:
-              {
-                options = {
-                  enable = mkEnableOpt ''
-                    Whether to enable this server.
-                    If set to <literal>false</literal>, does NOT delete any data in the data directory,
-                    just does not generate the service file.
-                  '';
+          postStart = "";
+          stop = ''
+            ${optionalString (server.stopCommand != null) ''
+              echo ${escapeShellArg server.stopCommand} > ${escapeShellArg (ms.systemd-socket.stdinSocket.path name)}
 
-                  autoStart = mkBoolOpt' true ''
-                    Whether to start this server on boot.
-                    If set to <literal>false</literal>, can still be started with
-                    <literal>systemctl start minecraft-server-servername</literal>.
-                    Requires the server to be enabled.
-                  '';
+              while kill -0 "$1" 2> /dev/null; do sleep 1s; done
+            ''}
+          '';
+        };
+      }
+    else
+      builtins.throw "At least one server management system must be enabled.";
 
-                  openFirewall = mkOption {
-                    type = types.bool;
-                    default = cfg.openFirewall;
-                    defaultText = "The value of <literal>services.minecraft-servers.openFirewall</literal>";
-                    description = ''
-                      Whether to open ports in the firewall for this server.
-                    '';
-                  };
+  mkEnableOpt = description: mkBoolOpt' false description;
+in
+{
+  options.services.minecraft-servers = {
+    enable = mkEnableOpt ''
+      If enabled, the servers in <option>services.minecraft-servers.servers</option>
+      will be created and started as applicable.
+      The data for the servers will be loaded from and
+      saved to <option>services.minecraft-servers.dataDir</option>
+    '';
 
-                  restart = mkOpt' types.str "always" ''
-                    Value of systemd's <literal>Restart=</literal> service configuration option.
-                    If you are using the tmux management system (the default), values other than
-                    <literal>"no"</literal> and <literal>"always"</literal> may not work properly.
-                    As a consequence of the <literal>"always"</literal> option, stopping the server
-                    in-game with the <literal>stop</literal> command will cause the server to automatically restart.
-                  '';
+    eula = mkEnableOpt ''
+      Whether you agree to
+      <link xlink:href="https://account.mojang.com/documents/minecraft_eula">
+      Mojang's EULA</link>. This option must be set to
+      <literal>true</literal> to run Minecraft server.
+    '';
 
-                  enableReload = mkOpt' types.bool false ''
-                    Reload server when configuration changes (instead of restart).
+    openFirewall = mkEnableOpt ''
+      Whether to open ports in the firewall for each server.
+      Sets the default for <option>services.minecraft-servers.servers.<name>.openFirewall</option>.
+    '';
 
-                    This action re-links/copies the declared symlinks/files. You can
-                    include additional actions (even in-game commands) by setting
-                    <option>services.minecraft-servers.<name>.extraReload</option>.
-                  '';
+    dataDir = mkOpt' types.path "/srv/minecraft" ''
+      Directory to store the Minecraft servers.
+      Each server will be under a subdirectory named after
+      the server name in this directory, such as <literal>/srv/minecraft/servername</literal>.
+    '';
 
-                  extraReload = mkOpt' types.lines "" ''
-                    Extra commands to run when reloading the service. Only has an
-                    effect if
-                    <option>services.minecraft-servers.<name>.enableReload</option> is
-                    true.
-                  '';
+    runDir = mkOpt' types.path "/run/minecraft" ''
+      Deprecated: Directory to place the runtime tmux sockets into.
+      Each server's console will be a tmux socket file in the form of <literal>servername.sock</literal>.
+      To connect to the console, run `tmux -S /run/minecraft/servername.sock attach`,
+      press `Ctrl + b` then `d` to detach.
 
-                  extraStartPre = mkOpt' types.lines "" ''
-                    Extra commands to run before starting the service.
-                  '';
+      Plase use <option>services.minecraft-servers.managementSystem.tmux.socketPath</option>` instead.
+    '';
 
-                  extraStartPost = mkOpt' types.lines "" ''
-                    Extra commands to run after starting the service.
-                  '';
+    user = mkOption {
+      type = types.str;
+      default = "minecraft";
+      description = ''
+        Name of the user to create and run servers under.
+        It is recommended to leave this as the default, as it is
+        the same user as <option>services.minecraft-server</option>.
+      '';
+      internal = true;
+      visible = false;
+    };
 
-                  extraStopPre = mkOpt' types.lines "" ''
-                    Extra commands to run before stopping the service.
-                  '';
+    group = mkOption {
+      type = types.str;
+      default = "minecraft";
+      description = ''
+        Name of the group to create and run servers under.
+        In order to modify the server files your user must be a part of this
+        group. If you are using the tmux management system (the default), you also need to be a part of this group to attach to the tmux socket.
+        It is recommended to leave this as the default, as it is
+        the same group as <option>services.minecraft-server</option>.
+      '';
+    };
 
-                  extraStopPost = mkOpt' types.lines "" ''
-                    Extra commands to run after stopping the service.
-                  '';
+    environmentFile = mkOpt' (types.nullOr types.path) null ''
+      File consisting of lines in the form varname=value to define environment
+      variables for the minecraft servers.
 
-                  stopCommand = mkOption {
-                    type = types.nullOr types.str;
-                    description = ''
-                      Console command to run when cleanly stopping the server (ExecStop).
-                      Defaults to <literal>stop</literal>, which works for most servers.
-                      For proxies (bungeecord, velocity), you should set
-                      <literal>end</literal>.
+      Secrets (database passwords, secret keys, etc.) can be provided to server
+      files without adding them to the Nix store by defining them in the
+      environment file and referring to them in option
+      <option>services.minecraft-servers.servers.<name>.files</option> with the
+      syntax @varname@.
+    '';
 
-                      If set to <literal>null</literal>, the server will be stopped by
-                      systemd without issuing any command.
-                    '';
-                    default = "stop";
-                  };
+    managementSystem = mkOption {
+      type = managementSystem;
+      description = ''
+        The default management system for all servers.
+      '';
+      default = {
+        tmux.enable = true;
+      };
+      example = ''
+        {
+          tmux.enable = false;
+          systemd-socket.enable = true;
+        }
+      '';
+    };
 
-                  whitelist = mkOption {
-                    type =
-                      let
-                        minecraftUUID =
-                          types.strMatching "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-                          // {
-                            description = "Minecraft UUID";
+    servers = mkOption {
+      default = { };
+      description = ''
+        Servers to create and manage using this module.
+        Each server can be stopped with <literal>systemctl stop minecraft-server-servername</literal>.
+        ::: {.warning}
+        If the server is not stopped using `systemctl`, the service will automatically restart the server.
+        See <option>services.minecraft-servers.servers.<name>.restart</option>.
+        :::
+      '';
+      type = types.attrsOf (
+        types.submodule (
+          { name, ... }:
+          {
+            options = {
+              enable = mkEnableOpt ''
+                Whether to enable this server.
+                If set to <literal>false</literal>, does NOT delete any data in the data directory,
+                just does not generate the service file.
+              '';
+
+              autoStart = mkBoolOpt' true ''
+                Whether to start this server on boot.
+                If set to <literal>false</literal>, can still be started with
+                <literal>systemctl start minecraft-server-servername</literal>.
+                Requires the server to be enabled.
+              '';
+
+              openFirewall = mkOption {
+                type = types.bool;
+                default = cfg.openFirewall;
+                defaultText = "The value of <literal>services.minecraft-servers.openFirewall</literal>";
+                description = ''
+                  Whether to open ports in the firewall for this server.
+                '';
+              };
+
+              restart = mkOpt' types.str "always" ''
+                Value of systemd's <literal>Restart=</literal> service configuration option.
+                If you are using the tmux management system (the default), values other than
+                <literal>"no"</literal> and <literal>"always"</literal> may not work properly.
+                As a consequence of the <literal>"always"</literal> option, stopping the server
+                in-game with the <literal>stop</literal> command will cause the server to automatically restart.
+              '';
+
+              enableReload = mkOpt' types.bool false ''
+                Reload server when configuration changes (instead of restart).
+
+                This action re-links/copies the declared symlinks/files. You can
+                include additional actions (even in-game commands) by setting
+                <option>services.minecraft-servers.<name>.extraReload</option>.
+              '';
+
+              extraReload = mkOpt' types.lines "" ''
+                Extra commands to run when reloading the service. Only has an
+                effect if
+                <option>services.minecraft-servers.<name>.enableReload</option> is
+                true.
+              '';
+
+              extraStartPre = mkOpt' types.lines "" ''
+                Extra commands to run before starting the service.
+              '';
+
+              extraStartPost = mkOpt' types.lines "" ''
+                Extra commands to run after starting the service.
+              '';
+
+              extraStopPre = mkOpt' types.lines "" ''
+                Extra commands to run before stopping the service.
+              '';
+
+              extraStopPost = mkOpt' types.lines "" ''
+                Extra commands to run after stopping the service.
+              '';
+
+              stopCommand = mkOption {
+                type = types.nullOr types.str;
+                description = ''
+                  Console command to run when cleanly stopping the server (ExecStop).
+                  Defaults to <literal>stop</literal>, which works for most servers.
+                  For proxies (bungeecord, velocity), you should set
+                  <literal>end</literal>.
+
+                  If set to <literal>null</literal>, the server will be stopped by
+                  systemd without issuing any command.
+                '';
+                default = "stop";
+              };
+
+              whitelist = mkOption {
+                type =
+                  let
+                    minecraftUUID =
+                      types.strMatching "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                      // {
+                        description = "Minecraft UUID";
+                      };
+                  in
+                  types.attrsOf minecraftUUID;
+                default = { };
+                description = ''
+                  Whitelisted players, only has an effect when
+                  enabled via <option>services.minecraft-servers.<name>.serverProperties</option>
+                  by setting <literal>white-list</literal> to <literal>true</literal>.
+
+                  To use a non-declarative whitelist, enable the whitelist and don't fill in this value.
+                  As long as it is empty, no whitelist file is generated.
+                '';
+                example = literalExpression ''
+                  {
+                    username1 = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+                    username2 = "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy";
+                  }
+                '';
+              };
+
+              operators = mkOption {
+                type =
+                  let
+                    minecraftUUID =
+                      types.strMatching "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                      // {
+                        description = "Minecraft UUID";
+                      };
+                  in
+                  types.attrsOf (
+                    types.coercedTo minecraftUUID (v: { uuid = v; }) (
+                      types.submodule {
+                        options = {
+                          uuid = mkOption {
+                            type = minecraftUUID;
+                            description = "The operator's UUID";
+                            example = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
                           };
-                      in
-                      types.attrsOf minecraftUUID;
-                    default = { };
-                    description = ''
-                      Whitelisted players, only has an effect when
-                      enabled via <option>services.minecraft-servers.<name>.serverProperties</option>
-                      by setting <literal>white-list</literal> to <literal>true</literal>.
-
-                      To use a non-declarative whitelist, enable the whitelist and don't fill in this value.
-                      As long as it is empty, no whitelist file is generated.
-                    '';
-                    example = literalExpression ''
-                      {
-                        username1 = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
-                        username2 = "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy";
-                      }
-                    '';
-                  };
-
-                  operators = mkOption {
-                    type =
-                      let
-                        minecraftUUID =
-                          types.strMatching "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-                          // {
-                            description = "Minecraft UUID";
+                          level = mkOption {
+                            type = types.ints.between 0 4;
+                            description = "The operator's permission level";
+                            default = 4;
                           };
-                      in
-                      types.attrsOf (
-                        types.coercedTo minecraftUUID (v: { uuid = v; }) (
-                          types.submodule {
-                            options = {
-                              uuid = mkOption {
-                                type = minecraftUUID;
-                                description = "The operator's UUID";
-                                example = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
-                              };
-                              level = mkOption {
-                                type = types.ints.between 0 4;
-                                description = "The operator's permission level";
-                                default = 4;
-                              };
-                              bypassesPlayerLimit = mkOption {
-                                type = types.bool;
-                                description = "If true, the operator can join the server even if the player limit has been reached";
-                                default = false;
-                              };
-                            };
-                          }
-                        )
-                      );
-                    default = { };
-                    description = ''
-                      Server operators. See <link xlink:href="https://minecraft.wiki/w/Ops.json_format"/>.
-
-                      To use a non-declarative operator list, don't fill in this value.
-                      As long as it is empty, no operators file is generated.
-                    '';
-                    example = literalExpression ''
-                      {
-                        username1 = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
-                        username2 = {
-                          uuid = "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy";
-                          level = 3;
-                          bypassesPlayerLimit = true;
+                          bypassesPlayerLimit = mkOption {
+                            type = types.bool;
+                            description = "If true, the operator can join the server even if the player limit has been reached";
+                            default = false;
+                          };
                         };
                       }
-                    '';
-                  };
+                    )
+                  );
+                default = { };
+                description = ''
+                  Server operators. See <link xlink:href="https://minecraft.wiki/w/Ops.json_format"/>.
 
-                  serverProperties = mkOption {
-                    type =
-                      with types;
-                      attrsOf (oneOf [
-                        bool
-                        int
-                        str
-                      ]);
-                    default = { };
-                    example = literalExpression ''
-                      {
-                        server-port = 43000;
-                        difficulty = 3;
-                        gamemode = 1;
-                        max-players = 5;
-                        motd = "NixOS Minecraft server!";
-                        white-list = true;
-                        enable-rcon = true;
-                        "rcon.password" = "hunter2";
-                      }
-                    '';
-                    description = ''
-                      Minecraft server properties for the server.properties file of this server. See
-                      <link xlink:href="https://minecraft.gamepedia.com/Server.properties#Java_Edition_3"/>
-                      for documentation on these values.
-
-                      To use a non-declarative server.properties, don't fill in this value.
-                      As long as it is empty, no server.properties file is generated.
-                    '';
-                  };
-
-                  package = mkOption {
-                    description = "The Minecraft server package to use.";
-                    type = types.package;
-                    default = pkgs.minecraft-server;
-                    defaultText = literalExpression "pkgs.minecraft-server";
-                    example = "pkgs.minecraftServers.vanilla-1_18_2";
-                  };
-
-                  jvmOpts = mkOpt' (
-                    with types; coercedTo (listOf str) (lib.concatStringsSep " ") (separatedString " ")
-                  ) "-Xmx2G -Xms1G" "JVM options for this server.";
-
-                  path =
-                    with types;
-                    mkOpt' (listOf (either path str)) [ ] ''
-                      Packages added to the Minecraft server's <literal>PATH</literal> environment variable.
-                      Works as <option>systemd.services.<name>.path</option>.
-                    '';
-
-                  environment =
-                    with types;
-                    mkOpt'
-                      (attrsOf (
-                        nullOr (oneOf [
-                          str
-                          path
-                          package
-                        ])
-                      ))
-                      { }
-                      ''
-                        Environment variables added to the Minecraft server's processes.
-                        Works as <option>systemd.services.<name>.environment</option>.
-                      '';
-
-                  symlinks =
-                    with types;
-                    mkOpt' (attrsOf (either path configType)) { } ''
-                      Things to symlink into this server's data directory, in the form of
-                      a nix package/derivation. Can be used to declaratively manage
-                      arbitrary files in the server's data directory.
-                    '';
-                  files =
-                    with types;
-                    mkOpt' (attrsOf (either path configType)) { } ''
-                      Things to copy into this server's data directory. Similar to symlinks,
-                      but these are actual, writable, files. Useful for configuration files
-                      that don't behave well when read-only. Directories are copied recursively and
-                      dereferenced. They will be deleted after the server stops, so any modification
-                      is discarded.
-
-                      These files may include placeholders to substitute with values from
-                      <option>services.minecraft-servers.environmentFile</option>
-                      (i.e. @variable_name@).
-                    '';
-
-                  managementSystem = mkOption {
-                    type = types.submodule (
-                      managementSystem.getSubModules
-                      ++ [
-                        { config = mkDefault cfg.managementSystem; }
-                      ]
-                    );
-                    description = ''
-                      Configuration for the system used to manage this server. Overrides the global configuration on an option-by-option basis.
-                    '';
-                    default = { };
-                    example = options.services.minecraft-servers.managementSystem.example;
-                  };
-
-                  # <<< NEW LAZYMC OPTIONS >>>
-                  lazymc = {
-                    enable = mkEnableOpt "Enable lazymc to manage this server.";
-                    package = mkOption { # <<< NEW OPTION
-                      type = types.package;
-                      default = pkgs.lazymc;
-                      defaultText = literalExpression "pkgs.lazymc";
-                      description = "The lazymc package to use.";
+                  To use a non-declarative operator list, don't fill in this value.
+                  As long as it is empty, no operators file is generated.
+                '';
+                example = literalExpression ''
+                  {
+                    username1 = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+                    username2 = {
+                      uuid = "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy";
+                      level = 3;
+                      bypassesPlayerLimit = true;
                     };
-                    config = mkOption {
-                      type = types.attrs; # Freeform attrs, corresponds to lazymc.toml structure
-                      default = {};
-                      description = ''
-                        Configuration for lazymc, mirroring its TOML structure.
-                        Some values like server command, directory, and internal ports
-                        will be automatically configured.
-                      '';
-                      example = literalExpression ''
-                        {
-                          public.address = "0.0.0.0:25565"; # Public port for players
-                          time.sleep_after = 900; # Sleep after 15 minutes
-                          motd.sleeping = "Shhh, the server is napping!";
-                          server.forge = false; # Set to true if this is a Forge server
-                        }
-                      '';
-                    };
-                  };
-                  # <<< END NEW LAZYMC OPTIONS >>>
-                };
-              }
-            )
-          );
-        };
-      };
-
-      config = mkIf cfg.enable (
-        let
-          servers = filterAttrs (_: cfg: cfg.enable) cfg.servers;
-        in
-        {
-          users = {
-            users.minecraft = mkIf (cfg.user == "minecraft") {
-              description = "Minecraft server service user";
-              home = cfg.dataDir;
-              createHome = true;
-              homeMode = "770";
-              isSystemUser = true;
-              group = "minecraft";
-            };
-            groups.minecraft = mkIf (cfg.group == "minecraft") { };
-          };
-
-          assertions = [
-            {
-              assertion = cfg.eula;
-              message =
-                "You must agree to Mojangs EULA to run minecraft-servers."
-                + " Read https://account.mojang.com/documents/minecraft_eula and"
-                + " set `services.minecraft-servers.eula` to `true` if you agree.";
-            }
-            {
-              assertion =
-                config.services.minecraft-server.enable -> cfg.dataDir != config.services.minecraft-server.dataDir;
-              message =
-                "`services.minecraft-servers.dataDir` and `services.minecraft-server.dataDir` conflict."
-                + " Set one to use a different data directory.";
-            }
-            {
-              assertion =
-                let
-                  serverPorts = mapAttrsToList (name: conf:
-                    if conf.lazymc.enable then
-                      let
-                        parsePort = addrStr: builtins.elemAt (lib.splitString ":" addrStr) 1;
-                        defaultPublicPort = toString (conf.serverProperties."server-port" or 25565);
-                        lazymcPublicAddr = conf.lazymc.config.public.address or "0.0.0.0:${defaultPublicPort}";
-                      in
-                      lib.toInt (parsePort lazymcPublicAddr)
-                    else
-                      conf.serverProperties."server-port" or 25565
-                  ) (filterAttrs (_: filterConf: filterConf.openFirewall) servers);
-                  counts = map (port: count (x: x == port) serverPorts) (unique serverPorts);
-                in
-                lib.all (x: x == 1) counts;
-              message = "Multiple servers are set to use the same public port. Change one to use a different port.";
-            }
-            {
-              assertion =
-                let
-                  portsPerServer = lib.mapAttrsToList (serverName: serverConf:
-                    let
-                      originalMcGamePort = serverConf.serverProperties."server-port" or 25565;
-                      parsePort = addrStr: lib.toInt (builtins.elemAt (lib.splitString ":" addrStr) 1);
-
-                      # Port the MC server JAR will ultimately listen on
-                      mcServerFinalListeningPort =
-                        if serverConf.lazymc.enable &&
-                          # Safely check for server.address in lazymc.config
-                          ( (serverConf.lazymc.config ? server) && (serverConf.lazymc.config.server ? address) ) &&
-                          # Safely check for advanced.rewrite_server_properties
-                          ( (serverConf.lazymc.config ? advanced) && (serverConf.lazymc.config.advanced ? rewrite_server_properties) && serverConf.lazymc.config.advanced.rewrite_server_properties ||
-                            # OR if advanced or rewrite_server_properties is not set, assume lazymc's default of true
-                            !((serverConf.lazymc.config ? advanced) && (serverConf.lazymc.config.advanced ? rewrite_server_properties))
-                          )
-                        then
-                          # If lazymc is enabled, user set server.address, and lazymc will rewrite server.properties
-                          parsePort serverConf.lazymc.config.server.address
-                        else if serverConf.lazymc.enable && !(
-                          # Condition for default offset: lazymc enabled AND user didn't customize relevant game ports
-                          ( ((serverConf.lazymc.config ? public) && (serverConf.lazymc.config.public ? address)) ||
-                            ((serverConf.lazymc.config ? server) && (serverConf.lazymc.config.server ? address)) )
-                        ) then
-                          # Lazymc enabled, user didn't customize lazymc game ports, so we apply default offset
-                          originalMcGamePort - 1
-                        else
-                          # No lazymc, or lazymc enabled but user customized game ports (so no offset by us),
-                          # or lazymc won't rewrite server.properties.
-                          originalMcGamePort;
-
-                      # Lazymc's public port, if enabled
-                      lazymcPublicPortList =
-                        if serverConf.lazymc.enable then
-                          let
-                            # Safely access public.address
-                            lazymcPublicAddrConfig =
-                              if (serverConf.lazymc.config ? public) && (serverConf.lazymc.config.public ? address) then
-                                serverConf.lazymc.config.public.address
-                              else
-                                "0.0.0.0:${toString originalMcGamePort}";
-                          in
-                          [ (parsePort lazymcPublicAddrConfig) ]
-                        else
-                          [];
-                    in
-                    [ mcServerFinalListeningPort ] ++ lazymcPublicPortList
-                  ) servers;
-
-                  allAttemptedListeningPorts = lib.unique (lib.flatten portsPerServer);
-                  hasNoDuplicates = lib.length (lib.flatten portsPerServer) == lib.length allAttemptedListeningPorts;
-
-                in
-                hasNoDuplicates;
-              message = "Multiple Minecraft server instances or their lazymc frontends are configured to use the same game port, note that when lazymc is enabeled with no further configuration, the port immidiatley before server-port is also occupied.";
-            }
-          ];
-
-          warnings = lib.optional (cfg.runDir != options.services.minecraft-servers.runDir.default) ''
-            `runDir` has been deprecated.
-
-            Please use `services.minecraft-servers.managementSystem.tmux.socketPath` instead.
-            For example, `name: "${cfg.runDir}/''${name}.sock"`.
-
-            See the changelog file for more information.
-          '';
-
-          networking.firewall =
-            let
-              toOpen = filterAttrs (_: firewallConf: firewallConf.openFirewall) servers;
-              getTCPPorts = n: c:
-                if c.lazymc.enable then
-                  let
-                    parsePort = addrStr: builtins.elemAt (lib.splitString ":" addrStr) 1;
-                    defaultPublicPort = toString (c.serverProperties."server-port" or 25565);
-                    lazymcPublicAddr = c.lazymc.config.public.address or "0.0.0.0:${defaultPublicPort}";
-                  in
-                  [ (lib.toInt (parsePort lazymcPublicAddr)) ]
-                else # lazymc disabled, open MC server port and RCON port if enabled
-                  [ (c.serverProperties."server-port" or 25565) ];
-                  # ++ (lib.optional (c.serverProperties.enable-rcon or false) (c.serverProperties."rcon.port" or 25575));
-
-              getUDPPorts =
-                n: c:
-                # Lazymc does not proxy query protocol, so query port is always direct to MC server
-                optional (c.serverProperties.enable-query or false) (
-                  if c.lazymc.enable then
-                    # If lazymc is on, MC server runs on an internal port. Query port in server.properties should reflect this.
-                    ( (c.serverProperties."server-port" or 25565) - 1 ) # Assuming query port is same as internal game port, or needs separate internal config
-                  else
-                    (c.serverProperties."query.port" or 25565) # Direct MC server query port
-                );
-            in
-            {
-              allowedUDPPorts = flatten (mapAttrsToList getUDPPorts toOpen);
-              allowedTCPPorts = flatten (mapAttrsToList getTCPPorts toOpen);
-            };
-
-          systemd.tmpfiles.rules = mapAttrsToList (
-            name: _: "d '${cfg.dataDir}/${name}' 0770 ${cfg.user} ${cfg.group} - -"
-          ) servers;
-
-          systemd.sockets = pipe servers [
-            (filterAttrs (name: server: !server.lazymc.enable && server.managementSystem.systemd-socket.enable)) # Only for non-lazymc systemd-socket
-            (mapAttrs' (
-              name: server: {
-                name = "minecraft-server-${name}";
-                value = {
-                  requires = [ "minecraft-server-${name}.service" ];
-                  partOf = [ "minecraft-server-${name}.service" ];
-                  socketConfig =
-                    let
-                      socketConf = server.managementSystem.systemd-socket.stdinSocket;
-                    in
-                    {
-                      ListenFIFO = socketConf.path name;
-                      SocketMode = socketConf.mode;
-                      SocketUser = cfg.user;
-                      SocketGroup = cfg.group;
-                      RemoveOnStop = true;
-                      FlushPending = true;
-                    };
-                };
-              }
-            ))
-          ];
-
-          systemd.services = mapAttrs' (
-            name: conf:
-            let
-              originalMcPort = conf.serverProperties."server-port" or 25565;
-              originalMcRconEnabled = conf.serverProperties.enable-rcon or false;
-              originalMcRconPort = conf.serverProperties."rcon.port" or 25575;
-
-              # True if user explicitly sets lazymc's public port OR lazymc's internal server port
-              userHasCustomizedLazymcPorts = conf.lazymc.enable && (
-                ( (conf.lazymc.config ? public) && (conf.lazymc.config.public ? address) ) ||
-                ( (conf.lazymc.config ? server) && (conf.lazymc.config.server ? address) )
-              );
-              # This is the port the actual Minecraft server JAR will be configured to listen on
-              # via the server.properties we generate.
-              internalMcPortForServerProperties =
-                if conf.lazymc.enable && !userHasCustomizedLazymcPorts then
-                  originalMcPort - 1 # Lazymc enabled, user did NOT customize relevant ports, so we offset
-                else
-                  originalMcPort;    # Lazymc disabled, OR user IS customizing lazymc ports
-
-              internalMcRconPortForServerProperties = 
-                if (conf.lazymc.config ? rcon) && (conf.lazymc.config.rcon ? port) then # Check for rcon, then rcon.port
-                      conf.lazymc.config.rcon.port
-                else # Lazymc targets the RCON port we configured for the Minecraft server
-                  25575;
-
-              finalServerPropertiesForMc = conf.serverProperties // lib.optionalAttrs conf.lazymc.enable {
-                "server-port" = internalMcPortForServerProperties;
-              } // lib.optionalAttrs (conf.lazymc.enable && originalMcRconEnabled) {
-                "rcon.port" = internalMcRconPortForServerProperties;
+                  }
+                '';
               };
 
-              symlinks = normalizeFiles (
-                {
-                  "eula.txt".value = {
-                    eula = true;
-                  };
-                  "eula.txt".format = pkgs.formats.keyValue { };
-                }
-                // conf.symlinks
-              );
-              files = normalizeFiles (
-                {
-                  "whitelist.json".value = mapAttrsToList (n: v: {
-                    name = n;
-                    uuid = v;
-                  }) conf.whitelist;
-                  "ops.json".value = mapAttrsToList (n: v: {
-                    name = n;
-                    uuid = v.uuid;
-                    level = v.level;
-                    bypassesPlayerLimit = v.bypassesPlayerLimit;
-                  }) conf.operators;
-                  "server.properties".value = finalServerPropertiesForMc;
-                }
-                // conf.files
-              );
+              serverProperties = mkOption {
+                type =
+                  with types;
+                  attrsOf (oneOf [
+                    bool
+                    int
+                    str
+                  ]);
+                default = { };
+                example = literalExpression ''
+                  {
+                    server-port = 43000;
+                    difficulty = 3;
+                    gamemode = 1;
+                    max-players = 5;
+                    motd = "NixOS Minecraft server!";
+                    white-list = true;
+                    enable-rcon = true;
+                    "rcon.password" = "hunter2";
+                  }
+                '';
+                description = ''
+                  Minecraft server properties for the server.properties file of this server. See
+                  <link xlink:href="https://minecraft.gamepedia.com/Server.properties#Java_Edition_3"/>
+                  for documentation on these values.
 
-              lazymcTomlGenerated =
+                  To use a non-declarative server.properties, don't fill in this value.
+                  As long as it is empty, no server.properties file is generated.
+                '';
+              };
+
+              package = mkOption {
+                description = "The Minecraft server package to use.";
+                type = types.package;
+                default = pkgs.minecraft-server;
+                defaultText = literalExpression "pkgs.minecraft-server";
+                example = "pkgs.minecraftServers.vanilla-1_18_2";
+              };
+
+              jvmOpts = mkOpt' (
+                with types; coercedTo (listOf str) (lib.concatStringsSep " ") (separatedString " ")
+              ) "-Xmx2G -Xms1G" "JVM options for this server.";
+
+              path =
+                with types;
+                mkOpt' (listOf (either path str)) [ ] ''
+                  Packages added to the Minecraft server's <literal>PATH</literal> environment variable.
+                  Works as <option>systemd.services.<name>.path</option>.
+                '';
+
+              environment =
+                with types;
+                mkOpt'
+                  (attrsOf (
+                    nullOr (oneOf [
+                      str
+                      path
+                      package
+                    ])
+                  ))
+                  { }
+                  ''
+                    Environment variables added to the Minecraft server's processes.
+                    Works as <option>systemd.services.<name>.environment</option>.
+                  '';
+
+              symlinks =
+                with types;
+                mkOpt' (attrsOf (either path configType)) { } ''
+                  Things to symlink into this server's data directory, in the form of
+                  a nix package/derivation. Can be used to declaratively manage
+                  arbitrary files in the server's data directory.
+                '';
+              files =
+                with types;
+                mkOpt' (attrsOf (either path configType)) { } ''
+                  Things to copy into this server's data directory. Similar to symlinks,
+                  but these are actual, writable, files. Useful for configuration files
+                  that don't behave well when read-only. Directories are copied recursively and
+                  dereferenced. They will be deleted after the server stops, so any modification
+                  is discarded.
+
+                  These files may include placeholders to substitute with values from
+                  <option>services.minecraft-servers.environmentFile</option>
+                  (i.e. @variable_name@).
+                '';
+
+              managementSystem = mkOption {
+                type = types.submodule (
+                  managementSystem.getSubModules
+                  ++ [
+                    { config = mkDefault cfg.managementSystem; }
+                  ]
+                );
+                description = ''
+                  Configuration for the system used to manage this server. Overrides the global configuration on an option-by-option basis.
+                '';
+                default = { };
+                example = options.services.minecraft-servers.managementSystem.example;
+              };
+
+              lazymc = {
+                enable = mkEnableOpt "Enable lazymc to manage this server.";
+                package = mkOption {
+                  type = types.package;
+                  default = pkgs.lazymc;
+                  defaultText = literalExpression "pkgs.lazymc";
+                  description = "The lazymc package to use.";
+                };
+                config = mkOption {
+                  type = types.attrs; # Freeform attrs, corresponds to lazymc.toml structure
+                  default = { };
+                  description = ''
+                    Configuration for lazymc, mirroring its TOML structure.
+                    Some values like server command, directory, and internal ports
+                    will be automatically configured.
+                  '';
+                  example = literalExpression ''
+                    {
+                      public.address = "0.0.0.0:25565"; # Public port for players
+                      time.sleep_after = 900; # Sleep after 15 minutes
+                      motd.sleeping = "Shhh, the server is napping!";
+                      server.forge = false; # Set to true if this is a Forge server
+                    }
+                  '';
+                };
+              };
+
+            };
+          }
+        )
+      );
+    };
+  };
+
+  config = mkIf cfg.enable (
+    let
+      servers = filterAttrs (_: cfg: cfg.enable) cfg.servers;
+    in
+    {
+      users = {
+        users.minecraft = mkIf (cfg.user == "minecraft") {
+          description = "Minecraft server service user";
+          home = cfg.dataDir;
+          createHome = true;
+          homeMode = "770";
+          isSystemUser = true;
+          group = "minecraft";
+        };
+        groups.minecraft = mkIf (cfg.group == "minecraft") { };
+      };
+
+      assertions = [
+        {
+          assertion = cfg.eula;
+          message =
+            "You must agree to Mojangs EULA to run minecraft-servers."
+            + " Read https://account.mojang.com/documents/minecraft_eula and"
+            + " set `services.minecraft-servers.eula` to `true` if you agree.";
+        }
+        {
+          assertion =
+            config.services.minecraft-server.enable -> cfg.dataDir != config.services.minecraft-server.dataDir;
+          message =
+            "`services.minecraft-servers.dataDir` and `services.minecraft-server.dataDir` conflict."
+            + " Set one to use a different data directory.";
+        }
+        {
+          assertion =
+            let
+              serverPorts = mapAttrsToList (
+                name: conf:
+                if conf.lazymc.enable then
+                  let
+                    parsePort = addrStr: builtins.elemAt (lib.splitString ":" addrStr) 1;
+                    defaultPublicPort = toString (conf.serverProperties."server-port" or 25565);
+                    lazymcPublicAddr = conf.lazymc.config.public.address or "0.0.0.0:${defaultPublicPort}";
+                  in
+                  lib.toInt (parsePort lazymcPublicAddr)
+                else
+                  conf.serverProperties."server-port" or 25565
+              ) (filterAttrs (_: filterConf: filterConf.openFirewall) servers);
+              counts = map (port: count (x: x == port) serverPorts) (unique serverPorts);
+            in
+            lib.all (x: x == 1) counts;
+          message = "Multiple servers are set to use the same public port. Change one to use a different port.";
+        }
+        {
+          assertion =
+            let
+              portsPerServer = lib.mapAttrsToList (
+                serverName: serverConf:
                 let
-                  # Public port for users to connect to lazymc
-                  effectivePublicAddress = conf.lazymc.config.public.address or "0.0.0.0:${toString originalMcPort}";
+                  originalMcGamePort = serverConf.serverProperties."server-port" or 25565;
+                  parsePort = addrStr: lib.toInt (builtins.elemAt (lib.splitString ":" addrStr) 1);
 
-                effectiveLazymcInternalServerAddress =
-                  if (conf.lazymc.config ? server) && (conf.lazymc.config.server ? address) then # Check for server, then server.address
-                    conf.lazymc.config.server.address
-                  else # Lazymc targets the port we configured for the Minecraft server
-                    "127.0.0.1:${toString internalMcPortForServerProperties}";
+                  # Port the MC server JAR will ultimately listen on
+                  mcServerFinalListeningPort =
+                    if
+                      serverConf.lazymc.enable
+                      &&
+                        # Safely check for server.address in lazymc.config
+                        ((serverConf.lazymc.config ? server) && (serverConf.lazymc.config.server ? address))
+                      &&
+                        # Safely check for advanced.rewrite_server_properties
+                        (
+                          (serverConf.lazymc.config ? advanced)
+                          && (serverConf.lazymc.config.advanced ? rewrite_server_properties)
+                          && serverConf.lazymc.config.advanced.rewrite_server_properties
+                          ||
+                            # OR if advanced or rewrite_server_properties is not set, assume lazymc's default of true
+                            !(
+                              (serverConf.lazymc.config ? advanced)
+                              && (serverConf.lazymc.config.advanced ? rewrite_server_properties)
+                            )
+                        )
+                    then
+                      # If lazymc is enabled, user set server.address, and lazymc will rewrite server.properties
+                      parsePort serverConf.lazymc.config.server.address
+                    else if
+                      serverConf.lazymc.enable
+                      && !(
+                        # Condition for default offset: lazymc enabled AND user didn't customize relevant game ports
+                        (
+                          ((serverConf.lazymc.config ? public) && (serverConf.lazymc.config.public ? address))
+                          || ((serverConf.lazymc.config ? server) && (serverConf.lazymc.config.server ? address))
+                        )
+                      )
+                    then
+                      # Lazymc enabled, user didn't customize lazymc game ports, so we apply default offset
+                      originalMcGamePort - 1
+                    else
+                      # No lazymc, or lazymc enabled but user customized game ports (so no offset by us),
+                      # or lazymc won't rewrite server.properties.
+                      originalMcGamePort;
 
-                  defaultLazymcConfig = {
-                    public = {
-                      address = effectivePublicAddress;
-                    };
-                    server = {
-                      address = effectiveLazymcInternalServerAddress;
-                      directory = "${cfg.dataDir}/${name}"; # Lazymc runs in the server's dataDir
-                      command = "${getExe conf.package} ${conf.jvmOpts}";
-                    };
-                    rcon = lib.optionalAttrs originalMcRconEnabled {
-                      enabled = true; # If MC had RCON, lazymc should be configured to use it
-                      port = internalMcRconPortForServerProperties;
-                    };
-                    advanced = {
-                      # Let lazymc manage server.properties.
-                      # It will ensure the actual Minecraft server runs on the port specified
-                      # in this lazymc.toml's `server.address`.
-                      # rewrite_server_properties = true; # I wonder if I should disable this be default, but then users would need to enable it to activate rcon
-                    };
-                  };
-                  finalLazymcNixConfig = lib.recursiveUpdate defaultLazymcConfig conf.lazymc.config;
+                  # Lazymc's public port, if enabled
+                  lazymcPublicPortList =
+                    if serverConf.lazymc.enable then
+                      let
+                        # Safely access public.address
+                        lazymcPublicAddrConfig =
+                          if (serverConf.lazymc.config ? public) && (serverConf.lazymc.config.public ? address) then
+                            serverConf.lazymc.config.public.address
+                          else
+                            "0.0.0.0:${toString originalMcGamePort}";
+                      in
+                      [ (parsePort lazymcPublicAddrConfig) ]
+                    else
+                      [ ];
                 in
-                pkgs.writers.writeTOML "lazymc-config-${name}.toml" finalLazymcNixConfig;
+                [ mcServerFinalListeningPort ] ++ lazymcPublicPortList
+              ) servers;
 
+              allAttemptedListeningPorts = lib.unique (lib.flatten portsPerServer);
+              hasNoDuplicates = lib.length (lib.flatten portsPerServer) == lib.length allAttemptedListeningPorts;
 
-              msConfig = managementSystemConfig name conf; # For non-lazymc case
+            in
+            hasNoDuplicates;
+          message = "Multiple Minecraft server instances or their lazymc frontends are configured to use the same game port, note that when lazymc is enabeled with no further configuration, the port immidiatley before server-port is also occupied.";
+        }
+      ];
 
-              markManaged = file: ''echo "${file}" >> .nix-minecraft-managed'';
-              cleanAllManaged = ''
-                if [ -e .nix-minecraft-managed ]; then
-                  readarray -t to_delete < .nix-minecraft-managed
-                  rm -rf "''${to_delete[@]}"
-                  rm .nix-minecraft-managed
+      warnings = lib.optional (cfg.runDir != options.services.minecraft-servers.runDir.default) ''
+        `runDir` has been deprecated.
+
+        Please use `services.minecraft-servers.managementSystem.tmux.socketPath` instead.
+        For example, `name: "${cfg.runDir}/''${name}.sock"`.
+
+        See the changelog file for more information.
+      '';
+
+      networking.firewall =
+        let
+          toOpen = filterAttrs (_: firewallConf: firewallConf.openFirewall) servers;
+          getTCPPorts =
+            n: c:
+            if c.lazymc.enable then
+              let
+                parsePort = addrStr: builtins.elemAt (lib.splitString ":" addrStr) 1;
+                defaultPublicPort = toString (c.serverProperties."server-port" or 25565);
+                lazymcPublicAddr = c.lazymc.config.public.address or "0.0.0.0:${defaultPublicPort}";
+              in
+              [ (lib.toInt (parsePort lazymcPublicAddr)) ]
+            # lazymc disabled, open MC server port
+            else
+              [ (c.serverProperties."server-port" or 25565) ];
+
+          getUDPPorts =
+            n: c:
+            # Lazymc does not proxy query protocol, so query port is always direct to MC server
+            optional (c.serverProperties.enable-query or false) (
+              if c.lazymc.enable then
+                # If lazymc is on, MC server runs on an internal port. Query port in server.properties should reflect this.
+                ((c.serverProperties."server-port" or 25565) - 1) # Assuming query port is same as internal game port, or needs separate internal config
+              else
+                (c.serverProperties."query.port" or 25565) # Direct MC server query port
+            );
+        in
+        {
+          allowedUDPPorts = flatten (mapAttrsToList getUDPPorts toOpen);
+          allowedTCPPorts = flatten (mapAttrsToList getTCPPorts toOpen);
+        };
+
+      systemd.tmpfiles.rules = mapAttrsToList (
+        name: _: "d '${cfg.dataDir}/${name}' 0770 ${cfg.user} ${cfg.group} - -"
+      ) servers;
+
+      systemd.sockets = pipe servers [
+        (filterAttrs (
+          name: server: !server.lazymc.enable && server.managementSystem.systemd-socket.enable
+        )) # Only for non-lazymc systemd-socket
+        (mapAttrs' (
+          name: server: {
+            name = "minecraft-server-${name}";
+            value = {
+              requires = [ "minecraft-server-${name}.service" ];
+              partOf = [ "minecraft-server-${name}.service" ];
+              socketConfig =
+                let
+                  socketConf = server.managementSystem.systemd-socket.stdinSocket;
+                in
+                {
+                  ListenFIFO = socketConf.path name;
+                  SocketMode = socketConf.mode;
+                  SocketUser = cfg.user;
+                  SocketGroup = cfg.group;
+                  RemoveOnStop = true;
+                  FlushPending = true;
+                };
+            };
+          }
+        ))
+      ];
+
+      systemd.services = mapAttrs' (
+        name: conf:
+        let
+          originalMcPort = conf.serverProperties."server-port" or 25565;
+          originalMcRconEnabled = conf.serverProperties.enable-rcon or false;
+          originalMcRconPort = conf.serverProperties."rcon.port" or 25575;
+
+          # True if user explicitly sets lazymc's public port OR lazymc's internal server port
+          userHasCustomizedLazymcPorts =
+            conf.lazymc.enable
+            && (
+              ((conf.lazymc.config ? public) && (conf.lazymc.config.public ? address))
+              || ((conf.lazymc.config ? server) && (conf.lazymc.config.server ? address))
+            );
+          # This is the port the actual Minecraft server JAR will be configured to listen on
+          # via the server.properties we generate.
+          internalMcPortForServerProperties =
+            if conf.lazymc.enable && !userHasCustomizedLazymcPorts then
+              originalMcPort - 1 # Lazymc enabled, user did NOT customize relevant ports, so we offset
+            else
+              originalMcPort; # Lazymc disabled, OR user IS customizing lazymc ports
+
+          internalMcRconPortForServerProperties =
+            if (conf.lazymc.config ? rcon) && (conf.lazymc.config.rcon ? port) then # Check for rcon, then rcon.port
+              conf.lazymc.config.rcon.port
+            # Lazymc targets the RCON port we configured for the Minecraft server
+            else
+              25575;
+
+          finalServerPropertiesForMc =
+            conf.serverProperties
+            // lib.optionalAttrs conf.lazymc.enable {
+              "server-port" = internalMcPortForServerProperties;
+            }
+            // lib.optionalAttrs (conf.lazymc.enable && originalMcRconEnabled) {
+              "rcon.port" = internalMcRconPortForServerProperties;
+            };
+
+          symlinks = normalizeFiles (
+            {
+              "eula.txt".value = {
+                eula = true;
+              };
+              "eula.txt".format = pkgs.formats.keyValue { };
+            }
+            // conf.symlinks
+          );
+          files = normalizeFiles (
+            {
+              "whitelist.json".value = mapAttrsToList (n: v: {
+                name = n;
+                uuid = v;
+              }) conf.whitelist;
+              "ops.json".value = mapAttrsToList (n: v: {
+                name = n;
+                uuid = v.uuid;
+                level = v.level;
+                bypassesPlayerLimit = v.bypassesPlayerLimit;
+              }) conf.operators;
+              "server.properties".value = finalServerPropertiesForMc;
+            }
+            // conf.files
+          );
+
+          lazymcTomlGenerated =
+            let
+              # Public port for users to connect to lazymc
+              effectivePublicAddress = conf.lazymc.config.public.address or "0.0.0.0:${toString originalMcPort}";
+
+              effectiveLazymcInternalServerAddress =
+                if (conf.lazymc.config ? server) && (conf.lazymc.config.server ? address) then # Check for server, then server.address
+                  conf.lazymc.config.server.address
+                # Lazymc targets the port we configured for the Minecraft server
+                else
+                  "127.0.0.1:${toString internalMcPortForServerProperties}";
+
+              defaultLazymcConfig = {
+                public = {
+                  address = effectivePublicAddress;
+                };
+                server = {
+                  address = effectiveLazymcInternalServerAddress;
+                  directory = "${cfg.dataDir}/${name}"; # Lazymc runs in the server's dataDir
+                  command = "${getExe conf.package} ${conf.jvmOpts}";
+                };
+                rcon = lib.optionalAttrs originalMcRconEnabled {
+                  enabled = true; # If MC had RCON, lazymc should be configured to use it
+                  port = internalMcRconPortForServerProperties;
+                };
+                advanced = {
+                  # Let lazymc manage server.properties.
+                  # It will ensure the actual Minecraft server runs on the port specified
+                  # in this lazymc.toml's `server.address`.
+                  # rewrite_server_properties = true; # I wonder if I should disable this be default, but then users would need to enable it to activate rcon
+                };
+              };
+              finalLazymcNixConfig = lib.recursiveUpdate defaultLazymcConfig conf.lazymc.config;
+            in
+            pkgs.writers.writeTOML "lazymc-config-${name}.toml" finalLazymcNixConfig;
+
+          msConfig = managementSystemConfig name conf; # For non-lazymc case
+
+          markManaged = file: ''echo "${file}" >> .nix-minecraft-managed'';
+          cleanAllManaged = ''
+            if [ -e .nix-minecraft-managed ]; then
+              readarray -t to_delete < .nix-minecraft-managed
+              rm -rf "''${to_delete[@]}"
+              rm .nix-minecraft-managed
+            fi
+          '';
+
+          ExecStartPre =
+            let
+              backup = file: ''
+                if [[ -e "${file}" ]]; then
+                  echo "${file} already exists, moving"
+                  mv "${file}" "${file}.bak"
                 fi
               '';
+              mkSymlinks = concatStringsSep "\n" (
+                mapAttrsToList (n: v: ''
+                  ${backup n}
+                  mkdir -p "$(dirname "${n}")"
 
-              ExecStartPre =
-                let
-                  backup = file: ''
-                    if [[ -e "${file}" ]]; then
-                      echo "${file} already exists, moving"
-                      mv "${file}" "${file}.bak"
-                    fi
-                  '';
-                  mkSymlinks = concatStringsSep "\n" (
-                    mapAttrsToList (n: v: ''
-                      ${backup n}
-                      mkdir -p "$(dirname "${n}")"
+                  ln -sf "${v}" "${n}"
 
-                      ln -sf "${v}" "${n}"
-
-                      ${markManaged n}
-                    '') symlinks
-                  );
-
-                  mkFiles = concatStringsSep "\n" (
-                    mapAttrsToList (n: v: ''
-                      ${backup n}
-                      mkdir -p "$(dirname "${n}")"
-
-                      # If it's not a binary, substitute env vars. Else, copy it normally
-                      if ${pkgs.file}/bin/file --mime-encoding "${v}" | grep -v '\bbinary$' -q; then
-                        ${pkgs.gawk}/bin/awk '{
-                          for(varname in ENVIRON)
-                            gsub("@"varname"@", ENVIRON[varname])
-                          print
-                        }' "${v}" > "${n}"
-                      else
-                        cp -r --dereference "${v}" -T "${n}"
-                        chmod +w -R "${n}"
-                      fi
-
-                      ${markManaged n}
-                    '') files
-                  );
-                  mkLazymcConfig = lib.optionalString conf.lazymc.enable ''
-                    ${backup "lazymc.toml"}
-                    ln -sf "${lazymcTomlGenerated}" "lazymc.toml"
-                    ${markManaged "lazymc.toml"}
-                  '';
-                in
-                getExe (
-                  pkgs.writeShellApplication {
-                    name = "minecraft-server-${name}-start-pre";
-                    text = ''
-                      ${cleanAllManaged}
-                      ${mkSymlinks}
-                      ${mkFiles}
-                      ${mkLazymcConfig}
-                      ${conf.extraStartPre}
-                    '';
-                  }
-                );
-
-              finalExecStartCmd = if conf.lazymc.enable then
-                "${conf.lazymc.package}/bin/lazymc start --config lazymc.toml"
-              else
-                msConfig.hooks.start;
-
-              ExecStart = getExe (
-                pkgs.writeShellApplication {
-                  name = "minecraft-server-${name}-start";
-                  text = finalExecStartCmd;
-                }
+                  ${markManaged n}
+                '') symlinks
               );
-              
-              finalServiceConfig = if conf.lazymc.enable then {
+
+              mkFiles = concatStringsSep "\n" (
+                mapAttrsToList (n: v: ''
+                  ${backup n}
+                  mkdir -p "$(dirname "${n}")"
+
+                  # If it's not a binary, substitute env vars. Else, copy it normally
+                  if ${pkgs.file}/bin/file --mime-encoding "${v}" | grep -v '\bbinary$' -q; then
+                    ${pkgs.gawk}/bin/awk '{
+                      for(varname in ENVIRON)
+                        gsub("@"varname"@", ENVIRON[varname])
+                      print
+                    }' "${v}" > "${n}"
+                  else
+                    cp -r --dereference "${v}" -T "${n}"
+                    chmod +w -R "${n}"
+                  fi
+
+                  ${markManaged n}
+                '') files
+              );
+              mkLazymcConfig = lib.optionalString conf.lazymc.enable ''
+                ${backup "lazymc.toml"}
+                ln -sf "${lazymcTomlGenerated}" "lazymc.toml"
+                ${markManaged "lazymc.toml"}
+              '';
+            in
+            getExe (
+              pkgs.writeShellApplication {
+                name = "minecraft-server-${name}-start-pre";
+                text = ''
+                  ${cleanAllManaged}
+                  ${mkSymlinks}
+                  ${mkFiles}
+                  ${mkLazymcConfig}
+                  ${conf.extraStartPre}
+                '';
+              }
+            );
+
+          finalExecStartCmd =
+            if conf.lazymc.enable then
+              "${conf.lazymc.package}/bin/lazymc start --config lazymc.toml"
+            else
+              msConfig.hooks.start;
+
+          ExecStart = getExe (
+            pkgs.writeShellApplication {
+              name = "minecraft-server-${name}-start";
+              text = finalExecStartCmd;
+            }
+          );
+
+          finalServiceConfig =
+            if conf.lazymc.enable then
+              {
                 Type = "simple"; # lazymc runs in foreground
                 StandardOutput = "journal";
                 StandardError = "journal";
                 # ExecStop sends SIGTERM to lazymc, which handles stopping Minecraft
-              } else msConfig.serviceConfig;
+              }
+            else
+              msConfig.serviceConfig;
 
-              ExecStartPost = lib.optionalString (!conf.lazymc.enable) (getExe (
+          ExecStartPost = lib.optionalString (!conf.lazymc.enable) (
+            getExe (
+              pkgs.writeShellApplication {
+                name = "minecraft-server-${name}-start-post";
+                text = ''
+                  ${msConfig.hooks.postStart}
+                  ${conf.extraStartPost}
+                '';
+              }
+            )
+          );
+
+          execStopScript = lib.optionalString (!conf.lazymc.enable) (
+            let
+              script = getExe (
                 pkgs.writeShellApplication {
-                  name = "minecraft-server-${name}-start-post";
+                  name = "minecraft-server-${name}-stop";
                   text = ''
-                    ${msConfig.hooks.postStart}
-                    ${conf.extraStartPost}
-                  '';
-                }
-              ));
-
-              execStopScript = lib.optionalString (!conf.lazymc.enable) (
-                let
-                  script = getExe (
-                    pkgs.writeShellApplication {
-                      name = "minecraft-server-${name}-stop";
-                      text = ''
-                        # systemd has no ExecStopPre hook, so we just run it here.
-                        ${conf.extraStopPre}
-                        ${msConfig.hooks.stop}
-                      '';
-                    }
-                  );
-                in
-                "${script} $MAINPID"
-              );
-
-              ExecStopPost = getExe (
-                pkgs.writeShellApplication {
-                  name = "minecraft-server-${name}-stop-post";
-                  text = ''
-                    ${cleanAllManaged}
-                    ${lib.optionalString (!conf.lazymc.enable) conf.extraStopPost}
-                  '';
-                }
-              );
-
-              ExecReload = getExe (
-                pkgs.writeShellApplication {
-                  name = "minecraft-server-${name}-reload";
-                  text = ''
-                    ${ExecStopPost} # This contains cleanAllManaged
-                    ${ExecStartPre} # This regenerates files including lazymc.toml
-                    ${conf.extraReload}
+                    # systemd has no ExecStopPre hook, so we just run it here.
+                    ${conf.extraStopPre}
+                    ${msConfig.hooks.stop}
                   '';
                 }
               );
             in
-            {
-              name = "minecraft-server-${name}";
-              value = {
-                description = "Minecraft Server ${name}" + (if conf.lazymc.enable then " (managed by lazymc)" else "");
-                wantedBy = mkIf conf.autoStart [ "multi-user.target" ];
-                requires = optional (!conf.lazymc.enable && conf.managementSystem.systemd-socket.enable) "minecraft-server-${name}.socket";
-                partOf = optional (!conf.lazymc.enable && conf.managementSystem.systemd-socket.enable) "minecraft-server-${name}.socket";
-                after = [
-                  "network.target"
-                ] ++ optional (!conf.lazymc.enable && conf.managementSystem.systemd-socket.enable) "minecraft-server-${name}.socket";
+            "${script} $MAINPID"
+          );
 
-                enable = conf.enable;
-
-                startLimitIntervalSec = 120;
-                startLimitBurst = 5;
-
-                serviceConfig = {
-                  inherit
-                    ExecStartPre
-                    ExecStart
-                    ExecStartPost
-                    ExecStopPost
-                    ExecReload
-                    ;
-                  ExecStop = execStopScript;
-                  
-                  # the Minecraft server (as of 1.20.6) has a 60s timeout for saving each world.
-                  # let's let it handle potential lock-ups by itself before resorting to killing it.
-                  TimeoutStopSec = "1min 15s";
-
-                  Restart = conf.restart;
-                  WorkingDirectory = "${cfg.dataDir}/${name}";
-                  User = cfg.user;
-                  Group = cfg.group;
-                  EnvironmentFile = mkIf (cfg.environmentFile != null) (toString cfg.environmentFile);
-
-                  # Default directory for management sockets
-                  RuntimeDirectory = "minecraft";
-                  RuntimeDirectoryPreserve = "yes";
-
-                  # Hardening
-                  CapabilityBoundingSet = [ "" ];
-                  DeviceAllow = [ "" ];
-                  LockPersonality = true;
-                  PrivateDevices = true;
-                  PrivateTmp = true;
-                  PrivateUsers = true;
-                  ProtectClock = true;
-                  ProtectControlGroups = true;
-                  ProtectHome = true;
-                  ProtectHostname = true;
-                  ProtectKernelLogs = true;
-                  ProtectKernelModules = true;
-                  ProtectKernelTunables = true;
-                  ProtectProc = "invisible";
-                  RestrictAddressFamilies = [
-                    "AF_UNIX"
-                    "AF_INET"
-                    "AF_INET6"
-                  ];
-                  RestrictNamespaces = true;
-                  RestrictRealtime = true;
-                  RestrictSUIDSGID = true;
-                  SystemCallArchitectures = "native";
-                  UMask = "0007";
-                } // finalServiceConfig;
-
-                restartIfChanged = !conf.enableReload;
-                reloadIfChanged = conf.enableReload;
-
-                inherit (conf) path environment;
-              };
+          ExecStopPost = getExe (
+            pkgs.writeShellApplication {
+              name = "minecraft-server-${name}-stop-post";
+              text = ''
+                ${cleanAllManaged}
+                ${lib.optionalString (!conf.lazymc.enable) conf.extraStopPost}
+              '';
             }
-          ) servers;
+          );
+
+          ExecReload = getExe (
+            pkgs.writeShellApplication {
+              name = "minecraft-server-${name}-reload";
+              text = ''
+                ${ExecStopPost} # This contains cleanAllManaged
+                ${ExecStartPre} # This regenerates files including lazymc.toml
+                ${conf.extraReload}
+              '';
+            }
+          );
+        in
+        {
+          name = "minecraft-server-${name}";
+          value = {
+            description =
+              "Minecraft Server ${name}" + (if conf.lazymc.enable then " (managed by lazymc)" else "");
+            wantedBy = mkIf conf.autoStart [ "multi-user.target" ];
+            requires = optional (
+              !conf.lazymc.enable && conf.managementSystem.systemd-socket.enable
+            ) "minecraft-server-${name}.socket";
+            partOf = optional (
+              !conf.lazymc.enable && conf.managementSystem.systemd-socket.enable
+            ) "minecraft-server-${name}.socket";
+            after =
+              [
+                "network.target"
+              ]
+              ++ optional (
+                !conf.lazymc.enable && conf.managementSystem.systemd-socket.enable
+              ) "minecraft-server-${name}.socket";
+
+            enable = conf.enable;
+
+            startLimitIntervalSec = 120;
+            startLimitBurst = 5;
+
+            serviceConfig = {
+              inherit
+                ExecStartPre
+                ExecStart
+                ExecStartPost
+                ExecStopPost
+                ExecReload
+                ;
+              ExecStop = execStopScript;
+
+              # the Minecraft server (as of 1.20.6) has a 60s timeout for saving each world.
+              # let's let it handle potential lock-ups by itself before resorting to killing it.
+              TimeoutStopSec = "1min 15s";
+
+              Restart = conf.restart;
+              WorkingDirectory = "${cfg.dataDir}/${name}";
+              User = cfg.user;
+              Group = cfg.group;
+              EnvironmentFile = mkIf (cfg.environmentFile != null) (toString cfg.environmentFile);
+
+              # Default directory for management sockets
+              RuntimeDirectory = "minecraft";
+              RuntimeDirectoryPreserve = "yes";
+
+              # Hardening
+              CapabilityBoundingSet = [ "" ];
+              DeviceAllow = [ "" ];
+              LockPersonality = true;
+              PrivateDevices = true;
+              PrivateTmp = true;
+              PrivateUsers = true;
+              ProtectClock = true;
+              ProtectControlGroups = true;
+              ProtectHome = true;
+              ProtectHostname = true;
+              ProtectKernelLogs = true;
+              ProtectKernelModules = true;
+              ProtectKernelTunables = true;
+              ProtectProc = "invisible";
+              RestrictAddressFamilies = [
+                "AF_UNIX"
+                "AF_INET"
+                "AF_INET6"
+              ];
+              RestrictNamespaces = true;
+              RestrictRealtime = true;
+              RestrictSUIDSGID = true;
+              SystemCallArchitectures = "native";
+              UMask = "0007";
+            } // finalServiceConfig;
+
+            restartIfChanged = !conf.enableReload;
+            reloadIfChanged = conf.enableReload;
+
+            inherit (conf) path environment;
+          };
         }
-      );
+      ) servers;
     }
+  );
+}

--- a/modules/minecraft-servers.nix
+++ b/modules/minecraft-servers.nix
@@ -570,6 +570,12 @@
                   # <<< NEW LAZYMC OPTIONS >>>
                   lazymc = {
                     enable = mkEnableOpt "Enable lazymc to manage this server.";
+                    package = mkOption { # <<< NEW OPTION
+                      type = types.package;
+                      default = pkgs.lazymc;
+                      defaultText = literalExpression "pkgs.lazymc";
+                      description = "The lazymc package to use.";
+                    };
                     config = mkOption {
                       type = types.attrs; # Freeform attrs, corresponds to lazymc.toml structure
                       default = {};
@@ -806,9 +812,6 @@
                       # in this lazymc.toml's `server.address`.
                       # rewrite_server_properties = true; # I wonder if I should disable this be default, but then users would need to enable it to activate rcon
                     };
-                    config = {
-                      version = pkgs.lazymc.version;
-                    };
                   };
                   finalLazymcNixConfig = lib.recursiveUpdate defaultLazymcConfig conf.lazymc.config;
                 in
@@ -885,7 +888,7 @@
                 );
 
               finalExecStartCmd = if conf.lazymc.enable then
-                "${pkgs.lazymc}/bin/lazymc start --config lazymc.toml"
+                "${conf.lazymc.package}/bin/lazymc start --config lazymc.toml"
               else
                 msConfig.hooks.start;
 

--- a/modules/minecraft-servers.nix
+++ b/modules/minecraft-servers.nix
@@ -1,1003 +1,1046 @@
-{
-  config,
-  lib,
-  options,
-  pkgs,
-  ...
-}:
-with lib;
-let
-  cfg = config.services.minecraft-servers;
-
-  mkOpt = type: default: mkOption { inherit type default; };
-
-  mkOpt' =
-    type: default: description:
-    mkOption { inherit type default description; };
-
-  mkBoolOpt =
-    default:
-    mkOption {
-      inherit default;
-      type = types.bool;
-      example = true;
-    };
-
-  mkBoolOpt' =
-    default: description:
-    mkOption {
-      inherit default description;
-      type = types.bool;
-      example = true;
-    };
-
-  normalizeFiles = files: mapAttrs configToPath (filterAttrs (_: nonEmptyValue) files);
-  nonEmptyValue = x: nonEmpty x && (x ? value -> nonEmpty x.value);
-  nonEmpty = x: x != { } && x != [ ];
-
-  configToPath =
-    name: config:
-    if
-      isStringLike config # Includes paths and packages
-    then
-      config
-    else
-      (getFormat name config).generate name config.value;
-  getFormat =
-    name: config: if config ? format && config.format != null then config.format else inferFormat name;
-  inferFormat =
-    name:
-    let
-      error = throw "nix-minecraft: Could not infer format from file '${name}'. Specify one using 'format'.";
-      extension = builtins.match "[^.]*\\.(.+)" name;
-    in
-    if extension != null && extension != [ ] then
-      formatExtensions.${head extension} or error
-    else
-      error;
-
-  txtList =
-    { }:
     {
-      type = with lib.types; listOf str;
-      generate = name: value: pkgs.writeText name (lib.concatStringsSep "\n" value);
-    };
-
-  formatExtensions = with pkgs.formats; {
-    "yml" = yaml { };
-    "yaml" = yaml { };
-    "json" = json { };
-    "props" = keyValue { };
-    "properties" = keyValue { };
-    "toml" = toml { };
-    "ini" = ini { };
-    "txt" = txtList { };
-  };
-
-  configType = types.submodule {
-    options = {
-      format = mkOption {
-        type = with types; nullOr attrs;
-        default = null;
-        description = ''
-          The format to use when converting "value" into a file. If set to
-          null (the default), we'll try to infer it from the file name.
-        '';
-        example = literalExpression "pkgs.formats.yaml { }";
-      };
-      value = mkOption {
-        type = with types; either (attrsOf anything) (listOf anything);
-        description = ''
-          A value that can be converted into the specified format.
-        '';
-      };
-    };
-  };
-
-  managementSystem = types.submodule {
-    options = {
-      tmux = {
-        enable = mkEnableOption "management via a TMUX socket";
-        socketPath = mkOption {
-          type = with types; functionTo path;
-          description = ''
-            Function from a server name to the path at which the server's tmux socket is placed.
-            To connect to the console, run `tmux -S <path to socket> attach`,
-            press `Ctrl + b` then `d` to detach.
-
-            Note that while currently the default respects <option>services.minecraft-servers.runDir</option>,
-            that option is deprecated and will be removed.
-            The default will then change to `name: "/run/minecraft/''${name}.sock`.
-          '';
-          default = name: "${cfg.runDir}/${name}.sock";
-          defaultText = literalExpression ''name: "''${cfg.runDir}/''${name}.sock"'';
-        };
-      };
-      systemd-socket = {
-        enable = mkEnableOpt "management through the systemd journal & a command socket";
-        stdinSocket = {
-          path = mkOption {
-            type = with types; functionTo path;
-            description = ''
-              Function from a server name to the path at which the server's stdin socket is placed.
-              You can send the server commands by writing to this socket,
-              for example with shell redirection: `echo 'list' > <path to socket>`.
-
-              Note that while currently the default respects <option>services.minecraft-servers.runDir</option>,
-              that option is deprecated and will be removed.
-              The default will then change to `name: "/run/minecraft/''${name}.stdin`.
-            '';
-            default = name: "${cfg.runDir}/${name}.stdin";
-            defaultText = literalExpression ''name: "''${cfg.runDir}/''${name}.stdin"'';
-          };
-          mode = mkOption {
-            type = types.strMatching "[0-7]{4}";
-            description = "Access mode of the socket file in octal notation";
-            default = "0660";
-          };
-        };
-      };
-    };
-  };
-
-  managementSystemConfig =
-    name: server:
+      config,
+      lib,
+      options,
+      pkgs,
+      ...
+    }:
+    with lib;
     let
-      ms = server.managementSystem;
-      tmux = "${getBin pkgs.tmux}/bin/tmux";
-    in
-    assert assertMsg (
-      !(ms.tmux.enable && ms.systemd-socket.enable)
-    ) "Only one server management system can be enabled at a time.";
-    if ms.tmux.enable then
-      let
-        sock = ms.tmux.socketPath name;
-      in
-      {
-        serviceConfig = {
-          Type = "forking";
-          GuessMainPID = true;
+      cfg = config.services.minecraft-servers;
+
+      mkOpt = type: default: mkOption { inherit type default; };
+
+      mkOpt' =
+        type: default: description:
+        mkOption { inherit type default description; };
+
+      mkBoolOpt =
+        default:
+        mkOption {
+          inherit default;
+          type = types.bool;
+          example = true;
         };
-        hooks = {
-          start = ''
-            ${tmux} -S ${sock} new -d ${getExe server.package} ${server.jvmOpts}
 
-            # HACK: PrivateUsers makes every user besides root/minecraft `nobody`, so this restores old tmux behavior
-            # See https://github.com/Infinidoge/nix-minecraft/issues/5
-            ${tmux} -S ${sock} server-access -aw nobody
-          '';
-          postStart = ''
-            ${pkgs.coreutils}/bin/chmod 660 ${sock}
-          '';
-          stop = ''
-            function server_running {
-              ${tmux} -S ${sock} has-session
-            }
-
-            if ! server_running ; then
-              exit 0
-            fi
-
-            ${tmux} -S ${sock} send-keys ${escapeShellArg server.stopCommand} Enter
-
-            while server_running; do sleep 1s; done
-          '';
+      mkBoolOpt' =
+        default: description:
+        mkOption {
+          inherit default description;
+          type = types.bool;
+          example = true;
         };
-      }
-    else if ms.systemd-socket.enable then
-      {
-        serviceConfig = {
-          Type = "simple";
-          StandardInput = "socket";
-          StandardOutput = "journal";
-          StandardError = "journal";
-        };
-        hooks = {
-          start = ''
-            ${getExe server.package} ${server.jvmOpts}
-          '';
-          postStart = "";
-          stop = ''
-            ${optionalString (server.stopCommand != null) ''
-              echo ${escapeShellArg server.stopCommand} > ${escapeShellArg (ms.systemd-socket.stdinSocket.path name)}
 
-              while kill -0 "$1" 2> /dev/null; do sleep 1s; done
-            ''}
-          '';
-        };
-      }
-    else
-      builtins.throw "At least one server management system must be enabled.";
+      normalizeFiles = files: mapAttrs configToPath (filterAttrs (_: nonEmptyValue) files);
+      nonEmptyValue = x: nonEmpty x && (x ? value -> nonEmpty x.value);
+      nonEmpty = x: x != { } && x != [ ];
 
-  mkEnableOpt = description: mkBoolOpt' false description;
-in
-{
-  options.services.minecraft-servers = {
-    enable = mkEnableOpt ''
-      If enabled, the servers in <option>services.minecraft-servers.servers</option>
-      will be created and started as applicable.
-      The data for the servers will be loaded from and
-      saved to <option>services.minecraft-servers.dataDir</option>
-    '';
+      configToPath =
+        name: config:
+        if
+          isStringLike config # Includes paths and packages
+        then
+          config
+        else
+          (getFormat name config).generate name config.value;
+      getFormat =
+        name: config: if config ? format && config.format != null then config.format else inferFormat name;
+      inferFormat =
+        name:
+        let
+          error = throw "nix-minecraft: Could not infer format from file '${name}'. Specify one using 'format'.";
+          extension = builtins.match "[^.]*\\.(.+)" name;
+        in
+        if extension != null && extension != [ ] then
+          formatExtensions.${head extension} or error
+        else
+          error;
 
-    eula = mkEnableOpt ''
-      Whether you agree to
-      <link xlink:href="https://account.mojang.com/documents/minecraft_eula">
-      Mojang's EULA</link>. This option must be set to
-      <literal>true</literal> to run Minecraft server.
-    '';
-
-    openFirewall = mkEnableOpt ''
-      Whether to open ports in the firewall for each server.
-      Sets the default for <option>services.minecraft-servers.servers.<name>.openFirewall</option>.
-    '';
-
-    dataDir = mkOpt' types.path "/srv/minecraft" ''
-      Directory to store the Minecraft servers.
-      Each server will be under a subdirectory named after
-      the server name in this directory, such as <literal>/srv/minecraft/servername</literal>.
-    '';
-
-    runDir = mkOpt' types.path "/run/minecraft" ''
-      Deprecated: Directory to place the runtime tmux sockets into.
-      Each server's console will be a tmux socket file in the form of <literal>servername.sock</literal>.
-      To connect to the console, run `tmux -S /run/minecraft/servername.sock attach`,
-      press `Ctrl + b` then `d` to detach.
-
-      Plase use <option>services.minecraft-servers.managementSystem.tmux.socketPath</option>` instead.
-    '';
-
-    user = mkOption {
-      type = types.str;
-      default = "minecraft";
-      description = ''
-        Name of the user to create and run servers under.
-        It is recommended to leave this as the default, as it is
-        the same user as <option>services.minecraft-server</option>.
-      '';
-      internal = true;
-      visible = false;
-    };
-
-    group = mkOption {
-      type = types.str;
-      default = "minecraft";
-      description = ''
-        Name of the group to create and run servers under.
-        In order to modify the server files your user must be a part of this
-        group. If you are using the tmux management system (the default), you also need to be a part of this group to attach to the tmux socket.
-        It is recommended to leave this as the default, as it is
-        the same group as <option>services.minecraft-server</option>.
-      '';
-    };
-
-    environmentFile = mkOpt' (types.nullOr types.path) null ''
-      File consisting of lines in the form varname=value to define environment
-      variables for the minecraft servers.
-
-      Secrets (database passwords, secret keys, etc.) can be provided to server
-      files without adding them to the Nix store by defining them in the
-      environment file and referring to them in option
-      <option>services.minecraft-servers.servers.<name>.files</option> with the
-      syntax @varname@.
-    '';
-
-    managementSystem = mkOption {
-      type = managementSystem;
-      description = ''
-        The default management system for all servers.
-      '';
-      default = {
-        tmux.enable = true;
-      };
-      example = ''
+      txtList =
+        { }:
         {
-          tmux.enable = false;
-          systemd-socket.enable = true;
-        }
-      '';
-    };
+          type = with lib.types; listOf str;
+          generate = name: value: pkgs.writeText name (lib.concatStringsSep "\n" value);
+        };
 
-    servers = mkOption {
-      default = { };
-      description = ''
-        Servers to create and manage using this module.
-        Each server can be stopped with <literal>systemctl stop minecraft-server-servername</literal>.
-        ::: {.warning}
-        If the server is not stopped using `systemctl`, the service will automatically restart the server.
-        See <option>services.minecraft-servers.servers.<name>.restart</option>.
-        :::
-      '';
-      type = types.attrsOf (
-        types.submodule (
-          { name, ... }:
+      formatExtensions = with pkgs.formats; {
+        "yml" = yaml { };
+        "yaml" = yaml { };
+        "json" = json { };
+        "props" = keyValue { };
+        "properties" = keyValue { };
+        "toml" = toml { };
+        "ini" = ini { };
+        "txt" = txtList { };
+      };
+
+      configType = types.submodule {
+        options = {
+          format = mkOption {
+            type = with types; nullOr attrs;
+            default = null;
+            description = ''
+              The format to use when converting "value" into a file. If set to
+              null (the default), we'll try to infer it from the file name.
+            '';
+            example = literalExpression "pkgs.formats.yaml { }";
+          };
+          value = mkOption {
+            type = with types; either (attrsOf anything) (listOf anything);
+            description = ''
+              A value that can be converted into the specified format.
+            '';
+          };
+        };
+      };
+
+      managementSystem = types.submodule {
+        options = {
+          tmux = {
+            enable = mkEnableOption "management via a TMUX socket";
+            socketPath = mkOption {
+              type = with types; functionTo path;
+              description = ''
+                Function from a server name to the path at which the server's tmux socket is placed.
+                To connect to the console, run `tmux -S <path to socket> attach`,
+                press `Ctrl + b` then `d` to detach.
+
+                Note that while currently the default respects <option>services.minecraft-servers.runDir</option>,
+                that option is deprecated and will be removed.
+                The default will then change to `name: "/run/minecraft/''${name}.sock`.
+              '';
+              default = name: "${cfg.runDir}/${name}.sock";
+              defaultText = literalExpression ''name: "''${cfg.runDir}/''${name}.sock"'';
+            };
+          };
+          systemd-socket = {
+            enable = mkEnableOpt "management through the systemd journal & a command socket";
+            stdinSocket = {
+              path = mkOption {
+                type = with types; functionTo path;
+                description = ''
+                  Function from a server name to the path at which the server's stdin socket is placed.
+                  You can send the server commands by writing to this socket,
+                  for example with shell redirection: `echo 'list' > <path to socket>`.
+
+                  Note that while currently the default respects <option>services.minecraft-servers.runDir</option>,
+                  that option is deprecated and will be removed.
+                  The default will then change to `name: "/run/minecraft/''${name}.stdin`.
+                '';
+                default = name: "${cfg.runDir}/${name}.stdin";
+                defaultText = literalExpression ''name: "''${cfg.runDir}/''${name}.stdin"'';
+              };
+              mode = mkOption {
+                type = types.strMatching "[0-7]{4}";
+                description = "Access mode of the socket file in octal notation";
+                default = "0660";
+              };
+            };
+          };
+        };
+      };
+
+      managementSystemConfig =
+        name: server:
+        let
+          ms = server.managementSystem;
+          tmux = "${getBin pkgs.tmux}/bin/tmux";
+        in
+        assert assertMsg (
+          !(ms.tmux.enable && ms.systemd-socket.enable)
+        ) "Only one server management system can be enabled at a time.";
+        if ms.tmux.enable then
+          let
+            sock = ms.tmux.socketPath name;
+          in
           {
-            options = {
-              enable = mkEnableOpt ''
-                Whether to enable this server.
-                If set to <literal>false</literal>, does NOT delete any data in the data directory,
-                just does not generate the service file.
+            serviceConfig = {
+              Type = "forking";
+              GuessMainPID = true;
+            };
+            hooks = {
+              start = ''
+                ${tmux} -S ${sock} new -d ${getExe server.package} ${server.jvmOpts}
+
+                # HACK: PrivateUsers makes every user besides root/minecraft `nobody`, so this restores old tmux behavior
+                # See https://github.com/Infinidoge/nix-minecraft/issues/5
+                ${tmux} -S ${sock} server-access -aw nobody
               '';
-
-              autoStart = mkBoolOpt' true ''
-                Whether to start this server on boot.
-                If set to <literal>false</literal>, can still be started with
-                <literal>systemctl start minecraft-server-servername</literal>.
-                Requires the server to be enabled.
+              postStart = ''
+                ${pkgs.coreutils}/bin/chmod 660 ${sock}
               '';
+              stop = ''
+                function server_running {
+                  ${tmux} -S ${sock} has-session
+                }
 
-              openFirewall = mkOption {
-                type = types.bool;
-                default = cfg.openFirewall;
-                defaultText = "The value of <literal>services.minecraft-servers.openFirewall</literal>";
-                description = ''
-                  Whether to open ports in the firewall for this server.
-                '';
-              };
+                if ! server_running ; then
+                  exit 0
+                fi
 
-              restart = mkOpt' types.str "always" ''
-                Value of systemd's <literal>Restart=</literal> service configuration option.
-                If you are using the tmux management system (the default), values other than
-                <literal>"no"</literal> and <literal>"always"</literal> may not work properly.
-                As a consequence of the <literal>"always"</literal> option, stopping the server
-                in-game with the <literal>stop</literal> command will cause the server to automatically restart.
+                ${tmux} -S ${sock} send-keys ${escapeShellArg server.stopCommand} Enter
+
+                while server_running; do sleep 1s; done
               '';
-
-              enableReload = mkOpt' types.bool false ''
-                Reload server when configuration changes (instead of restart).
-
-                This action re-links/copies the declared symlinks/files. You can
-                include additional actions (even in-game commands) by setting
-                <option>services.minecraft-servers.<name>.extraReload</option>.
+            };
+          }
+        else if ms.systemd-socket.enable then
+          {
+            serviceConfig = {
+              Type = "simple";
+              StandardInput = "socket";
+              StandardOutput = "journal";
+              StandardError = "journal";
+            };
+            hooks = {
+              start = ''
+                ${getExe server.package} ${server.jvmOpts}
               '';
+              postStart = "";
+              stop = ''
+                ${optionalString (server.stopCommand != null) ''
+                  echo ${escapeShellArg server.stopCommand} > ${escapeShellArg (ms.systemd-socket.stdinSocket.path name)}
 
-              extraReload = mkOpt' types.lines "" ''
-                Extra commands to run when reloading the service. Only has an
-                effect if
-                <option>services.minecraft-servers.<name>.enableReload</option> is
-                true.
+                  while kill -0 "$1" 2> /dev/null; do sleep 1s; done
+                ''}
               '';
+            };
+          }
+        else
+          builtins.throw "At least one server management system must be enabled.";
 
-              extraStartPre = mkOpt' types.lines "" ''
-                Extra commands to run before starting the service.
-              '';
+      mkEnableOpt = description: mkBoolOpt' false description;
+    in
+    {
+      options.services.minecraft-servers = {
+        enable = mkEnableOpt ''
+          If enabled, the servers in <option>services.minecraft-servers.servers</option>
+          will be created and started as applicable.
+          The data for the servers will be loaded from and
+          saved to <option>services.minecraft-servers.dataDir</option>
+        '';
 
-              extraStartPost = mkOpt' types.lines "" ''
-                Extra commands to run after starting the service.
-              '';
+        eula = mkEnableOpt ''
+          Whether you agree to
+          <link xlink:href="https://account.mojang.com/documents/minecraft_eula">
+          Mojang's EULA</link>. This option must be set to
+          <literal>true</literal> to run Minecraft server.
+        '';
 
-              extraStopPre = mkOpt' types.lines "" ''
-                Extra commands to run before stopping the service.
-              '';
+        openFirewall = mkEnableOpt ''
+          Whether to open ports in the firewall for each server.
+          Sets the default for <option>services.minecraft-servers.servers.<name>.openFirewall</option>.
+        '';
 
-              extraStopPost = mkOpt' types.lines "" ''
-                Extra commands to run after stopping the service.
-              '';
+        dataDir = mkOpt' types.path "/srv/minecraft" ''
+          Directory to store the Minecraft servers.
+          Each server will be under a subdirectory named after
+          the server name in this directory, such as <literal>/srv/minecraft/servername</literal>.
+        '';
 
-              stopCommand = mkOption {
-                type = types.nullOr types.str;
-                description = ''
-                  Console command to run when cleanly stopping the server (ExecStop).
-                  Defaults to <literal>stop</literal>, which works for most servers.
-                  For proxies (bungeecord, velocity), you should set
-                  <literal>end</literal>.
+        runDir = mkOpt' types.path "/run/minecraft" ''
+          Deprecated: Directory to place the runtime tmux sockets into.
+          Each server's console will be a tmux socket file in the form of <literal>servername.sock</literal>.
+          To connect to the console, run `tmux -S /run/minecraft/servername.sock attach`,
+          press `Ctrl + b` then `d` to detach.
 
-                  If set to <literal>null</literal>, the server will be stopped by
-                  systemd without issuing any command.
-                '';
-                default = "stop";
-              };
+          Plase use <option>services.minecraft-servers.managementSystem.tmux.socketPath</option>` instead.
+        '';
 
-              whitelist = mkOption {
-                type =
-                  let
-                    minecraftUUID =
-                      types.strMatching "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-                      // {
-                        description = "Minecraft UUID";
-                      };
-                  in
-                  types.attrsOf minecraftUUID;
-                default = { };
-                description = ''
-                  Whitelisted players, only has an effect when
-                  enabled via <option>services.minecraft-servers.<name>.serverProperties</option>
-                  by setting <literal>white-list</literal> to <literal>true</literal>.
+        user = mkOption {
+          type = types.str;
+          default = "minecraft";
+          description = ''
+            Name of the user to create and run servers under.
+            It is recommended to leave this as the default, as it is
+            the same user as <option>services.minecraft-server</option>.
+          '';
+          internal = true;
+          visible = false;
+        };
 
-                  To use a non-declarative whitelist, enable the whitelist and don't fill in this value.
-                  As long as it is empty, no whitelist file is generated.
-                '';
-                example = literalExpression ''
-                  {
-                    username1 = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
-                    username2 = "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy";
-                  }
-                '';
-              };
+        group = mkOption {
+          type = types.str;
+          default = "minecraft";
+          description = ''
+            Name of the group to create and run servers under.
+            In order to modify the server files your user must be a part of this
+            group. If you are using the tmux management system (the default), you also need to be a part of this group to attach to the tmux socket.
+            It is recommended to leave this as the default, as it is
+            the same group as <option>services.minecraft-server</option>.
+          '';
+        };
 
-              operators = mkOption {
-                type =
-                  let
-                    minecraftUUID =
-                      types.strMatching "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-                      // {
-                        description = "Minecraft UUID";
-                      };
-                  in
-                  types.attrsOf (
-                    types.coercedTo minecraftUUID (v: { uuid = v; }) (
-                      types.submodule {
-                        options = {
-                          uuid = mkOption {
-                            type = minecraftUUID;
-                            description = "The operator's UUID";
-                            example = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+        environmentFile = mkOpt' (types.nullOr types.path) null ''
+          File consisting of lines in the form varname=value to define environment
+          variables for the minecraft servers.
+
+          Secrets (database passwords, secret keys, etc.) can be provided to server
+          files without adding them to the Nix store by defining them in the
+          environment file and referring to them in option
+          <option>services.minecraft-servers.servers.<name>.files</option> with the
+          syntax @varname@.
+        '';
+
+        managementSystem = mkOption {
+          type = managementSystem;
+          description = ''
+            The default management system for all servers.
+          '';
+          default = {
+            tmux.enable = true;
+          };
+          example = ''
+            {
+              tmux.enable = false;
+              systemd-socket.enable = true;
+            }
+          '';
+        };
+
+        servers = mkOption {
+          default = { };
+          description = ''
+            Servers to create and manage using this module.
+            Each server can be stopped with <literal>systemctl stop minecraft-server-servername</literal>.
+            ::: {.warning}
+            If the server is not stopped using `systemctl`, the service will automatically restart the server.
+            See <option>services.minecraft-servers.servers.<name>.restart</option>.
+            :::
+          '';
+          type = types.attrsOf (
+            types.submodule (
+              { name, ... }:
+              {
+                options = {
+                  enable = mkEnableOpt ''
+                    Whether to enable this server.
+                    If set to <literal>false</literal>, does NOT delete any data in the data directory,
+                    just does not generate the service file.
+                  '';
+
+                  autoStart = mkBoolOpt' true ''
+                    Whether to start this server on boot.
+                    If set to <literal>false</literal>, can still be started with
+                    <literal>systemctl start minecraft-server-servername</literal>.
+                    Requires the server to be enabled.
+                  '';
+
+                  openFirewall = mkOption {
+                    type = types.bool;
+                    default = cfg.openFirewall;
+                    defaultText = "The value of <literal>services.minecraft-servers.openFirewall</literal>";
+                    description = ''
+                      Whether to open ports in the firewall for this server.
+                    '';
+                  };
+
+                  restart = mkOpt' types.str "always" ''
+                    Value of systemd's <literal>Restart=</literal> service configuration option.
+                    If you are using the tmux management system (the default), values other than
+                    <literal>"no"</literal> and <literal>"always"</literal> may not work properly.
+                    As a consequence of the <literal>"always"</literal> option, stopping the server
+                    in-game with the <literal>stop</literal> command will cause the server to automatically restart.
+                  '';
+
+                  enableReload = mkOpt' types.bool false ''
+                    Reload server when configuration changes (instead of restart).
+
+                    This action re-links/copies the declared symlinks/files. You can
+                    include additional actions (even in-game commands) by setting
+                    <option>services.minecraft-servers.<name>.extraReload</option>.
+                  '';
+
+                  extraReload = mkOpt' types.lines "" ''
+                    Extra commands to run when reloading the service. Only has an
+                    effect if
+                    <option>services.minecraft-servers.<name>.enableReload</option> is
+                    true.
+                  '';
+
+                  extraStartPre = mkOpt' types.lines "" ''
+                    Extra commands to run before starting the service.
+                  '';
+
+                  extraStartPost = mkOpt' types.lines "" ''
+                    Extra commands to run after starting the service.
+                  '';
+
+                  extraStopPre = mkOpt' types.lines "" ''
+                    Extra commands to run before stopping the service.
+                  '';
+
+                  extraStopPost = mkOpt' types.lines "" ''
+                    Extra commands to run after stopping the service.
+                  '';
+
+                  stopCommand = mkOption {
+                    type = types.nullOr types.str;
+                    description = ''
+                      Console command to run when cleanly stopping the server (ExecStop).
+                      Defaults to <literal>stop</literal>, which works for most servers.
+                      For proxies (bungeecord, velocity), you should set
+                      <literal>end</literal>.
+
+                      If set to <literal>null</literal>, the server will be stopped by
+                      systemd without issuing any command.
+                    '';
+                    default = "stop";
+                  };
+
+                  whitelist = mkOption {
+                    type =
+                      let
+                        minecraftUUID =
+                          types.strMatching "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                          // {
+                            description = "Minecraft UUID";
                           };
-                          level = mkOption {
-                            type = types.ints.between 0 4;
-                            description = "The operator's permission level";
-                            default = 4;
+                      in
+                      types.attrsOf minecraftUUID;
+                    default = { };
+                    description = ''
+                      Whitelisted players, only has an effect when
+                      enabled via <option>services.minecraft-servers.<name>.serverProperties</option>
+                      by setting <literal>white-list</literal> to <literal>true</literal>.
+
+                      To use a non-declarative whitelist, enable the whitelist and don't fill in this value.
+                      As long as it is empty, no whitelist file is generated.
+                    '';
+                    example = literalExpression ''
+                      {
+                        username1 = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+                        username2 = "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy";
+                      }
+                    '';
+                  };
+
+                  operators = mkOption {
+                    type =
+                      let
+                        minecraftUUID =
+                          types.strMatching "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                          // {
+                            description = "Minecraft UUID";
                           };
-                          bypassesPlayerLimit = mkOption {
-                            type = types.bool;
-                            description = "If true, the operator can join the server even if the player limit has been reached";
-                            default = false;
-                          };
+                      in
+                      types.attrsOf (
+                        types.coercedTo minecraftUUID (v: { uuid = v; }) (
+                          types.submodule {
+                            options = {
+                              uuid = mkOption {
+                                type = minecraftUUID;
+                                description = "The operator's UUID";
+                                example = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+                              };
+                              level = mkOption {
+                                type = types.ints.between 0 4;
+                                description = "The operator's permission level";
+                                default = 4;
+                              };
+                              bypassesPlayerLimit = mkOption {
+                                type = types.bool;
+                                description = "If true, the operator can join the server even if the player limit has been reached";
+                                default = false;
+                              };
+                            };
+                          }
+                        )
+                      );
+                    default = { };
+                    description = ''
+                      Server operators. See <link xlink:href="https://minecraft.wiki/w/Ops.json_format"/>.
+
+                      To use a non-declarative operator list, don't fill in this value.
+                      As long as it is empty, no operators file is generated.
+                    '';
+                    example = literalExpression ''
+                      {
+                        username1 = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+                        username2 = {
+                          uuid = "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy";
+                          level = 3;
+                          bypassesPlayerLimit = true;
                         };
                       }
-                    )
-                  );
-                default = { };
-                description = ''
-                  Server operators. See <link xlink:href="https://minecraft.wiki/w/Ops.json_format"/>.
+                    '';
+                  };
 
-                  To use a non-declarative operator list, don't fill in this value.
-                  As long as it is empty, no operators file is generated.
-                '';
-                example = literalExpression ''
-                  {
-                    username1 = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
-                    username2 = {
-                      uuid = "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy";
-                      level = 3;
-                      bypassesPlayerLimit = true;
+                  serverProperties = mkOption {
+                    type =
+                      with types;
+                      attrsOf (oneOf [
+                        bool
+                        int
+                        str
+                      ]);
+                    default = { };
+                    example = literalExpression ''
+                      {
+                        server-port = 43000;
+                        difficulty = 3;
+                        gamemode = 1;
+                        max-players = 5;
+                        motd = "NixOS Minecraft server!";
+                        white-list = true;
+                        enable-rcon = true;
+                        "rcon.password" = "hunter2";
+                      }
+                    '';
+                    description = ''
+                      Minecraft server properties for the server.properties file of this server. See
+                      <link xlink:href="https://minecraft.gamepedia.com/Server.properties#Java_Edition_3"/>
+                      for documentation on these values.
+
+                      To use a non-declarative server.properties, don't fill in this value.
+                      As long as it is empty, no server.properties file is generated.
+                    '';
+                  };
+
+                  package = mkOption {
+                    description = "The Minecraft server package to use.";
+                    type = types.package;
+                    default = pkgs.minecraft-server;
+                    defaultText = literalExpression "pkgs.minecraft-server";
+                    example = "pkgs.minecraftServers.vanilla-1_18_2";
+                  };
+
+                  jvmOpts = mkOpt' (
+                    with types; coercedTo (listOf str) (lib.concatStringsSep " ") (separatedString " ")
+                  ) "-Xmx2G -Xms1G" "JVM options for this server.";
+
+                  path =
+                    with types;
+                    mkOpt' (listOf (either path str)) [ ] ''
+                      Packages added to the Minecraft server's <literal>PATH</literal> environment variable.
+                      Works as <option>systemd.services.<name>.path</option>.
+                    '';
+
+                  environment =
+                    with types;
+                    mkOpt'
+                      (attrsOf (
+                        nullOr (oneOf [
+                          str
+                          path
+                          package
+                        ])
+                      ))
+                      { }
+                      ''
+                        Environment variables added to the Minecraft server's processes.
+                        Works as <option>systemd.services.<name>.environment</option>.
+                      '';
+
+                  symlinks =
+                    with types;
+                    mkOpt' (attrsOf (either path configType)) { } ''
+                      Things to symlink into this server's data directory, in the form of
+                      a nix package/derivation. Can be used to declaratively manage
+                      arbitrary files in the server's data directory.
+                    '';
+                  files =
+                    with types;
+                    mkOpt' (attrsOf (either path configType)) { } ''
+                      Things to copy into this server's data directory. Similar to symlinks,
+                      but these are actual, writable, files. Useful for configuration files
+                      that don't behave well when read-only. Directories are copied recursively and
+                      dereferenced. They will be deleted after the server stops, so any modification
+                      is discarded.
+
+                      These files may include placeholders to substitute with values from
+                      <option>services.minecraft-servers.environmentFile</option>
+                      (i.e. @variable_name@).
+                    '';
+
+                  managementSystem = mkOption {
+                    type = types.submodule (
+                      managementSystem.getSubModules
+                      ++ [
+                        { config = mkDefault cfg.managementSystem; }
+                      ]
+                    );
+                    description = ''
+                      Configuration for the system used to manage this server. Overrides the global configuration on an option-by-option basis.
+                    '';
+                    default = { };
+                    example = options.services.minecraft-servers.managementSystem.example;
+                  };
+
+                  # <<< NEW LAZYMC OPTIONS >>>
+                  lazymc = {
+                    enable = mkEnableOpt "Enable lazymc to manage this server.";
+                    config = mkOption {
+                      type = types.attrs; # Freeform attrs, corresponds to lazymc.toml structure
+                      default = {};
+                      description = ''
+                        Configuration for lazymc, mirroring its TOML structure.
+                        Some values like server command, directory, and internal ports
+                        will be automatically configured.
+                      '';
+                      example = literalExpression ''
+                        {
+                          public.address = "0.0.0.0:25565"; # Public port for players
+                          time.sleep_after = 900; # Sleep after 15 minutes
+                          motd.sleeping = "Shhh, the server is napping!";
+                          server.forge = false; # Set to true if this is a Forge server
+                        }
+                      '';
                     };
-                  }
-                '';
-              };
-
-              serverProperties = mkOption {
-                type =
-                  with types;
-                  attrsOf (oneOf [
-                    bool
-                    int
-                    str
-                  ]);
-                default = { };
-                example = literalExpression ''
-                  {
-                    server-port = 43000;
-                    difficulty = 3;
-                    gamemode = 1;
-                    max-players = 5;
-                    motd = "NixOS Minecraft server!";
-                    white-list = true;
-                    enable-rcon = true;
-                    "rcon.password" = "hunter2";
-                  }
-                '';
-                description = ''
-                  Minecraft server properties for the server.properties file of this server. See
-                  <link xlink:href="https://minecraft.gamepedia.com/Server.properties#Java_Edition_3"/>
-                  for documentation on these values.
-
-                  To use a non-declarative server.properties, don't fill in this value.
-                  As long as it is empty, no server.properties file is generated.
-                '';
-              };
-
-              package = mkOption {
-                description = "The Minecraft server package to use.";
-                type = types.package;
-                default = pkgs.minecraft-server;
-                defaultText = literalExpression "pkgs.minecraft-server";
-                example = "pkgs.minecraftServers.vanilla-1_18_2";
-              };
-
-              jvmOpts = mkOpt' (
-                with types; coercedTo (listOf str) (lib.concatStringsSep " ") (separatedString " ")
-              ) "-Xmx2G -Xms1G" "JVM options for this server.";
-
-              path =
-                with types;
-                mkOpt' (listOf (either path str)) [ ] ''
-                  Packages added to the Minecraft server's <literal>PATH</literal> environment variable.
-                  Works as <option>systemd.services.<name>.path</option>.
-                '';
-
-              environment =
-                with types;
-                mkOpt'
-                  (attrsOf (
-                    nullOr (oneOf [
-                      str
-                      path
-                      package
-                    ])
-                  ))
-                  { }
-                  ''
-                    Environment variables added to the Minecraft server's processes.
-                    Works as <option>systemd.services.<name>.environment</option>.
-                  '';
-
-              symlinks =
-                with types;
-                mkOpt' (attrsOf (either path configType)) { } ''
-                  Things to symlink into this server's data directory, in the form of
-                  a nix package/derivation. Can be used to declaratively manage
-                  arbitrary files in the server's data directory.
-                '';
-              files =
-                with types;
-                mkOpt' (attrsOf (either path configType)) { } ''
-                  Things to copy into this server's data directory. Similar to symlinks,
-                  but these are actual, writable, files. Useful for configuration files
-                  that don't behave well when read-only. Directories are copied recursively and
-                  dereferenced. They will be deleted after the server stops, so any modification
-                  is discarded.
-
-                  These files may include placeholders to substitute with values from
-                  <option>services.minecraft-servers.environmentFile</option>
-                  (i.e. @variable_name@).
-                '';
-
-              managementSystem = mkOption {
-                type = types.submodule (
-                  managementSystem.getSubModules
-                  ++ [
-                    { config = mkDefault cfg.managementSystem; }
-                  ]
-                );
-                description = ''
-                  Configuration for the system used to manage this server. Overrides the global configuration on an option-by-option basis.
-                '';
-                default = { };
-                example = options.services.minecraft-servers.managementSystem.example;
-              };
-
-              # <<< NEW LAZYMC OPTIONS >>>
-              lazymc = {
-                enable = mkEnableOpt "Enable lazymc to manage this server.";
-                config = mkOption {
-                  type = types.attrs; # Freeform attrs, corresponds to lazymc.toml structure
-                  default = {};
-                  description = ''
-                    Configuration for lazymc, mirroring its TOML structure.
-                    Some values like server command, directory, and internal ports
-                    will be automatically configured.
-                  '';
-                  example = literalExpression ''
-                    {
-                      public.address = "0.0.0.0:25565"; # Public port for players
-                      time.sleep_after = 900; # Sleep after 15 minutes
-                      motd.sleeping = "Shhh, the server is napping!";
-                      server.forge = false; # Set to true if this is a Forge server
-                    }
-                  '';
+                  };
+                  # <<< END NEW LAZYMC OPTIONS >>>
                 };
-              };
-              # <<< END NEW LAZYMC OPTIONS >>>
-            };
-          }
-        )
-      );
-    };
-  };
-
-  config = mkIf cfg.enable (
-    let
-      servers = filterAttrs (_: cfg: cfg.enable) cfg.servers;
-    in
-    {
-      users = {
-        users.minecraft = mkIf (cfg.user == "minecraft") {
-          description = "Minecraft server service user";
-          home = cfg.dataDir;
-          createHome = true;
-          homeMode = "770";
-          isSystemUser = true;
-          group = "minecraft";
+              }
+            )
+          );
         };
-        groups.minecraft = mkIf (cfg.group == "minecraft") { };
       };
 
-      assertions = [
-        {
-          assertion = cfg.eula;
-          message =
-            "You must agree to Mojangs EULA to run minecraft-servers."
-            + " Read https://account.mojang.com/documents/minecraft_eula and"
-            + " set `services.minecraft-servers.eula` to `true` if you agree.";
-        }
-        {
-          assertion =
-            config.services.minecraft-server.enable -> cfg.dataDir != config.services.minecraft-server.dataDir;
-          message =
-            "`services.minecraft-servers.dataDir` and `services.minecraft-server.dataDir` conflict."
-            + " Set one to use a different data directory.";
-        }
-        {
-          assertion =
-            let
-              serverPorts = mapAttrsToList (name: conf:
-                if conf.lazymc.enable then
-                  let
-                    parsePort = addrStr: builtins.elemAt (lib.splitString ":" addrStr) 1;
-                    defaultPublicPort = toString (conf.serverProperties."server-port" or 25565);
-                    lazymcPublicAddr = conf.lazymc.config.public.address or "0.0.0.0:${defaultPublicPort}";
-                  in
-                  lib.toInt (parsePort lazymcPublicAddr)
-                else
-                  conf.serverProperties."server-port" or 25565
-              ) (filterAttrs (_: filterConf: filterConf.openFirewall) servers);
-              counts = map (port: count (x: x == port) serverPorts) (unique serverPorts);
-            in
-            lib.all (x: x == 1) counts;
-          message = "Multiple servers are set to use the same public port. Change one to use a different port.";
-        }
-      ];
-
-      warnings = lib.optional (cfg.runDir != options.services.minecraft-servers.runDir.default) ''
-        `runDir` has been deprecated.
-
-        Please use `services.minecraft-servers.managementSystem.tmux.socketPath` instead.
-        For example, `name: "${cfg.runDir}/''${name}.sock"`.
-
-        See the changelog file for more information.
-      '';
-
-      networking.firewall =
+      config = mkIf cfg.enable (
         let
-          toOpen = filterAttrs (_: firewallConf: firewallConf.openFirewall) servers;
-          getTCPPorts = n: c:
-            if c.lazymc.enable then
-              let
-                parsePort = addrStr: builtins.elemAt (lib.splitString ":" addrStr) 1;
-                defaultPublicPort = toString (c.serverProperties."server-port" or 25565);
-                lazymcPublicAddr = c.lazymc.config.public.address or "0.0.0.0:${defaultPublicPort}";
-              in
-              [ (lib.toInt (parsePort lazymcPublicAddr)) ]
-            else # lazymc disabled, open MC server port and RCON port if enabled
-              [ (c.serverProperties."server-port" or 25565) ];
-              # ++ (lib.optional (c.serverProperties.enable-rcon or false) (c.serverProperties."rcon.port" or 25575));
-
-          getUDPPorts =
-            n: c:
-            # Lazymc does not proxy query protocol, so query port is always direct to MC server
-            optional (c.serverProperties.enable-query or false) (
-              if c.lazymc.enable then
-                # If lazymc is on, MC server runs on an internal port. Query port in server.properties should reflect this.
-                ( (c.serverProperties."server-port" or 25565) - 1 ) # Assuming query port is same as internal game port, or needs separate internal config
-              else
-                (c.serverProperties."query.port" or 25565) # Direct MC server query port
-            );
+          servers = filterAttrs (_: cfg: cfg.enable) cfg.servers;
         in
         {
-          allowedUDPPorts = flatten (mapAttrsToList getUDPPorts toOpen);
-          allowedTCPPorts = flatten (mapAttrsToList getTCPPorts toOpen);
-        };
-
-      systemd.tmpfiles.rules = mapAttrsToList (
-        name: _: "d '${cfg.dataDir}/${name}' 0770 ${cfg.user} ${cfg.group} - -"
-      ) servers;
-
-      systemd.sockets = pipe servers [
-        (filterAttrs (name: server: !server.lazymc.enable && server.managementSystem.systemd-socket.enable)) # Only for non-lazymc systemd-socket
-        (mapAttrs' (
-          name: server: {
-            name = "minecraft-server-${name}";
-            value = {
-              requires = [ "minecraft-server-${name}.service" ];
-              partOf = [ "minecraft-server-${name}.service" ];
-              socketConfig =
-                let
-                  socketConf = server.managementSystem.systemd-socket.stdinSocket;
-                in
-                {
-                  ListenFIFO = socketConf.path name;
-                  SocketMode = socketConf.mode;
-                  SocketUser = cfg.user;
-                  SocketGroup = cfg.group;
-                  RemoveOnStop = true;
-                  FlushPending = true;
-                };
+          users = {
+            users.minecraft = mkIf (cfg.user == "minecraft") {
+              description = "Minecraft server service user";
+              home = cfg.dataDir;
+              createHome = true;
+              homeMode = "770";
+              isSystemUser = true;
+              group = "minecraft";
             };
-          }
-        ))
-      ];
-
-      systemd.services = mapAttrs' (
-        name: conf:
-        let
-          originalMcPort = conf.serverProperties."server-port" or 25565;
-          originalMcRconEnabled = conf.serverProperties.enable-rcon or false;
-          originalMcRconPort = conf.serverProperties."rcon.port" or 25575;
-
-          internalMcPort = if conf.lazymc.enable then originalMcPort - 1 else originalMcPort;
-          internalMcRconPort = if conf.lazymc.enable then originalMcRconPort - 1 else originalMcRconPort;
-
-          finalServerPropertiesForMc = conf.serverProperties // lib.optionalAttrs conf.lazymc.enable {
-            "server-port" = internalMcPort;
-          } // lib.optionalAttrs (conf.lazymc.enable && originalMcRconEnabled) {
-            "rcon.port" = internalMcRconPort;
-            # Ensure RCON is enabled in server.properties for lazymc if it was originally
-            "enable-rcon" = true;
+            groups.minecraft = mkIf (cfg.group == "minecraft") { };
           };
 
-          symlinks = normalizeFiles (
+          assertions = [
             {
-              "eula.txt".value = {
-                eula = true;
-              };
-              "eula.txt".format = pkgs.formats.keyValue { };
+              assertion = cfg.eula;
+              message =
+                "You must agree to Mojangs EULA to run minecraft-servers."
+                + " Read https://account.mojang.com/documents/minecraft_eula and"
+                + " set `services.minecraft-servers.eula` to `true` if you agree.";
             }
-            // conf.symlinks
-          );
-          files = normalizeFiles (
             {
-              "whitelist.json".value = mapAttrsToList (n: v: {
-                name = n;
-                uuid = v;
-              }) conf.whitelist;
-              "ops.json".value = mapAttrsToList (n: v: {
-                name = n;
-                uuid = v.uuid;
-                level = v.level;
-                bypassesPlayerLimit = v.bypassesPlayerLimit;
-              }) conf.operators;
-              "server.properties".value = finalServerPropertiesForMc;
+              assertion =
+                config.services.minecraft-server.enable -> cfg.dataDir != config.services.minecraft-server.dataDir;
+              message =
+                "`services.minecraft-servers.dataDir` and `services.minecraft-server.dataDir` conflict."
+                + " Set one to use a different data directory.";
             }
-            // conf.files
-          );
+            {
+              assertion =
+                let
+                  serverPorts = mapAttrsToList (name: conf:
+                    if conf.lazymc.enable then
+                      let
+                        parsePort = addrStr: builtins.elemAt (lib.splitString ":" addrStr) 1;
+                        defaultPublicPort = toString (conf.serverProperties."server-port" or 25565);
+                        lazymcPublicAddr = conf.lazymc.config.public.address or "0.0.0.0:${defaultPublicPort}";
+                      in
+                      lib.toInt (parsePort lazymcPublicAddr)
+                    else
+                      conf.serverProperties."server-port" or 25565
+                  ) (filterAttrs (_: filterConf: filterConf.openFirewall) servers);
+                  counts = map (port: count (x: x == port) serverPorts) (unique serverPorts);
+                in
+                lib.all (x: x == 1) counts;
+              message = "Multiple servers are set to use the same public port. Change one to use a different port.";
+            }
+          ];
 
-          lazymcTomlGenerated =
-            let
-              defaultLazymcConfig = {
-                public = {
-                  address = "0.0.0.0:${toString originalMcPort}";
-                };
-                server = {
-                  address = "127.0.0.1:${toString internalMcPort}";
-                  directory = "${cfg.dataDir}/${name}"; # "${cfg.dataDir}/${name}";
-                  command = "${getExe conf.package} ${conf.jvmOpts}";
-                };
-                rcon = lib.optionalAttrs originalMcRconEnabled {
-                  enabled = true;
-                  port = internalMcRconPort;
-                };
-                advanced = {
-                  rewrite_server_properties = false;
-                };
-                config = {
-                  version = pkgs.lazymc.version;
-                };
-              };
-              finalLazymcNixConfig = lib.recursiveUpdate defaultLazymcConfig conf.lazymc.config;
-            in
-            pkgs.writers.writeTOML "lazymc-config-${name}.toml" finalLazymcNixConfig;
+          warnings = lib.optional (cfg.runDir != options.services.minecraft-servers.runDir.default) ''
+            `runDir` has been deprecated.
 
+            Please use `services.minecraft-servers.managementSystem.tmux.socketPath` instead.
+            For example, `name: "${cfg.runDir}/''${name}.sock"`.
 
-          msConfig = managementSystemConfig name conf; # For non-lazymc case
-
-          markManaged = file: ''echo "${file}" >> .nix-minecraft-managed'';
-          cleanAllManaged = ''
-            if [ -e .nix-minecraft-managed ]; then
-              readarray -t to_delete < .nix-minecraft-managed
-              rm -rf "''${to_delete[@]}"
-              rm .nix-minecraft-managed
-            fi
+            See the changelog file for more information.
           '';
 
-          ExecStartPre =
+          networking.firewall =
             let
-              backup = file: ''
-                if [[ -e "${file}" ]]; then
-                  echo "${file} already exists, moving"
-                  mv "${file}" "${file}.bak"
+              toOpen = filterAttrs (_: firewallConf: firewallConf.openFirewall) servers;
+              getTCPPorts = n: c:
+                if c.lazymc.enable then
+                  let
+                    parsePort = addrStr: builtins.elemAt (lib.splitString ":" addrStr) 1;
+                    defaultPublicPort = toString (c.serverProperties."server-port" or 25565);
+                    lazymcPublicAddr = c.lazymc.config.public.address or "0.0.0.0:${defaultPublicPort}";
+                  in
+                  [ (lib.toInt (parsePort lazymcPublicAddr)) ]
+                else # lazymc disabled, open MC server port and RCON port if enabled
+                  [ (c.serverProperties."server-port" or 25565) ];
+                  # ++ (lib.optional (c.serverProperties.enable-rcon or false) (c.serverProperties."rcon.port" or 25575));
+
+              getUDPPorts =
+                n: c:
+                # Lazymc does not proxy query protocol, so query port is always direct to MC server
+                optional (c.serverProperties.enable-query or false) (
+                  if c.lazymc.enable then
+                    # If lazymc is on, MC server runs on an internal port. Query port in server.properties should reflect this.
+                    ( (c.serverProperties."server-port" or 25565) - 1 ) # Assuming query port is same as internal game port, or needs separate internal config
+                  else
+                    (c.serverProperties."query.port" or 25565) # Direct MC server query port
+                );
+            in
+            {
+              allowedUDPPorts = flatten (mapAttrsToList getUDPPorts toOpen);
+              allowedTCPPorts = flatten (mapAttrsToList getTCPPorts toOpen);
+            };
+
+          systemd.tmpfiles.rules = mapAttrsToList (
+            name: _: "d '${cfg.dataDir}/${name}' 0770 ${cfg.user} ${cfg.group} - -"
+          ) servers;
+
+          systemd.sockets = pipe servers [
+            (filterAttrs (name: server: !server.lazymc.enable && server.managementSystem.systemd-socket.enable)) # Only for non-lazymc systemd-socket
+            (mapAttrs' (
+              name: server: {
+                name = "minecraft-server-${name}";
+                value = {
+                  requires = [ "minecraft-server-${name}.service" ];
+                  partOf = [ "minecraft-server-${name}.service" ];
+                  socketConfig =
+                    let
+                      socketConf = server.managementSystem.systemd-socket.stdinSocket;
+                    in
+                    {
+                      ListenFIFO = socketConf.path name;
+                      SocketMode = socketConf.mode;
+                      SocketUser = cfg.user;
+                      SocketGroup = cfg.group;
+                      RemoveOnStop = true;
+                      FlushPending = true;
+                    };
+                };
+              }
+            ))
+          ];
+
+          systemd.services = mapAttrs' (
+            name: conf:
+            let
+              originalMcPort = conf.serverProperties."server-port" or 25565;
+              originalMcRconEnabled = conf.serverProperties.enable-rcon or false;
+              originalMcRconPort = conf.serverProperties."rcon.port" or 25575;
+
+              # --- REVISED LOGIC FOR INTERNAL PORTS FOR server.properties ---
+              # True if user explicitly sets lazymc's public port OR lazymc's internal server port
+              userHasCustomizedLazymcPorts = conf.lazymc.enable && (
+                (conf.lazymc.config.public ? address) || (conf.lazymc.config.server ? address)
+              );
+              # True if user explicitly sets lazymc's RCON port (for lazymc to connect to MC RCON)
+              userHasCustomizedLazymcRconPort = conf.lazymc.enable && (conf.lazymc.config.rcon ? port);
+
+
+              # This is the port the actual Minecraft server JAR will be configured to listen on
+              # via the server.properties we generate.
+              internalMcPortForServerProperties =
+                if conf.lazymc.enable && !userHasCustomizedLazymcPorts then
+                  originalMcPort - 1 # Lazymc enabled, user did NOT customize relevant ports, so we offset
+                else
+                  originalMcPort;    # Lazymc disabled, OR user IS customizing lazymc ports
+
+              internalMcRconPortForServerProperties =
+                if conf.lazymc.enable && originalMcRconEnabled && !userHasCustomizedLazymcRconPort then
+                  originalMcRconPort - 1 # Lazymc + RCON enabled, user did NOT customize lazymc RCON port, so we offset
+                else
+                  originalMcRconPort;   # Lazymc disabled, or RCON disabled, or user IS customizing lazymc RCON port
+              # --- END REVISED LOGIC ---
+
+
+    #          internalMcPort = if conf.lazymc.enable then originalMcPort - 1 else originalMcPort;
+    #          internalMcRconPort = if conf.lazymc.enable then originalMcRconPort - 1 else originalMcRconPort;
+
+              finalServerPropertiesForMc = conf.serverProperties // lib.optionalAttrs conf.lazymc.enable {
+                "server-port" = internalMcPortForServerProperties;
+              } // lib.optionalAttrs (conf.lazymc.enable && originalMcRconEnabled) {
+                "rcon.port" = internalMcRconPortForServerProperties;
+                "enable-rcon" = true;
+              };
+
+              symlinks = normalizeFiles (
+                {
+                  "eula.txt".value = {
+                    eula = true;
+                  };
+                  "eula.txt".format = pkgs.formats.keyValue { };
+                }
+                // conf.symlinks
+              );
+              files = normalizeFiles (
+                {
+                  "whitelist.json".value = mapAttrsToList (n: v: {
+                    name = n;
+                    uuid = v;
+                  }) conf.whitelist;
+                  "ops.json".value = mapAttrsToList (n: v: {
+                    name = n;
+                    uuid = v.uuid;
+                    level = v.level;
+                    bypassesPlayerLimit = v.bypassesPlayerLimit;
+                  }) conf.operators;
+                  "server.properties".value = finalServerPropertiesForMc;
+                }
+                // conf.files
+              );
+
+              lazymcTomlGenerated =
+                let
+                  # Public port for users to connect to lazymc
+                  effectivePublicAddress = conf.lazymc.config.public.address or "0.0.0.0:${toString originalMcPort}";
+
+                  # The address lazymc will use for the Minecraft server it manages
+                  effectiveLazymcInternalServerAddress =
+                    if conf.lazymc.config.server ? address then # User explicitly sets lazymc's internal server target
+                      conf.lazymc.config.server.address
+                    else # Lazymc targets the port we configured for the Minecraft server
+                      "127.0.0.1:${toString internalMcPortForServerProperties}";
+
+                  effectiveLazymcInternalRconPort =
+                    if conf.lazymc.config.rcon ? port then # User explicitly sets lazymc's internal RCON target
+                      conf.lazymc.config.rcon.port
+                    else # Lazymc targets the RCON port we configured for the Minecraft server
+                      internalMcRconPortForServerProperties;
+
+                  defaultLazymcConfig = {
+                    public = {
+                      address = effectivePublicAddress;
+                    };
+                    server = {
+                      address = effectiveLazymcInternalServerAddress;
+                      directory = "."; # Lazymc runs in the server's dataDir
+                      command = "${getExe conf.package} ${conf.jvmOpts}";
+                    };
+                    rcon = lib.optionalAttrs originalMcRconEnabled {
+                      enabled = true; # If MC had RCON, lazymc should be configured to use it
+                      port = effectiveLazymcInternalRconPort;
+                    };
+                    advanced = {
+                      # Let lazymc manage server.properties.
+                      # It will ensure the actual Minecraft server runs on the port specified
+                      # in this lazymc.toml's `server.address`.
+                      rewrite_server_properties = true;
+                    };
+                    config = {
+                      version = pkgs.lazymc.version;
+                    };
+                  };
+                  finalLazymcNixConfig = lib.recursiveUpdate defaultLazymcConfig conf.lazymc.config;
+                in
+                pkgs.writers.writeTOML "lazymc-config-${name}.toml" finalLazymcNixConfig;
+
+
+              msConfig = managementSystemConfig name conf; # For non-lazymc case
+
+              markManaged = file: ''echo "${file}" >> .nix-minecraft-managed'';
+              cleanAllManaged = ''
+                if [ -e .nix-minecraft-managed ]; then
+                  readarray -t to_delete < .nix-minecraft-managed
+                  rm -rf "''${to_delete[@]}"
+                  rm .nix-minecraft-managed
                 fi
               '';
-              mkSymlinks = concatStringsSep "\n" (
-                mapAttrsToList (n: v: ''
-                  ${backup n}
-                  mkdir -p "$(dirname "${n}")"
 
-                  ln -sf "${v}" "${n}"
+              ExecStartPre =
+                let
+                  backup = file: ''
+                    if [[ -e "${file}" ]]; then
+                      echo "${file} already exists, moving"
+                      mv "${file}" "${file}.bak"
+                    fi
+                  '';
+                  mkSymlinks = concatStringsSep "\n" (
+                    mapAttrsToList (n: v: ''
+                      ${backup n}
+                      mkdir -p "$(dirname "${n}")"
 
-                  ${markManaged n}
-                '') symlinks
-              );
+                      ln -sf "${v}" "${n}"
 
-              mkFiles = concatStringsSep "\n" (
-                mapAttrsToList (n: v: ''
-                  ${backup n}
-                  mkdir -p "$(dirname "${n}")"
+                      ${markManaged n}
+                    '') symlinks
+                  );
 
-                  # If it's not a binary, substitute env vars. Else, copy it normally
-                  if ${pkgs.file}/bin/file --mime-encoding "${v}" | grep -v '\bbinary$' -q; then
-                    ${pkgs.gawk}/bin/awk '{
-                      for(varname in ENVIRON)
-                        gsub("@"varname"@", ENVIRON[varname])
-                      print
-                    }' "${v}" > "${n}"
-                  else
-                    cp -r --dereference "${v}" -T "${n}"
-                    chmod +w -R "${n}"
-                  fi
+                  mkFiles = concatStringsSep "\n" (
+                    mapAttrsToList (n: v: ''
+                      ${backup n}
+                      mkdir -p "$(dirname "${n}")"
 
-                  ${markManaged n}
-                '') files
-              );
-              mkLazymcConfig = lib.optionalString conf.lazymc.enable ''
-                ${backup "lazymc.toml"}
-                ln -sf "${lazymcTomlGenerated}" "lazymc.toml"
-                ${markManaged "lazymc.toml"}
-              '';
-            in
-            getExe (
-              pkgs.writeShellApplication {
-                name = "minecraft-server-${name}-start-pre";
-                text = ''
-                  ${cleanAllManaged}
-                  ${mkSymlinks}
-                  ${mkFiles}
-                  ${mkLazymcConfig}
-                  ${conf.extraStartPre}
-                '';
-              }
-            );
+                      # If it's not a binary, substitute env vars. Else, copy it normally
+                      if ${pkgs.file}/bin/file --mime-encoding "${v}" | grep -v '\bbinary$' -q; then
+                        ${pkgs.gawk}/bin/awk '{
+                          for(varname in ENVIRON)
+                            gsub("@"varname"@", ENVIRON[varname])
+                          print
+                        }' "${v}" > "${n}"
+                      else
+                        cp -r --dereference "${v}" -T "${n}"
+                        chmod +w -R "${n}"
+                      fi
 
-          finalExecStartCmd = if conf.lazymc.enable then
-            "${pkgs.lazymc}/bin/lazymc start --config lazymc.toml"
-          else
-            msConfig.hooks.start;
+                      ${markManaged n}
+                    '') files
+                  );
+                  mkLazymcConfig = lib.optionalString conf.lazymc.enable ''
+                    ${backup "lazymc.toml"}
+                    ln -sf "${lazymcTomlGenerated}" "lazymc.toml"
+                    ${markManaged "lazymc.toml"}
+                  '';
+                in
+                getExe (
+                  pkgs.writeShellApplication {
+                    name = "minecraft-server-${name}-start-pre";
+                    text = ''
+                      ${cleanAllManaged}
+                      ${mkSymlinks}
+                      ${mkFiles}
+                      ${mkLazymcConfig}
+                      ${conf.extraStartPre}
+                    '';
+                  }
+                );
 
-          ExecStart = getExe (
-            pkgs.writeShellApplication {
-              name = "minecraft-server-${name}-start";
-              text = finalExecStartCmd;
-            }
-          );
-          
-          finalServiceConfig = if conf.lazymc.enable then {
-            Type = "simple"; # lazymc runs in foreground
-            StandardOutput = "journal";
-            StandardError = "journal";
-            # ExecStop sends SIGTERM to lazymc, which handles stopping Minecraft
-          } else msConfig.serviceConfig;
+              finalExecStartCmd = if conf.lazymc.enable then
+                "${pkgs.lazymc}/bin/lazymc start --config lazymc.toml"
+              else
+                msConfig.hooks.start;
 
-          ExecStartPost = lib.optionalString (!conf.lazymc.enable) (getExe (
-            pkgs.writeShellApplication {
-              name = "minecraft-server-${name}-start-post";
-              text = ''
-                ${msConfig.hooks.postStart}
-                ${conf.extraStartPost}
-              '';
-            }
-          ));
-
-          execStopScript = lib.optionalString (!conf.lazymc.enable) (
-            let
-              script = getExe (
+              ExecStart = getExe (
                 pkgs.writeShellApplication {
-                  name = "minecraft-server-${name}-stop";
+                  name = "minecraft-server-${name}-start";
+                  text = finalExecStartCmd;
+                }
+              );
+              
+              finalServiceConfig = if conf.lazymc.enable then {
+                Type = "simple"; # lazymc runs in foreground
+                StandardOutput = "journal";
+                StandardError = "journal";
+                # ExecStop sends SIGTERM to lazymc, which handles stopping Minecraft
+              } else msConfig.serviceConfig;
+
+              ExecStartPost = lib.optionalString (!conf.lazymc.enable) (getExe (
+                pkgs.writeShellApplication {
+                  name = "minecraft-server-${name}-start-post";
                   text = ''
-                    # systemd has no ExecStopPre hook, so we just run it here.
-                    ${conf.extraStopPre}
-                    ${msConfig.hooks.stop}
+                    ${msConfig.hooks.postStart}
+                    ${conf.extraStartPost}
+                  '';
+                }
+              ));
+
+              execStopScript = lib.optionalString (!conf.lazymc.enable) (
+                let
+                  script = getExe (
+                    pkgs.writeShellApplication {
+                      name = "minecraft-server-${name}-stop";
+                      text = ''
+                        # systemd has no ExecStopPre hook, so we just run it here.
+                        ${conf.extraStopPre}
+                        ${msConfig.hooks.stop}
+                      '';
+                    }
+                  );
+                in
+                "${script} $MAINPID"
+              );
+
+              ExecStopPost = getExe (
+                pkgs.writeShellApplication {
+                  name = "minecraft-server-${name}-stop-post";
+                  text = ''
+                    ${cleanAllManaged}
+                    ${lib.optionalString (!conf.lazymc.enable) conf.extraStopPost}
+                  '';
+                }
+              );
+
+              ExecReload = getExe (
+                pkgs.writeShellApplication {
+                  name = "minecraft-server-${name}-reload";
+                  text = ''
+                    ${ExecStopPost} # This contains cleanAllManaged
+                    ${ExecStartPre} # This regenerates files including lazymc.toml
+                    ${conf.extraReload}
                   '';
                 }
               );
             in
-            "${script} $MAINPID"
-          );
+            {
+              name = "minecraft-server-${name}";
+              value = {
+                description = "Minecraft Server ${name}" + (if conf.lazymc.enable then " (managed by lazymc)" else "");
+                wantedBy = mkIf conf.autoStart [ "multi-user.target" ];
+                requires = optional (!conf.lazymc.enable && conf.managementSystem.systemd-socket.enable) "minecraft-server-${name}.socket";
+                partOf = optional (!conf.lazymc.enable && conf.managementSystem.systemd-socket.enable) "minecraft-server-${name}.socket";
+                after = [
+                  "network.target"
+                ] ++ optional (!conf.lazymc.enable && conf.managementSystem.systemd-socket.enable) "minecraft-server-${name}.socket";
 
-          ExecStopPost = getExe (
-            pkgs.writeShellApplication {
-              name = "minecraft-server-${name}-stop-post";
-              text = ''
-                ${cleanAllManaged}
-                ${lib.optionalString (!conf.lazymc.enable) conf.extraStopPost}
-              '';
+                enable = conf.enable;
+
+                startLimitIntervalSec = 120;
+                startLimitBurst = 5;
+
+                serviceConfig = {
+                  inherit
+                    ExecStartPre
+                    ExecStart
+                    ExecStartPost
+                    ExecStopPost
+                    ExecReload
+                    ;
+                  ExecStop = execStopScript;
+                  
+                  # the Minecraft server (as of 1.20.6) has a 60s timeout for saving each world.
+                  # let's let it handle potential lock-ups by itself before resorting to killing it.
+                  TimeoutStopSec = "1min 15s";
+
+                  Restart = conf.restart;
+                  WorkingDirectory = "${cfg.dataDir}/${name}";
+                  User = cfg.user;
+                  Group = cfg.group;
+                  EnvironmentFile = mkIf (cfg.environmentFile != null) (toString cfg.environmentFile);
+
+                  # Default directory for management sockets
+                  RuntimeDirectory = "minecraft";
+                  RuntimeDirectoryPreserve = "yes";
+
+                  # Hardening
+                  CapabilityBoundingSet = [ "" ];
+                  DeviceAllow = [ "" ];
+                  LockPersonality = true;
+                  PrivateDevices = true;
+                  PrivateTmp = true;
+                  PrivateUsers = true;
+                  ProtectClock = true;
+                  ProtectControlGroups = true;
+                  ProtectHome = true;
+                  ProtectHostname = true;
+                  ProtectKernelLogs = true;
+                  ProtectKernelModules = true;
+                  ProtectKernelTunables = true;
+                  ProtectProc = "invisible";
+                  RestrictAddressFamilies = [
+                    "AF_UNIX"
+                    "AF_INET"
+                    "AF_INET6"
+                  ];
+                  RestrictNamespaces = true;
+                  RestrictRealtime = true;
+                  RestrictSUIDSGID = true;
+                  SystemCallArchitectures = "native";
+                  UMask = "0007";
+                } // finalServiceConfig;
+
+                restartIfChanged = !conf.enableReload;
+                reloadIfChanged = conf.enableReload;
+
+                inherit (conf) path environment;
+              };
             }
-          );
-
-          ExecReload = getExe (
-            pkgs.writeShellApplication {
-              name = "minecraft-server-${name}-reload";
-              text = ''
-                ${ExecStopPost} # This contains cleanAllManaged
-                ${ExecStartPre} # This regenerates files including lazymc.toml
-                ${conf.extraReload}
-              '';
-            }
-          );
-        in
-        {
-          name = "minecraft-server-${name}";
-          value = {
-            description = "Minecraft Server ${name}" + (if conf.lazymc.enable then " (managed by lazymc)" else "");
-            wantedBy = mkIf conf.autoStart [ "multi-user.target" ];
-            requires = optional (!conf.lazymc.enable && conf.managementSystem.systemd-socket.enable) "minecraft-server-${name}.socket";
-            partOf = optional (!conf.lazymc.enable && conf.managementSystem.systemd-socket.enable) "minecraft-server-${name}.socket";
-            after = [
-              "network.target"
-            ] ++ optional (!conf.lazymc.enable && conf.managementSystem.systemd-socket.enable) "minecraft-server-${name}.socket";
-
-            enable = conf.enable;
-
-            startLimitIntervalSec = 120;
-            startLimitBurst = 5;
-
-            serviceConfig = {
-              inherit
-                ExecStartPre
-                ExecStart
-                ExecStartPost
-                ExecStopPost
-                ExecReload
-                ;
-              ExecStop = execStopScript;
-              
-              # the Minecraft server (as of 1.20.6) has a 60s timeout for saving each world.
-              # let's let it handle potential lock-ups by itself before resorting to killing it.
-              TimeoutStopSec = "1min 15s";
-
-              Restart = conf.restart;
-              WorkingDirectory = "${cfg.dataDir}/${name}";
-              User = cfg.user;
-              Group = cfg.group;
-              EnvironmentFile = mkIf (cfg.environmentFile != null) (toString cfg.environmentFile);
-
-              # Default directory for management sockets
-              RuntimeDirectory = "minecraft";
-              RuntimeDirectoryPreserve = "yes";
-
-              # Hardening
-              CapabilityBoundingSet = [ "" ];
-              DeviceAllow = [ "" ];
-              LockPersonality = true;
-              PrivateDevices = true;
-              PrivateTmp = true;
-              PrivateUsers = true;
-              ProtectClock = true;
-              ProtectControlGroups = true;
-              ProtectHome = true;
-              ProtectHostname = true;
-              ProtectKernelLogs = true;
-              ProtectKernelModules = true;
-              ProtectKernelTunables = true;
-              ProtectProc = "invisible";
-              RestrictAddressFamilies = [
-                "AF_UNIX"
-                "AF_INET"
-                "AF_INET6"
-              ];
-              RestrictNamespaces = true;
-              RestrictRealtime = true;
-              RestrictSUIDSGID = true;
-              SystemCallArchitectures = "native";
-              UMask = "0007";
-            } // finalServiceConfig;
-
-            restartIfChanged = !conf.enableReload;
-            reloadIfChanged = conf.enableReload;
-
-            inherit (conf) path environment;
-          };
+          ) servers;
         }
-      ) servers;
+      );
     }
-  );
-}


### PR DESCRIPTION
Solves https://github.com/Infinidoge/nix-minecraft/issues/142
This adds the options:
```nix
        lazymc = {
          enable = true;
          package = pkgs.lazymc;
          config = { ... };
        };
```
Under each instance. This makes servers go to sleep when there are no players and wake up when one player tries to join [lazymc](https://github.com/timvisee/lazymc)

When simply set with `lazymc.enable = true;` It will displace the minecraft `server-port` to one port before, and `lazymc` will run on `serverProperties.server-port` instead, so it's a single switch activation. But if `lazymc.config.public.address` or `lazymc.config.server.address` is set, then the minecraft `server-port` will be respected again. All this is described in the README section I added in the pr, witch I'm going to add below as well. All the options were tested

#### `servers.<name>.lazymc`

Integrates [lazymc](https://github.com/timvisee/lazymc) to manage the server's lifecycle, putting it to sleep when idle and waking it upon player connection. Because server startup is now handeled by lazymc, there is no tmux anymore, you'll need `rcon` or to disable `lazymc` to make a player`op`.

*   **`enable`**: `boolean`, default `false`
    Whether to enable lazymc for this server instance. When enabled, lazymc will take over starting and stopping the Minecraft server process.

*   **`package`**: `package`, default `pkgs.lazymc`
    The specific `lazymc` package to use for this server instance. Allows overriding the default `lazymc` from `pkgs`.
    You might have to change lazymc version according to your minecraft server version, for example lazymc v0.2.10 supports Minecraft Java Edition 1.7.2+, while for Minecraft Java Edition 1.20.3+ you'll need lazymc v0.2.11

*   **`config`**: `attribute set`, default `{}`
    Allows overriding settings in the `lazymc.toml` configuration file that this module generates for lazymc. The structure of this attribute set directly mirrors the TOML structure of lazymc's configuration.

    **Automatic Configuration & Port Handling:**

    To provide a seamless "one-toggle" solution, when `lazymc.enable = true` and you *do not* explicitly set `lazymc.config.public.address` or `lazymc.config.server.address`:
    *   The actual Minecraft server (as configured in `server.properties` by this module) will have its `server-port` set to the value from `services.minecraft-servers.servers.<name>.serverProperties."server-port"` (or its default `25565`) **minus 1**. For example, if `server-port` was `25565`, the Minecraft server will run on port `25564`.
    *   Lazymc will then be configured with:
        *   `public.address`: Defaults to `0.0.0.0:<original-server-port>` (e.g., `0.0.0.0:25565`). This is the port players connect to.
        *   `server.address`: Defaults to `127.0.0.1:<original-server-port - 1>` (e.g., `127.0.0.1:25564`). This is the internal port lazymc uses to proxy to the actual Minecraft server.
    * **Ensure the `<original-server-port - 1>` port is available and not used by another service.**

    If you **do** set either `lazymc.config.public.address` or `lazymc.config.server.address`:
    *   The automatic `-1` offset for the Minecraft server's `server-port` (in `server.properties`) is **not applied**. The Minecraft server will be configured to use the `server-port` directly from `services.minecraft-servers.servers.<name>.serverProperties."server-port"`.
    *   Lazymc's `public.address` will be what you set, or default to `0.0.0.0:<original-server-port>`.
    *   Lazymc's `server.address` will be what you set, or default to `127.0.0.1:<original-server-port>`.

    **Other Auto-configured `lazymc.toml` settings:**
    *   `server.command`: Automatically set to use the server `package` and `jvmOpts` defined for this nix-minecraft server instance.
    *   `server.directory`: Automatically set.
    *   `rcon.enabled`: Automatically enabled in `lazymc.toml` if `enable-rcon = true;` is set in `serverProperties`.
    *   `rcon.port`: In `lazymc.toml`, this will be set to the port the Minecraft server's RCON is actually listening on or `25575` by default

    **Important Considerations:**
    *   **Firewall:** When `lazymc.enable = true`, the  `openFirewall` option for this server instance will open the port specified in `lazymc.config.public.address` (or its default), not the internal Minecraft server port.
    *   **`max-tick-time`:** Setting `max-tick-time=-1` in `server.properties` might help if you're experiencing issues.

    **Example:**
    ```nix
    # In your NixOS configuration
    { pkgs, ... }: {
      services.minecraft-servers.servers.myPaperServer = {
        enable = true;
        eula = true;
        package = pkgs.paperServers.paper-1_18_2;
        jvmOpts = "-Xmx4G -Xms2G";
        serverProperties = {
          "server-port" = 25565;
          "enable-rcon" = true;
          "rcon.port" = 25575;
          "max-tick-time" = -1; # Recommended with lazymc
        };

        lazymc = {
          enable = true;
          package = let
          # you can use https://lazamar.co.uk/nix-versions/
            pkgs-with-lazymc_0_2_10 = import (builtins.fetchTarball {
                url = "https://github.com/NixOS/nixpkgs/archive/336eda0d07dc5e2be1f923990ad9fdb6bc8e28e3.tar.gz";
                sha256 = "sha256:0v8vnmgw7cifsp5irib1wkc0bpxzqcarlv8mdybk6dck5m7p10lr";
            }) { inherit (pkgs) system; };
          in pkgs-with-lazymc_0_2_10.lazymc;
          config = {
            # see lazymc config here: https://github.com/timvisee/lazymc/blob/master/res/lazymc.toml

            # Other lazymc options:
            time.sleep_after = 900; # Sleep after 15 minutes
            motd.sleeping = "💤 Server is napping! Connect to wake it.";
          };
        };
      };
    }
    ```

