### PR TITLE
feat: Add Folia support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,7 @@
             quilt-server
             paper-server
             purpur-server
+            folia-server
             velocity-server
             minecraft-server
             nix-modrinth-prefetch

--- a/pkgs/all-packages.nix
+++ b/pkgs/all-packages.nix
@@ -24,6 +24,7 @@ rec {
   legacyFabricServers = callPackage ./legacy-fabric-servers { inherit vanillaServers; };
   paperServers = callPackage ./paper-servers { inherit vanillaServers; };
   purpurServers = callPackage ./purpur-servers { inherit vanillaServers; };
+  foliaServers = callPackage ./folia-servers { inherit vanillaServers; };
   velocityServers = callPackage ./velocity-servers { };
   neoforgeServers = callPackage ./neoforge-servers { inherit vanillaServers; };
 
@@ -34,6 +35,7 @@ rec {
     legacyFabricServers
     paperServers
     purpurServers
+    foliaServers
     neoforgeServers
   ];
 
@@ -42,6 +44,7 @@ rec {
   quilt-server = quiltServers.quilt;
   paper-server = paperServers.paper;
   purpur-server = purpurServers.purpur;
+  folia-server = paperServers.folia;
   velocity-server = velocityServers.velocity;
   minecraft-server = vanilla-server;
   neoforge-server = neoforgeServers.neoforge;

--- a/pkgs/folia-servers/default.nix
+++ b/pkgs/folia-servers/default.nix
@@ -1,0 +1,45 @@
+{
+  callPackage,
+  lib,
+  vanillaServers,
+}:
+let
+  inherit (lib.our) escapeVersion;
+  inherit (lib)
+    nameValuePair
+    flatten
+    last
+    versionOlder
+    mapAttrsToList
+    ;
+  versions = lib.importJSON ./lock.json;
+
+  # Remove -build... suffix
+  stripBuild = v: builtins.head (builtins.match "(.*)-build.*" v);
+  # Sort by attribute 'attr' using 'f' function
+  sortBy = attr: f: builtins.sort (a: b: f a.${attr} b.${attr});
+
+  packages = mapAttrsToList (
+    mcVersion: builds:
+    sortBy "version" versionOlder (
+      mapAttrsToList (
+        buildNumber: value:
+        callPackage ./derivation.nix {
+          inherit (value) url sha256;
+          version = "${mcVersion}-build.${buildNumber}";
+          minecraft-server = vanillaServers."vanilla-${escapeVersion mcVersion}";
+        }
+      ) builds
+    )
+  ) versions;
+
+  # Latest build for each MC version
+  latestBuilds = sortBy "version" versionOlder (map last packages);
+in
+lib.recurseIntoAttrs (
+  builtins.listToAttrs (
+    (map (x: nameValuePair (escapeVersion x.name) x) (flatten packages))
+    ++ (map (x: nameValuePair (escapeVersion (stripBuild x.name)) x) latestBuilds)
+    ++ [ (nameValuePair "folia" (last latestBuilds)) ]
+  )
+)

--- a/pkgs/folia-servers/derivation.nix
+++ b/pkgs/folia-servers/derivation.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  nixosTests,
+  jre_headless,
+  version,
+  url,
+  sha256,
+  minecraft-server,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "folia";
+  inherit version;
+
+  src = fetchurl { inherit url sha256; };
+
+  preferLocalBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib/minecraft
+    cp -v $src $out/lib/minecraft/server.jar
+
+    cat > $out/bin/minecraft-server << EOF
+    #!/bin/sh
+    exec ${jre_headless}/bin/java \$@ -jar $out/lib/minecraft/server.jar nogui
+    EOF
+
+    chmod +x $out/bin/minecraft-server
+  '';
+
+  dontUnpack = true;
+
+  passthru = {
+    updateScript = ./update.py;
+    # If you plan on running folia without internet, be sure to link this jar
+    # to `cache/mojang_{version}.jar`.
+    vanillaJar = "${minecraft-server}/lib/minecraft/server.jar";
+  };
+
+  meta = with lib; {
+    description = "A high performance spigot fork";
+    homepage = "https://papermc.io";
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ misterio77 ];
+    mainProgram = "minecraft-server";
+  };
+}

--- a/pkgs/folia-servers/lock.json
+++ b/pkgs/folia-servers/lock.json
@@ -1,0 +1,442 @@
+{
+  "1.19.4": {
+    "1": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/1/downloads/folia-1.19.4-1.jar",
+      "sha256": "5c0cdaa614b6951954cdd246f547d4c9461fa852bffa96e5584835b672f7a760"
+    },
+    "2": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/2/downloads/folia-1.19.4-2.jar",
+      "sha256": "3f493d2f62fdb5ea873b097a9b57433ac7f1ec877f2c21be8467c8102d308fd7"
+    },
+    "3": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/3/downloads/folia-1.19.4-3.jar",
+      "sha256": "941cc26a34fbd784c5ed0405f3b89706cff26dd6dfd8eb3a292404b949744b05"
+    },
+    "4": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/4/downloads/folia-1.19.4-4.jar",
+      "sha256": "dc4ef95411e0e8f81e7477c9732f85040a6045771a0a5f0965a5e1202c3809b6"
+    },
+    "5": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/5/downloads/folia-1.19.4-5.jar",
+      "sha256": "1f718a0f3499ca8ef50792d1d15847d20d126dad8b0e65ef0682ae224e1ff609"
+    },
+    "6": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/6/downloads/folia-1.19.4-6.jar",
+      "sha256": "a541b294f88a339c00225e385a3f0984654f47cb5de8d301d7f54e5e4fd81581"
+    },
+    "7": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/7/downloads/folia-1.19.4-7.jar",
+      "sha256": "ab9ba1e424922a4a4fb25cc2b741536189ac9ca9ebd71fe2a82ca7e3770eee1d"
+    },
+    "8": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/8/downloads/folia-1.19.4-8.jar",
+      "sha256": "209a7d2234a97adaffb3752d732cd86b93fc2b693cd64029f3f5367dc2c721e6"
+    },
+    "9": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/9/downloads/folia-1.19.4-9.jar",
+      "sha256": "fbf05b4cc73cc3348469aa872c25abe88a130502f9a70803e955773cc7300f10"
+    },
+    "10": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/10/downloads/folia-1.19.4-10.jar",
+      "sha256": "2375bd2b79b09ca1f913cd662f899803745b3fdddca07ec91d2424fec7f60a43"
+    },
+    "11": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/11/downloads/folia-1.19.4-11.jar",
+      "sha256": "a400698362ecbeb263e2243805b4c93a2abfd5840f3805415ad09918c8b8e408"
+    },
+    "12": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/12/downloads/folia-1.19.4-12.jar",
+      "sha256": "472860884c47121a5035596053323f7d6623609118557e7b960a4674a8c79bd2"
+    },
+    "13": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/13/downloads/folia-1.19.4-13.jar",
+      "sha256": "d1cb0d4aaab7de2c74dab27835e71014edee2b9cc085d41c960d6f0e62c5edf4"
+    },
+    "14": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/14/downloads/folia-1.19.4-14.jar",
+      "sha256": "0ee4333d062e4a1191d13d4085eb5323a9d762aadee13230fdbafdfbc3e8eaa5"
+    },
+    "15": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/15/downloads/folia-1.19.4-15.jar",
+      "sha256": "35e071c2543740aff0e284c92adde14f7cffd63db9eee2611adec22591f17a28"
+    },
+    "16": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/16/downloads/folia-1.19.4-16.jar",
+      "sha256": "51cc630865c109208f22442644ab238c6915a5b6f57d0e9b9c7681697b50dcea"
+    },
+    "17": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/17/downloads/folia-1.19.4-17.jar",
+      "sha256": "54d4a18742ef3c0444449f30f573ed94d7245f3128c465ffa0e728d6033c8f03"
+    },
+    "18": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/18/downloads/folia-1.19.4-18.jar",
+      "sha256": "9b8efc9e345e70e4ea7d6d6f6f1d61526c004d4e694062239ccd25c6064d39cb"
+    },
+    "19": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/19/downloads/folia-1.19.4-19.jar",
+      "sha256": "5a3d81f9b7ba1f10d833d5a97b037bf11d7c3b5f5b2329d50af441ddc79a0001"
+    },
+    "20": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/20/downloads/folia-1.19.4-20.jar",
+      "sha256": "40880d2ba43b100df0a9826eaa24049d3dd15fc03f9d759d88d81e1e674d8b60"
+    },
+    "21": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/21/downloads/folia-1.19.4-21.jar",
+      "sha256": "c9656cc15e989c2a3b44891b05b80877630b07e01c00f5c8ae64fcd4c3427393"
+    },
+    "22": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/22/downloads/folia-1.19.4-22.jar",
+      "sha256": "c3ca44f41fced58501fd645298eb20376988480a7e6e47144926e16bcc0e5ada"
+    },
+    "23": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/23/downloads/folia-1.19.4-23.jar",
+      "sha256": "49820dd8389baad32a3a4b76df624e6fabb2ef98312199110af20c8d330304c4"
+    },
+    "24": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/24/downloads/folia-1.19.4-24.jar",
+      "sha256": "80179183a87d10414eb3ea6bfbdf6e9f354841d11dd4b4d3514921aae6762f27"
+    },
+    "25": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/25/downloads/folia-1.19.4-25.jar",
+      "sha256": "79f80ce56fb5c453d0326cf5f63106bcf8514aac721a98c07a8507608aa46559"
+    },
+    "26": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/26/downloads/folia-1.19.4-26.jar",
+      "sha256": "5f58842dbc791079025a5254dc7f241a75d9f89827f4e06fe0ee9ed3ff89ac90"
+    },
+    "27": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/27/downloads/folia-1.19.4-27.jar",
+      "sha256": "2738b90c8286f40d0755e18df1caf03d9efdfeb68aac98d0ea7cc06fd58e2d1f"
+    },
+    "28": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/28/downloads/folia-1.19.4-28.jar",
+      "sha256": "55a80676fbd78c028f8396efbb8c5d1f217167b58b97ba53a65480eefb588d4f"
+    },
+    "29": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/29/downloads/folia-1.19.4-29.jar",
+      "sha256": "1c287e2b817bf5b3be46acb127db3b71e4e9a743e9cf4aa17feeaa0d10aa7340"
+    },
+    "30": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/30/downloads/folia-1.19.4-30.jar",
+      "sha256": "e91562e6d43804a2d2f5095b09d8fe6932017af10d16e516b47420d8fa7eca8a"
+    },
+    "31": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/31/downloads/folia-1.19.4-31.jar",
+      "sha256": "609d7288d4faacc0c13c5ced8af8b32f3c3325ca551f8597637bcce99f606a39"
+    },
+    "32": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/32/downloads/folia-1.19.4-32.jar",
+      "sha256": "95182931ce6d21abb741db6ccbc4d6a0ba18cc5d74bbd628d3a3846e775d6b0c"
+    },
+    "33": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/33/downloads/folia-1.19.4-33.jar",
+      "sha256": "4bc69009c142ced3031a0b9497b80f7cebb2b8c564b43376c9942d7cb4065943"
+    },
+    "34": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/34/downloads/folia-1.19.4-34.jar",
+      "sha256": "7aeb6b5e7e41732791fd6a6e7829e5fce2c9488e1ee7311649a1962a1f57f410"
+    },
+    "35": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/35/downloads/folia-1.19.4-35.jar",
+      "sha256": "f593d640dba32c1c923adea9ca2b7e0b6db4b969305bca3b8fcb8f7600e45dd5"
+    },
+    "36": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/36/downloads/folia-1.19.4-36.jar",
+      "sha256": "ef3de5730c823113a1ade80a37836b03518eb087490beb99bfa64c7a17951946"
+    },
+    "37": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/37/downloads/folia-1.19.4-37.jar",
+      "sha256": "b727b965948b5168fc3f29fdcfa9be69ae5d656f021ebb4792db1f27e175db63"
+    },
+    "38": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/38/downloads/folia-1.19.4-38.jar",
+      "sha256": "fde4cd849aa3e37412e7c5aa0aa69531eb3639e1b01c676621630010387c0edf"
+    },
+    "39": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.19.4/builds/39/downloads/folia-1.19.4-39.jar",
+      "sha256": "e6729be678110cf76b5feebaf4da09f447aacad907350f156bf163b561a9d979"
+    }
+  },
+  "1.20.1": {
+    "1": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.1/builds/1/downloads/folia-1.20.1-1.jar",
+      "sha256": "9e2dccea517ca097f9081655f85535669c9fadcea28fe4249c7c3eb73ad9fcc0"
+    },
+    "2": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.1/builds/2/downloads/folia-1.20.1-2.jar",
+      "sha256": "e180bad1798077f9e8643b047e1a567f40bca57b970d09c2d80f9f24df1c53e7"
+    },
+    "3": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.1/builds/3/downloads/folia-1.20.1-3.jar",
+      "sha256": "b84f3b4392875c1f7088059066481b0e2e37f0bb50c489a54b77870e198352bf"
+    },
+    "4": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.1/builds/4/downloads/folia-1.20.1-4.jar",
+      "sha256": "f1c1d96270726c876bb98eb6eb8e9f695abe54acbde53c9e0607690f09bb9913"
+    },
+    "5": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.1/builds/5/downloads/folia-1.20.1-5.jar",
+      "sha256": "fd5d278bf321b19d7370dbc09fc67c224283080135eff6fd71ec82780f547329"
+    },
+    "6": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.1/builds/6/downloads/folia-1.20.1-6.jar",
+      "sha256": "8cd2c273a74759a51814cc45a3beaf034955a736171f0ec3e7a1a6c3f6a28cea"
+    },
+    "7": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.1/builds/7/downloads/folia-1.20.1-7.jar",
+      "sha256": "cd11359838c891d2b3191baf84038347a099cc1f76c9caf3f0f953ee625c5e7a"
+    },
+    "8": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.1/builds/8/downloads/folia-1.20.1-8.jar",
+      "sha256": "478508991bdf895fa0d822440916d26d7d6b37490e003473e5f8bb3f15d96fd8"
+    },
+    "9": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.1/builds/9/downloads/folia-1.20.1-9.jar",
+      "sha256": "e79b71130862cf3f53031f0a1a304dfaf823724b2fbc9355667c92422c70800a"
+    },
+    "10": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.1/builds/10/downloads/folia-1.20.1-10.jar",
+      "sha256": "42e868ae311e7ff3a0ea3669660370666121439fca0cfb54a15de26e2949d106"
+    },
+    "11": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.1/builds/11/downloads/folia-1.20.1-11.jar",
+      "sha256": "d509e02dffe9ec620b8c574928d0be1f82f0f127647e55f2bb22e65d5736d9fb"
+    },
+    "12": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.1/builds/12/downloads/folia-1.20.1-12.jar",
+      "sha256": "d9e92ed616777b0c5ffdc5cd33d37a54c14855e7ebb82e42ff83ca907e0f177b"
+    },
+    "13": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.1/builds/13/downloads/folia-1.20.1-13.jar",
+      "sha256": "155a9a8e1d44b6d1d520d91396fc4df32d91dbc6d7faa4cd5b7aa268c085e2ed"
+    },
+    "14": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.1/builds/14/downloads/folia-1.20.1-14.jar",
+      "sha256": "a7cb943999f443119e4ae0def2a320a3d7498d298573d6e6287bb55b95c1e2e6"
+    },
+    "15": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.1/builds/15/downloads/folia-1.20.1-15.jar",
+      "sha256": "dded0bc70e2de3c2f18b565efb0513bbf6e6b5efb4e479ed370fdd6b523595ca"
+    },
+    "16": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.1/builds/16/downloads/folia-1.20.1-16.jar",
+      "sha256": "7c4648d0d564d58a61dfae46973d75f36e58da3ec646a03f7bcd96eb07a9ae44"
+    },
+    "17": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.1/builds/17/downloads/folia-1.20.1-17.jar",
+      "sha256": "c533d8886c60e1db17ebcf841b862731ab0a18d72377f37189930c3324eb7759"
+    }
+  },
+  "1.20.2": {
+    "18": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.2/builds/18/downloads/folia-1.20.2-18.jar",
+      "sha256": "9d89880e711983990e6e9cf4b082775a4d62be0bd77cd446c1b86c783f5568bd"
+    },
+    "19": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.2/builds/19/downloads/folia-1.20.2-19.jar",
+      "sha256": "51bc2379cf6e3d492ff2f6cd3daebf9865e6a821149d0d7ec7f98ff76b146b16"
+    },
+    "20": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.2/builds/20/downloads/folia-1.20.2-20.jar",
+      "sha256": "d01746e0176b6ef1ae0bef65bc3fa44e2f2063eaa8ab78f9e941345268d4c9e5"
+    }
+  },
+  "1.20.4": {
+    "21": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.4/builds/21/downloads/folia-1.20.4-21.jar",
+      "sha256": "8194af0d23d450680fd73aaf5265693d68b459dd837aaae07995acf9afa80d6d"
+    },
+    "22": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.4/builds/22/downloads/folia-1.20.4-22.jar",
+      "sha256": "f2798397e563bc8cab16425fbf68aa1fa671eb2bbb863f91873f435550f71596"
+    },
+    "23": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.4/builds/23/downloads/folia-1.20.4-23.jar",
+      "sha256": "b8586810c70197434cf3b0fd7c5d9273b4d594363237f4bc424e8efbd26e0c9e"
+    },
+    "24": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.4/builds/24/downloads/folia-1.20.4-24.jar",
+      "sha256": "dd73cb1dc245feb4de2630c45e14c721e9ef17b61c983c245fc290758526548a"
+    },
+    "26": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.4/builds/26/downloads/folia-1.20.4-26.jar",
+      "sha256": "81950017d5a5ec265b695053459ba343927edfe1cc2240224ba784dd8e515623"
+    },
+    "27": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.4/builds/27/downloads/folia-1.20.4-27.jar",
+      "sha256": "4892b4984cbe374be958b465bd56a91c538eebbc45528bb8535c15c1919de640"
+    },
+    "28": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.4/builds/28/downloads/folia-1.20.4-28.jar",
+      "sha256": "06b0af819c9a9fbe0535d8a0a6ef5f4ce530e97dcf65fb041aa2998d3468068c"
+    },
+    "29": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.4/builds/29/downloads/folia-1.20.4-29.jar",
+      "sha256": "7797cb535c9154aac37207161251a5b6e8472537e0b08df1e21dc83133baa579"
+    },
+    "30": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.4/builds/30/downloads/folia-1.20.4-30.jar",
+      "sha256": "91e79557376125ccda94afaf0cd2e90ac2156a5c0cfe8c70eddf9a756f75ea8d"
+    },
+    "31": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.4/builds/31/downloads/folia-1.20.4-31.jar",
+      "sha256": "b0d55be3ba19cb6e040f0e7fba400e5224a271fbc7db73a9683aef7468425af9"
+    }
+  },
+  "1.20.6": {
+    "2": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.6/builds/2/downloads/folia-1.20.6-2.jar",
+      "sha256": "888ada440ede55253be0db1b96b3fd69b34a5bc9412654458a8907d747f82727"
+    },
+    "3": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.6/builds/3/downloads/folia-1.20.6-3.jar",
+      "sha256": "8e90cfc8129d3d6ca10531aaf5a029cf05a8c86506cbf6d50753c16638c33684"
+    },
+    "4": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.6/builds/4/downloads/folia-1.20.6-4.jar",
+      "sha256": "8e743ea68033bcba1daf6e8841368730b2cf283af3c35868a819ac63d8dd1553"
+    },
+    "5": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.6/builds/5/downloads/folia-1.20.6-5.jar",
+      "sha256": "915ef267705ccf8219a8c93fe0844244374c3091390aab51b66c1da9636c30c0"
+    },
+    "6": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.20.6/builds/6/downloads/folia-1.20.6-6.jar",
+      "sha256": "a30625d8824b03aae64898b001b46bdc4424b0e5caee1a370af7b444d8ec361a"
+    }
+  },
+  "1.21.4": {
+    "1": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.4/builds/1/downloads/folia-1.21.4-1.jar",
+      "sha256": "84e027fed2cdc931fb3a5b163c1f36404615d19af8b43cbe70238aaae582808f"
+    },
+    "4": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.4/builds/4/downloads/folia-1.21.4-4.jar",
+      "sha256": "51f6fedb9dfca4c408d0b34dc367dce5b403afaaef83d0bb47e608e59d7ffd26"
+    },
+    "6": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.4/builds/6/downloads/folia-1.21.4-6.jar",
+      "sha256": "dcf2333211c1468c8eddc482bc8549600818cc661a709124a79c752f8fa2ac3a"
+    }
+  },
+  "1.21.5": {
+    "1": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.5/builds/1/downloads/folia-1.21.5-1.jar",
+      "sha256": "9e97c9a177b9b76d98d4185371fc8515fa50b9723718a6c4878bfa4be167e411"
+    },
+    "2": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.5/builds/2/downloads/folia-1.21.5-2.jar",
+      "sha256": "c71af8dd571b0e789aea30e4b8dd07e32dbab7f44f3942c92ad2c29e27686836"
+    },
+    "3": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.5/builds/3/downloads/folia-1.21.5-3.jar",
+      "sha256": "d8af4bd229af459cc35fb8db50802132d6679120d8cc333dd00c697b807f2e73"
+    },
+    "4": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.5/builds/4/downloads/folia-1.21.5-4.jar",
+      "sha256": "bab41ae8244e5a327ad52cec7b0aa87320dbf4ae8fa27034ef6dd4e2024e107c"
+    },
+    "5": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.5/builds/5/downloads/folia-1.21.5-5.jar",
+      "sha256": "8e030f0041c20b5ceb9a06a7fef6cdd66be218abbacefebcd7d87ae7990196df"
+    },
+    "6": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.5/builds/6/downloads/folia-1.21.5-6.jar",
+      "sha256": "29a5512bc177e8fd20b958db81f779ed6ad14accb72a6c779010b71391780c3f"
+    },
+    "7": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.5/builds/7/downloads/folia-1.21.5-7.jar",
+      "sha256": "8960239dcf23d08446c952d500c9bc1571427b4c48178e64ce52a34a0563f4d5"
+    },
+    "8": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.5/builds/8/downloads/folia-1.21.5-8.jar",
+      "sha256": "1c84eedfa83e79b208e8667ecc48bd29edef1f39cc36d9283ad0a99119a7ae41"
+    },
+    "9": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.5/builds/9/downloads/folia-1.21.5-9.jar",
+      "sha256": "ff34a5089195534f0e1dd37eca75cf57b17f316b8aa5b4ab933bfa17779bf426"
+    },
+    "11": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.5/builds/11/downloads/folia-1.21.5-11.jar",
+      "sha256": "03afb1cce8408359da4e1ee00b3467d7f3a74440b0bcbdfab25d700c3d1d496a"
+    },
+    "12": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.5/builds/12/downloads/folia-1.21.5-12.jar",
+      "sha256": "ebeb8f2f9e97fd972c89ebc276bc547c6194c6542d3a1884e3cfef7228f69cdb"
+    }
+  },
+  "1.21.6": {
+    "1": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.6/builds/1/downloads/folia-1.21.6-1.jar",
+      "sha256": "ab42a98492bd25b111d5bb00a85d1e5414dcbf84b44269e9874068af6ed39dc2"
+    },
+    "2": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.6/builds/2/downloads/folia-1.21.6-2.jar",
+      "sha256": "a750fc1eef640c2d73345e176164daae34a0730ff9385fe4ecdf42f18f5d0a73"
+    },
+    "3": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.6/builds/3/downloads/folia-1.21.6-3.jar",
+      "sha256": "49a21eed49f6010411075b2fd68e2dd9ac6277c08202116b20b022ce07bd5523"
+    },
+    "4": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.6/builds/4/downloads/folia-1.21.6-4.jar",
+      "sha256": "639656cc358603f9cc3a34434f023dfc076cffd5325bc2aac5727eca1c200746"
+    },
+    "5": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.6/builds/5/downloads/folia-1.21.6-5.jar",
+      "sha256": "00d1aeb4cf00e8e4a5810dbd9ccdfc97bc3d189ab019f5a44fe3b6c36c2d6862"
+    },
+    "6": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.6/builds/6/downloads/folia-1.21.6-6.jar",
+      "sha256": "917a8abaa542c1d0ef0e969693e227a7bfe1c42e671aaa806309e00a64efc234"
+    }
+  },
+  "1.21.8": {
+    "2": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.8/builds/2/downloads/folia-1.21.8-2.jar",
+      "sha256": "ee4b2ffd1bb821760766422f7edc52af5e262fb9b4009f3d8c304c8bbc1b6abf"
+    },
+    "3": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.8/builds/3/downloads/folia-1.21.8-3.jar",
+      "sha256": "1c1bc5475c926aefc6c7dac426f361a1a6501cf13a52dd5a9572a4e638690725"
+    },
+    "4": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.8/builds/4/downloads/folia-1.21.8-4.jar",
+      "sha256": "6072b63af577632578cc3d4632e86422e8cbfd92a3840f9d9d6169e91b69ce24"
+    },
+    "5": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.8/builds/5/downloads/folia-1.21.8-5.jar",
+      "sha256": "06a99a637b3bfc1a2ea1b6788869bb130704daf43215c8a69cf70bf1361f4b21"
+    },
+    "6": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.8/builds/6/downloads/folia-1.21.8-6.jar",
+      "sha256": "233843cfd5001b6f658fcab549178d694cc37f0277d004ea295de0a94c57278f"
+    }
+  },
+  "1.21.11": {
+    "1": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.11/builds/1/downloads/folia-1.21.11-1.jar",
+      "sha256": "43f6cec8d96e6172cb646520039067d71fabd87600580cc0d676ee377d649a94"
+    },
+    "2": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.11/builds/2/downloads/folia-1.21.11-2.jar",
+      "sha256": "15e2a9dcca5f11f4aa02cf36a9d01ea2972ddaa5d479edeabc08bc83a32a48e3"
+    },
+    "3": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.11/builds/3/downloads/folia-1.21.11-3.jar",
+      "sha256": "787016fab2f83b365b8e14d8b22bbc1758e2630795ce8e42dff51d917726f757"
+    },
+    "4": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.11/builds/4/downloads/folia-1.21.11-4.jar",
+      "sha256": "e7d1c95ea083cb199400b96c2f40d54a3e2440a86019712799d55a7d948df1fb"
+    },
+    "5": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.11/builds/5/downloads/folia-1.21.11-5.jar",
+      "sha256": "e942a1b1c734285b00b3ad7e6138231916372ec2011dc0abb15f268cf33d7275"
+    },
+    "6": {
+      "url": "https://api.papermc.io/v2/projects/folia/versions/1.21.11/builds/6/downloads/folia-1.21.11-6.jar",
+      "sha256": "dd9024830591269724b5940324eda64f533e8318af77e30584411a0911311d70"
+    }
+  }
+}

--- a/pkgs/folia-servers/update.py
+++ b/pkgs/folia-servers/update.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python3 -p python3Packages.requests
+
+import json
+import requests
+from pathlib import Path
+from requests.adapters import HTTPAdapter, Retry
+
+ENDPOINT = "https://api.papermc.io/v2/projects/folia"
+
+TIMEOUT = 5
+RETRIES = 5
+
+class TimeoutHTTPAdapter(HTTPAdapter):
+    def __init__(self, *args, **kwargs):
+        self.timeout = TIMEOUT
+        if "timeout" in kwargs:
+            self.timeout = kwargs["timeout"]
+            del kwargs["timeout"]
+        super().__init__(*args, **kwargs)
+
+    def send(self, request, **kwargs):
+        timeout = kwargs.get("timeout")
+        if timeout is None:
+            kwargs["timeout"] = self.timeout
+        return super().send(request, **kwargs)
+
+
+def make_client():
+    http = requests.Session()
+    retries = Retry(total=RETRIES, backoff_factor=1, status_forcelist=[429, 500, 502, 503, 504])
+    http.mount('https://', TimeoutHTTPAdapter(max_retries=retries))
+    return http
+
+
+def get_game_versions(client):
+    print("Fetching game versions")
+    data = client.get(ENDPOINT).json()
+    return data["versions"]
+
+
+def get_builds(version, client):
+    print(f"Fetching builds for {version}")
+    data = client.get(f"{ENDPOINT}/versions/{version}/builds").json()
+    return data.get("builds", [])
+
+
+def main(lock, client):
+    output = {}
+    print("Starting fetch")
+
+    for version in get_game_versions(client):
+        version_builds = {}
+        for build in get_builds(version, client):
+            build_number = build["build"]
+            build_sha256 = build["downloads"]["application"]["sha256"]
+            build_filename = build["downloads"]["application"]["name"]
+            build_url = f"{ENDPOINT}/versions/{version}/builds/{build_number}/downloads/{build_filename}"
+            version_builds[build_number] = {
+                "url": build_url,
+                "sha256": build_sha256,
+            }
+        if version_builds:
+            output[version] = version_builds
+
+    json.dump(output, lock, indent=2)
+    lock.write("\n")
+
+
+if __name__ == "__main__":
+    folder = Path(__file__).parent
+    lock_path = folder / "lock.json"
+    main(open(lock_path, "w"), make_client())


### PR DESCRIPTION
Now that Folia has publicly downloadable builds, it seems easy enough to add Folia as a server option.
I've based it directly off ``paper-server``, and have added ``folia-server`` next to it.
The only tweak I've made was removing the JRE check, since Folia currently bases on 1.19 and above only.