### PR TITLE
Clear input in tmux session before sending stop command

### DIFF
--- a/modules/minecraft-servers.nix
+++ b/modules/minecraft-servers.nix
@@ -178,7 +178,7 @@ let
               exit 0
             fi
 
-            ${tmux} -S ${sock} send-keys ${escapeShellArg server.stopCommand} Enter
+            ${tmux} -S ${sock} send-keys C-u ${escapeShellArg server.stopCommand} Enter
 
             while server_running; do sleep 1s; done
           '';


### PR DESCRIPTION
This pull request clears any input in the tmux session before sending the stop command, preventing stop failures if leftover text is present.