### PR TITLE
Add lazymc (on-demand) functionality to nix-minecraft

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,3 +577,53 @@ files."white-list.txt" = {
 ```
 
 generates a legacy `white-list.txt` that is needed for older minecraft versions (< 1.7.6)
+
+#### `servers.<name>.lazymc`
+
+Integrates [lazymc](https://github.com/timvisee/lazymc), putting server to sleep when idle and waking it upon player connection.  
+When enabled the server's public address is controlled by lazymc, by default 25565. So a new internal `serverProperties.server-port` has to be chosen.
+
+*   **`enable`**: `boolean`, default `false`
+
+*   **`package`**: `package`, default `pkgs.lazymc`  
+    The `lazymc` package to use. You might have to change lazymc version according to your minecraft server version, for example lazymc v0.2.10 supports Minecraft Java Edition 1.7.2+, while for Minecraft Java Edition 1.20.3+ you'll need lazymc v0.2.11
+
+*   **`config`**: `attribute set`, default `{}`  
+    Allows defining and overriding settings in the `lazymc.toml`, for all options see [here](https://github.com/timvisee/lazymc/blob/master/res/lazymc.toml). The auto generated config options are:
+    *   `server.command`: Automatically set to use the server `package` and `jvmOpts`;
+    *   `server.directory`;
+    *   `server.address`: Automatically set to `127.0.0.1:<serverProperties.server-port or 25565>";`
+
+    **Firewall**
+    *   When `lazymc.enable = true`, the  `openFirewall` option for this server instance will open the port specified in `lazymc.config.public.address` (or 25565), not the internal Minecraft `serverProperties.server-port`.
+
+    **Example:**
+    ```nix
+    { pkgs, ... }: {
+      services.minecraft-servers = {
+        eula = true;
+        servers.myLazyServer = {
+          enable = true;
+          package = pkgs.paperServers.paper-1_18_2;
+          serverProperties = {
+            "server-port" = 25566;
+            "max-tick-time" = -1; # Recommended with lazymc
+          };
+
+          lazymc = {
+            enable = true;
+            package = let
+            # you can use https://lazamar.co.uk/nix-versions/
+              pkgs-with-lazymc_0_2_10 = import (builtins.fetchTarball {
+                  url = "https://github.com/NixOS/nixpkgs/archive/336eda0d07dc5e2be1f923990ad9fdb6bc8e28e3.tar.gz";
+                  sha256 = "sha256:0v8vnmgw7cifsp5irib1wkc0bpxzqcarlv8mdybk6dck5m7p10lr";
+              }) { inherit (pkgs) system; };
+            in pkgs-with-lazymc_0_2_10.lazymc;
+            config = {
+              public.address = "0.0.0.0:25565";
+            };
+          };
+        };
+      };
+    }
+    ```

--- a/modules/minecraft-servers.nix
+++ b/modules/minecraft-servers.nix
@@ -151,6 +151,11 @@ let
     let
       ms = server.managementSystem;
       tmux = "${getBin pkgs.tmux}/bin/tmux";
+      runCommand =
+        if server.lazymc.enable then
+          "${server.lazymc.package}/bin/lazymc start --config lazymc.toml"
+        else
+          "${getExe server.package} ${server.jvmOpts}";
     in
     assert assertMsg (
       !(ms.tmux.enable && ms.systemd-socket.enable)
@@ -166,7 +171,7 @@ let
         };
         hooks = {
           start = ''
-            ${tmux} -S ${sock} new -d ${getExe server.package} ${server.jvmOpts}
+            ${tmux} -S ${sock} new -d ${runCommand}
 
             # HACK: PrivateUsers makes every user besides root/minecraft `nobody`, so this restores old tmux behavior
             # See https://github.com/Infinidoge/nix-minecraft/issues/5
@@ -175,7 +180,7 @@ let
           postStart = ''
             ${pkgs.coreutils}/bin/chmod 660 ${sock}
           '';
-          stop = ''
+          stop = optionalString (!server.lazymc.enable) ''
             function server_running {
               ${tmux} -S ${sock} has-session
             }
@@ -199,12 +204,10 @@ let
           StandardError = "journal";
         };
         hooks = {
-          start = ''
-            ${getExe server.package} ${server.jvmOpts}
-          '';
+          start = runCommand;
           postStart = "";
           stop = ''
-            ${optionalString (server.stopCommand != null) ''
+            ${optionalString (server.stopCommand != null && !server.lazymc.enable) ''
               echo ${escapeShellArg server.stopCommand} > ${escapeShellArg (ms.systemd-socket.stdinSocket.path name)}
 
               while kill -0 "$1" 2> /dev/null; do sleep 1s; done
@@ -634,6 +637,52 @@ in
                 default = { };
                 example = options.services.minecraft-servers.managementSystem.example;
               };
+              lazymc = {
+                enable = mkEnableOpt "Puts your Minecraft server to rest when idle, and wakes it up when players connect.";
+                package = mkOption {
+                  type = types.package;
+                  default = pkgs.lazymc;
+                  defaultText = literalExpression "pkgs.lazymc";
+                  description = "The lazymc package to use.";
+                };
+                config = mkOption {
+                  type = types.submodule {
+                    freeformType = types.attrs;
+                    options = {
+                      public = mkOption {
+                        type = types.submodule {
+                          freeformType = types.attrs;
+                          options = {
+                            address = mkOption {
+                              type = types.strMatching "^[^:]+:[0-9]+$";
+                              default = "0.0.0.0:25565";
+                              description = "Public address in format 'address:port'";
+                            };
+                          };
+                        };
+                        default = { };
+                      };
+                    };
+                  };
+                  default = { };
+                  description = ''
+                    Configuration for lazymc, mirroring its TOML structure.
+                    Some values like server.command, server.directory and server.address will
+                    be automatically configured by this module when generating lazymc.toml. 
+
+                    See <link xlink:href="https://github.com/timvisee/lazymc/blob/master/res/lazymc.toml"/>
+                    for documentation on these values.
+                  '';
+                  example = literalExpression ''
+                    {
+                      public.address = "0.0.0.0:25565"; # Public port for players
+                      time.sleep_after = 900; # Sleep after 15 minutes
+                      motd.sleeping = "Shhh, the server is napping!";
+                      server.forge = false; # Set to true if this is a Forge server
+                    }
+                  '';
+                };
+              };
             };
 
             config = {
@@ -648,6 +697,17 @@ in
   config = mkIf cfg.enable (
     let
       servers = filterAttrs (_: cfg: cfg.enable) cfg.servers;
+
+      getPublicPort =
+        conf:
+        if conf.lazymc.enable then
+          let
+            addr = conf.lazymc.config.public.address or "0.0.0.0:25565";
+            portStr = lib.last (lib.splitString ":" addr);
+          in
+          lib.toInt portStr
+        else
+          conf.serverProperties.server-port or 25565;
     in
     {
       users = {
@@ -680,15 +740,35 @@ in
         {
           assertion =
             let
-              serverPorts = mapAttrsToList (name: conf: conf.serverProperties.server-port or 25565) (
+              serverPorts = mapAttrsToList (name: conf: getPublicPort conf) (
                 filterAttrs (_: cfg: cfg.openFirewall) servers
               );
 
               counts = map (port: count (x: x == port) serverPorts) (unique serverPorts);
             in
             lib.all (x: x == 1) counts;
-          message = "Multiple servers are set to use the same port. Change one to use a different port.";
+          message = "Multiple servers are set to use the same public port (either through lazymc public.address or server.properties server-port). Change one to use a different port.";
         }
+        (
+          let
+            lazymcPortConflicts = filter (x: x.hasConflict) (
+              mapAttrsToList (name: conf: {
+                inherit name;
+                hasConflict =
+                  conf.lazymc.enable && getPublicPort conf == (conf.serverProperties.server-port or 25565);
+              }) servers
+            );
+            conflictingServerNames = map (x: x.name) lazymcPortConflicts;
+          in
+          {
+            assertion = lazymcPortConflicts == [ ];
+            message = ''
+              Server(s): ${concatStringsSep ", " conflictingServerNames} has the same port set for serverProperties.server-port and lazymc.config.public.address
+              Please set for example: `serverName.serverProperties.server-port = 25566;`, lazymc's internal server.address will automatically point to it
+              Lazymc's public.address is "0.0.0.0:25565" by default
+            '';
+          }
+        )
       ];
 
       warnings = lib.optional (cfg.runDir != options.services.minecraft-servers.runDir.default) ''
@@ -706,7 +786,9 @@ in
           # Minecraft and RCON
           getTCPPorts =
             n: c:
-            [ c.serverProperties.server-port or 25565 ]
+            [
+              (getPublicPort c)
+            ]
             ++ (optional (c.serverProperties.enable-rcon or false) (c.serverProperties."rcon.port" or 25575));
           # Query
           getUDPPorts =
@@ -793,6 +875,15 @@ in
               "server.properties".value = conf.serverProperties;
               "allowed_symlinks.txt".value = conf.allowedSymlinks;
             }
+            // (optionalAttrs conf.lazymc.enable {
+              "lazymc.toml".value = lib.recursiveUpdate {
+                server = {
+                  command = "${getExe conf.package} ${conf.jvmOpts}";
+                  directory = ".";
+                  address = "127.0.0.1:${toString conf.serverProperties.server-port or 25565}";
+                };
+              } conf.lazymc.config;
+            })
             // conf.files
           );
 


### PR DESCRIPTION
Solves https://github.com/Infinidoge/nix-minecraft/issues/142
This adds the options:
```nix
        lazymc = {
          enable = true;
          package = pkgs.lazymc;
          config = { ... };
        };
```
Under each instance. This makes servers go to sleep when there are no players and wake up when one player tries to join [lazymc](https://github.com/timvisee/lazymc)

#### `servers.<name>.lazymc`

Integrates [lazymc](https://github.com/timvisee/lazymc), putting server to sleep when idle and waking it upon player connection.

*   **`enable`**: `boolean`, default `false`

*   **`package`**: `package`, default `pkgs.lazymc`  
    The `lazymc` package to use. You might have to change lazymc version according to your minecraft server version, for example lazymc v0.2.10 supports Minecraft Java Edition 1.7.2+, while for Minecraft Java Edition 1.20.3+ you'll need lazymc v0.2.11

*   **`config`**: `attribute set`, default `{}`  
    Allows defining and overriding settings in the `lazymc.toml`, for all options see [here](https://github.com/timvisee/lazymc/blob/master/res/lazymc.toml). The auto generated config options are:
    *   `server.command`: Automatically set to use the server `package` and `jvmOpts`;
    *   `server.directory`;
    *   `server.address`: Automatically set to `127.0.0.1:<serverProperties.server-port or 25565>";`

    **Firewall**
    *   When `lazymc.enable = true`, the  `openFirewall` option for this server instance will open the port specified in `lazymc.config.public.address` (or its default), not the internal Minecraft `serverProperties.server-port`.

    **Example:**
    ```nix
    { pkgs, ... }: {
      services.minecraft-servers = {
        eula = true;
        servers.myLazyServer = {
          enable = true;
          package = pkgs.paperServers.paper-1_18_2;
          serverProperties = {
            "server-port" = 25566;
            "max-tick-time" = -1; # Recommended with lazymc
          };
    
          lazymc = {
            enable = true;
            package = let
            # you can use https://lazamar.co.uk/nix-versions/
              pkgs-with-lazymc_0_2_10 = import (builtins.fetchTarball {
                  url = "https://github.com/NixOS/nixpkgs/archive/336eda0d07dc5e2be1f923990ad9fdb6bc8e28e3.tar.gz";
                  sha256 = "sha256:0v8vnmgw7cifsp5irib1wkc0bpxzqcarlv8mdybk6dck5m7p10lr";
              }) { inherit (pkgs) system; };
            in pkgs-with-lazymc_0_2_10.lazymc;
            config = {
              public.address = "0.0.0.0:25565";
            };
          };
        };
      };
    }
    ```
