### PR TITLE
Add minecraftctl for server management

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ As of currently, it packages:
 - All supported versions of the following:
   - Velocity proxy
 - Various tools
+  - `minecraftctl`
   - `nix-modrinth-prefetch`
   - `fetchPackwizModpack`
 
@@ -270,6 +271,43 @@ nix run github:Infinidoge/nix-minecraft#nix-modrinth-prefetch -- versionid
 (This helper script can also be used in a temporary shell with `nix shell github:Infinidoge/nix-minecraft#nix-modrinth-prefetch`)
 
 This `fetchurl` invocation directly fetches the mod, and can be copy-pasted to wherever necessary.
+
+#### `minecraftctl`
+
+[Source](./pkgs/tools/minecraftctl.nix)
+
+A command-line tool for managing Minecraft servers created by the nix-minecraft module. It provides a convenient interface to interact with multiple server instances through systemd services and tmux sessions.
+
+**Features:**
+- List all available server instances with their status
+- View detailed status information for specific servers
+- Send commands directly to running servers via tmux
+- View server logs with optional live following
+- Start, stop, and restart server instances
+
+**Usage:**
+```bash
+# List all server instances with their current status
+minecraftctl list
+
+# Show detailed status of a specific server
+minecraftctl status myserver
+
+# Send a command to a running server (e.g., in-game commands)
+minecraftctl send myserver "say Hello world"
+minecraftctl send myserver "whitelist add player123"
+
+# View recent logs (last 50 lines)
+minecraftctl tail myserver
+
+# Follow logs in real-time
+minecraftctl tail myserver -f
+
+# Control server lifecycle
+minecraftctl stop myserver
+minecraftctl start myserver
+minecraftctl restart myserver
+```
 
 ## Modules
 

--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,7 @@
             velocity-server
             minecraft-server
             nix-modrinth-prefetch
+            nix-minecraft-cli
             ;
 
           docsAsciiDoc = docs.optionsAsciiDoc;

--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,7 @@
             velocity-server
             minecraft-server
             nix-modrinth-prefetch
-            nix-minecraft-cli
+            minecraftctl
             ;
 
           docsAsciiDoc = docs.optionsAsciiDoc;

--- a/pkgs/tools/minecraftctl.nix
+++ b/pkgs/tools/minecraftctl.nix
@@ -11,7 +11,7 @@
   ...
 }:
 writeShellApplication {
-  name = "nix-minecraft-cli";
+  name = "minecraftctl";
 
   runtimeInputs = [
     systemd
@@ -32,25 +32,25 @@ writeShellApplication {
 
     show_help() {
       cat << 'EOF'
-    nix-minecraft-cli - Manage Minecraft servers created by nix-minecraft
+    minecraftctl - Manage Minecraft servers created by nix-minecraft
 
     Usage:
-      nix-minecraft-cli list                      # list available instances with their status
-      nix-minecraft-cli status <instance>         # show status of the instance
-      nix-minecraft-cli send <instance> <command> # send command to the tmux session
-      nix-minecraft-cli tail <instance> [-f]      # tail logs, with optional follow flag
-      nix-minecraft-cli stop <instance>           # pause the instance
-      nix-minecraft-cli start <instance>          # start the paused instance
-      nix-minecraft-cli restart <instance>        # restart it
+      minecraftctl list                      # list available instances with their status
+      minecraftctl status <instance>         # show status of the instance
+      minecraftctl send <instance> <command> # send command to the tmux session
+      minecraftctl tail <instance> [-f]      # tail logs, with optional follow flag
+      minecraftctl stop <instance>           # pause the instance
+      minecraftctl start <instance>          # start the paused instance
+      minecraftctl restart <instance>        # restart it
 
     Examples:
-      nix-minecraft-cli list
-      nix-minecraft-cli status myserver
-      nix-minecraft-cli send myserver "say Hello world"
-      nix-minecraft-cli tail myserver -f
-      nix-minecraft-cli stop myserver
-      nix-minecraft-cli start myserver
-      nix-minecraft-cli restart myserver
+      minecraftctl list
+      minecraftctl status myserver
+      minecraftctl send myserver "say Hello world"
+      minecraftctl tail myserver -f
+      minecraftctl stop myserver
+      minecraftctl start myserver
+      minecraftctl restart myserver
     EOF
     }
 
@@ -199,7 +199,7 @@ writeShellApplication {
       status)
         if [[ $# -lt 2 ]]; then
           echo "Error: instance name required"
-          echo "Usage: nix-minecraft-cli status <instance>"
+          echo "Usage: minecraftctl status <instance>"
           exit 1
         fi
         show_status "$2"
@@ -207,7 +207,7 @@ writeShellApplication {
       send)
         if [[ $# -lt 3 ]]; then
           echo "Error: instance name and command required"
-          echo "Usage: nix-minecraft-cli send <instance> <command>"
+          echo "Usage: minecraftctl send <instance> <command>"
           exit 1
         fi
         # Join all arguments after the second as the command
@@ -219,7 +219,7 @@ writeShellApplication {
       tail)
         if [[ $# -lt 2 ]]; then
           echo "Error: instance name required"
-          echo "Usage: nix-minecraft-cli tail <instance> [-f]"
+          echo "Usage: minecraftctl tail <instance> [-f]"
           exit 1
         fi
         tail_logs "$2" "''${3:-}"
@@ -227,7 +227,7 @@ writeShellApplication {
       stop)
         if [[ $# -lt 2 ]]; then
           echo "Error: instance name required"
-          echo "Usage: nix-minecraft-cli stop <instance>"
+          echo "Usage: minecraftctl stop <instance>"
           exit 1
         fi
         stop_instance "$2"
@@ -235,7 +235,7 @@ writeShellApplication {
       start)
         if [[ $# -lt 2 ]]; then
           echo "Error: instance name required"
-          echo "Usage: nix-minecraft-cli start <instance>"
+          echo "Usage: minecraftctl start <instance>"
           exit 1
         fi
         start_instance "$2"
@@ -243,7 +243,7 @@ writeShellApplication {
       restart)
         if [[ $# -lt 2 ]]; then
           echo "Error: instance name required"
-          echo "Usage: nix-minecraft-cli restart <instance>"
+          echo "Usage: minecraftctl restart <instance>"
           exit 1
         fi
         restart_instance "$2"

--- a/pkgs/tools/nix-minecraft-cli.nix
+++ b/pkgs/tools/nix-minecraft-cli.nix
@@ -1,0 +1,262 @@
+{
+  lib,
+  writeShellApplication,
+  systemd,
+  tmux,
+  findutils,
+  coreutils,
+  gnugrep,
+  gawk,
+  procps,
+  ...
+}:
+writeShellApplication {
+  name = "nix-minecraft-cli";
+
+  runtimeInputs = [
+    systemd
+    tmux
+    findutils
+    coreutils
+    gnugrep
+    gawk
+    procps
+  ];
+
+  text = ''
+    set -euo pipefail
+
+    # Default paths
+    DATA_DIR="/srv/minecraft"
+    RUN_DIR="/run/minecraft"
+
+    show_help() {
+      cat << 'EOF'
+    nix-minecraft-cli - Manage Minecraft servers created by nix-minecraft
+
+    Usage:
+      nix-minecraft-cli list                      # list available instances with their status
+      nix-minecraft-cli status <instance>         # show status of the instance
+      nix-minecraft-cli send <instance> <command> # send command to the tmux session
+      nix-minecraft-cli tail <instance> [-f]      # tail logs, with optional follow flag
+      nix-minecraft-cli stop <instance>           # pause the instance
+      nix-minecraft-cli start <instance>          # start the paused instance
+      nix-minecraft-cli restart <instance>        # restart it
+
+    Examples:
+      nix-minecraft-cli list
+      nix-minecraft-cli status myserver
+      nix-minecraft-cli send myserver "say Hello world"
+      nix-minecraft-cli tail myserver -f
+      nix-minecraft-cli stop myserver
+      nix-minecraft-cli start myserver
+      nix-minecraft-cli restart myserver
+    EOF
+    }
+
+    get_service_name() {
+      local instance="$1"
+      echo "minecraft-server-$instance"
+    }
+
+    get_tmux_socket() {
+      local instance="$1"
+      echo "$RUN_DIR/$instance.sock"
+    }
+
+    get_log_path() {
+      local instance="$1"
+      # Use journalctl for systemd logs
+      echo "journalctl"
+    }
+
+    list_instances() {
+      echo "Instance                Status"
+      echo "------------------------"
+
+      # Find all minecraft server data directories
+      if [[ -d "$DATA_DIR" ]]; then
+        for server_dir in "$DATA_DIR"/*; do
+          if [[ -d "$server_dir" ]]; then
+            instance=$(basename "$server_dir")
+            service_name=$(get_service_name "$instance")
+
+            # Check if service exists and get status
+            if systemctl list-unit-files --type=service | grep -q "^$service_name.service"; then
+              if systemctl is-active --quiet "$service_name"; then
+                status="running"
+              elif systemctl is-enabled --quiet "$service_name" 2>/dev/null; then
+                status="stopped"
+              else
+                status="disabled"
+              fi
+            else
+              status="no-service"
+            fi
+
+            printf "%-24s %s\n" "$instance" "$status"
+          fi
+        done
+      else
+        echo "No Minecraft data directory found at $DATA_DIR"
+      fi
+    }
+
+    show_status() {
+      local instance="$1"
+      local service_name
+      service_name=$(get_service_name "$instance")
+
+      echo "Instance: $instance"
+      echo "Service: $service_name"
+      echo
+
+      # Show systemd status
+      systemctl status "$service_name" --no-pager -l || true
+
+      echo
+      echo "Recent logs:"
+      journalctl -u "$service_name" -n 10 --no-pager || true
+    }
+
+    send_command() {
+      local instance="$1"
+      local command="$2"
+      local socket
+      socket=$(get_tmux_socket "$instance")
+
+      if [[ ! -S "$socket" ]]; then
+        echo "Error: tmux socket not found at $socket"
+        echo "Make sure the server is running and using tmux management"
+        exit 1
+      fi
+
+      # Send command to tmux session
+      tmux -S "$socket" send-keys "$command" Enter
+      echo "Command sent: $command"
+    }
+
+    tail_logs() {
+      local instance="$1"
+      local follow_flag=""
+
+      # Check if -f flag is provided
+      if [[ $# -gt 1 && "$2" == "-f" ]]; then
+        follow_flag="-f"
+      fi
+
+      local service_name
+      service_name=$(get_service_name "$instance")
+
+      # Use journalctl to tail logs
+      if [[ "$follow_flag" == "-f" ]]; then
+        journalctl -u "$service_name" -f --no-pager
+      else
+        journalctl -u "$service_name" -n 50 --no-pager
+      fi
+    }
+
+    stop_instance() {
+      local instance="$1"
+      local service_name
+      service_name=$(get_service_name "$instance")
+
+      echo "Stopping $instance..."
+      systemctl stop "$service_name"
+      echo "Stopped $instance"
+    }
+
+    start_instance() {
+      local instance="$1"
+      local service_name
+      service_name=$(get_service_name "$instance")
+
+      echo "Starting $instance..."
+      systemctl start "$service_name"
+      echo "Started $instance"
+    }
+
+    restart_instance() {
+      local instance="$1"
+      local service_name
+      service_name=$(get_service_name "$instance")
+
+      echo "Restarting $instance..."
+      systemctl restart "$service_name"
+      echo "Restarted $instance"
+    }
+
+    # Main command processing
+    if [[ $# -eq 0 ]]; then
+      show_help
+      exit 1
+    fi
+
+    case "$1" in
+      list)
+        list_instances
+        ;;
+      status)
+        if [[ $# -lt 2 ]]; then
+          echo "Error: instance name required"
+          echo "Usage: nix-minecraft-cli status <instance>"
+          exit 1
+        fi
+        show_status "$2"
+        ;;
+      send)
+        if [[ $# -lt 3 ]]; then
+          echo "Error: instance name and command required"
+          echo "Usage: nix-minecraft-cli send <instance> <command>"
+          exit 1
+        fi
+        # Join all arguments after the second as the command
+        instance="$2"
+        shift 2
+        command="$*"
+        send_command "$instance" "$command"
+        ;;
+      tail)
+        if [[ $# -lt 2 ]]; then
+          echo "Error: instance name required"
+          echo "Usage: nix-minecraft-cli tail <instance> [-f]"
+          exit 1
+        fi
+        tail_logs "$2" "''${3:-}"
+        ;;
+      stop)
+        if [[ $# -lt 2 ]]; then
+          echo "Error: instance name required"
+          echo "Usage: nix-minecraft-cli stop <instance>"
+          exit 1
+        fi
+        stop_instance "$2"
+        ;;
+      start)
+        if [[ $# -lt 2 ]]; then
+          echo "Error: instance name required"
+          echo "Usage: nix-minecraft-cli start <instance>"
+          exit 1
+        fi
+        start_instance "$2"
+        ;;
+      restart)
+        if [[ $# -lt 2 ]]; then
+          echo "Error: instance name required"
+          echo "Usage: nix-minecraft-cli restart <instance>"
+          exit 1
+        fi
+        restart_instance "$2"
+        ;;
+      help|--help|-h)
+        show_help
+        ;;
+      *)
+        echo "Error: unknown command '$1'"
+        echo
+        show_help
+        exit 1
+        ;;
+    esac
+  '';
+}


### PR DESCRIPTION
## Summary

This PR adds a new CLI tool `minecraftctl` for managing Minecraft servers created by the nix-minecraft NixOS module. The tool provides a convenient command-line interface for common server management tasks.

closes #166

## Features

### Commands Implemented
- `minecraftctl list` - List all available instances with their status
- `minecraftctl status <instance>` - Show detailed status and recent logs for a specific instance  
- `minecraftctl send <instance> <command>` - Send commands to the server via tmux session
- `minecraftctl tail <instance> [-f]` - View server logs with optional follow mode
- `minecraftctl stop <instance>` - Stop a running server instance
- `minecraftctl start <instance>` - Start a stopped server instance  
- `minecraftctl restart <instance>` - Restart a server instance

### Key Features
- **Seamless Integration**: Works with the existing NixOS minecraft-servers module
- **Service Management**: Uses systemd services (`minecraft-server-<name>`) for lifecycle control
- **Command Interface**: Sends in-game commands via tmux sockets when using tmux management
- **Log Access**: Leverages journalctl for comprehensive log viewing and following
- **Error Handling**: Provides clear error messages and comprehensive help text
- **Robust Implementation**: Follows shell scripting best practices with proper error handling

## Technical Details

- **Location**: `pkgs/tools/minecraftctl.nix`
- **Dependencies**: systemd, tmux, findutils, coreutils, gnugrep, gawk, procps
- **Integration**: Added to flake packages for easy installation
- **Testing**: Passes `nix flake check` validation

## Usage Examples

```bash
# List all server instances
minecraftctl list

# Check status of a specific server
minecraftctl status myserver

# Send an in-game command
minecraftctl send myserver "say Hello players!"

# View logs in follow mode
minecraftctl tail myserver -f

# Manage server lifecycle
minecraftctl stop myserver
minecraftctl start myserver
minecraftctl restart myserver
```

## Test Plan

- [x] Tool builds successfully via `nix build .#minecraftctl`
- [x] All commands show appropriate help and error messages
- [x] Integration with existing flake structure works correctly
- [x] Passes flake evaluation checks

🤖 Generated with [Claude Code](https://claude.ai/code)
