### PR TITLE
Make fetchPackwizModpack work with an `src` argument

### DIFF
--- a/tests/packwiz-from-src/default.nix
+++ b/tests/packwiz-from-src/default.nix
@@ -1,0 +1,24 @@
+{
+  fetchPackwizModpack,
+  stdenvNoCC,
+}:
+let
+  pack = fetchPackwizModpack {
+    src = ./sample-pack;
+    packHash = "sha256-x7e1UzyVKfprQgayVLUcN4nzcPUx9nq+D/NmLe+ElKs=";
+  };
+in
+stdenvNoCC.mkDerivation {
+  name = "packwiz-from-src-check";
+  doCheck = true;
+  phases = [
+    "checkPhase"
+    "installPhase"
+  ];
+  checkPhase = ''
+    set -euo pipefail
+    test -f ${pack}/pack.toml
+    test -f '${pack}/mods/lithium-fabric-0.16.2+mc1.21.5.jar'
+  '';
+  installPhase = "mkdir $out";
+}

--- a/tests/packwiz-from-src/sample-pack/index.toml
+++ b/tests/packwiz-from-src/sample-pack/index.toml
@@ -1,0 +1,6 @@
+hash-format = "sha256"
+
+[[files]]
+file = "mods/lithium.pw.toml"
+hash = "5773d3e597b591a9cd1d6d0808aa5820ecfef9f95c3ebe88aae485980f032e8a"
+metafile = true

--- a/tests/packwiz-from-src/sample-pack/mods/lithium.pw.toml
+++ b/tests/packwiz-from-src/sample-pack/mods/lithium.pw.toml
@@ -1,0 +1,13 @@
+name = "Lithium"
+filename = "lithium-fabric-0.16.2+mc1.21.5.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/gvQqBUqZ/versions/VWYoZjBF/lithium-fabric-0.16.2%2Bmc1.21.5.jar"
+hash-format = "sha512"
+hash = "09a68051504bb16069dd6af8901f2bbeadfd08ad5353d8bcc0c4784e814fb293d9197b4fb0a8393be1f2db003cd987a9e4b98391bbe18c50ae181dace20c2fa4"
+
+[update]
+[update.modrinth]
+mod-id = "gvQqBUqZ"
+version = "VWYoZjBF"

--- a/tests/packwiz-from-src/sample-pack/pack.toml
+++ b/tests/packwiz-from-src/sample-pack/pack.toml
@@ -1,0 +1,12 @@
+name = "sample-pack"
+version = "1.0.0"
+pack-format = "packwiz:1.1.0"
+
+[index]
+file = "index.toml"
+hash-format = "sha256"
+hash = "55d902bab53ae9d70f379030a80b6925a70424d3750e019f29590a20183d776e"
+
+[versions]
+fabric = "0.16.14"
+minecraft = "1.21.5"


### PR DESCRIPTION
Allows for setting an src argument for the `fetchPackwizModpack` function. It needs to be a derivation or a file path containing a `pack.toml` file.

I'm using `updog` to serve the contents of `src` to `packwizInstallerBootstrap` rather than `packwiz serve`, since the latter would attempt to update the contents of the working directory on top of just serving the files, which does not work for read only nix store file paths.

I've been using the code [for myself](https://github.com/ehllie/vanilla-plus/blob/main/bootstrapPackwiz.nix) for a while now, and figured I'd try to upstream that change.

Should close #110.