### PR TITLE
vanilla-servers: fixed png icons crashing jre8 servers

### DIFF
--- a/pkgs/vanilla-servers/default.nix
+++ b/pkgs/vanilla-servers/default.nix
@@ -1,7 +1,7 @@
 {
   callPackage,
   lib,
-  jre8_headless,
+  jre8,
   jre_headless,
 }:
 let
@@ -12,7 +12,7 @@ let
   # are no longer as important for stability as they used to be. Meaning we can
   # target latest the latest JDK for all newer versions of Minecraft.
   # TODO: Assert that jre_headless >= java version
-  getJavaVersion = v: if v == 8 then jre8_headless else jre_headless;
+  getJavaVersion = v: if v == 8 then jre8 else jre_headless;
 
   packages = lib.mapAttrs' (version: value: {
     name = "vanilla-${lib.our.escapeVersion version}";


### PR DESCRIPTION
Closes #154 
Replaced jre8_headless with jre8, which includes the awt library required to load png icons.