### PR TITLE
module: per-server data dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,8 +340,8 @@ Module for hosting multiple servers at once. All of the following are under this
 
 #### `enable`
 
-If enabled, the servers in `services.minecraft-servers.servers` will be created and started as applicable. 
-The data for the servers will be loaded from and saved to `dataDir`, and any sockets will be put in `runDir`.
+If enabled, the servers in `services.minecraft-servers.servers` will be created and started as applicable.
+The data for the servers will be loaded from and saved to `servers.<name>.dataDir`, and any sockets will be put in `runDir`.
 
 #### `eula`
 
@@ -355,11 +355,13 @@ This will only work if the ports are specified in `servers.<name>.serverProperti
 Remember to change the ports if you running multiple servers.
 The module asserts that servers with `openFirewall` set do not have conflicting ports to try to catch this.
 
-#### `dataDir`
+#### `defaultDataDir`
 
-Directory to store the Minecraft servers. Defaults to `/srv/minecraft`.
+Defaults to `/srv/minecraft`.
 
-Each server will be under a subdirectory named after the server name, such as `/srv/minecraft/servername`.
+Sets the default value for `servers.<name>.dataDir`.
+
+Each server will be under a subdirectory named after the server name in this directory, such as `/srv/minecraft/servername`.
 
 #### `runDir`
 
@@ -386,6 +388,12 @@ This family of options govern individual servers, which will be created on boot.
 #### `servers.<name>.enable`
 
 Whether to enable this server. If set to false, does **NOT** delete any data in the data directory, just does not generate the service file.
+
+#### `servers.<name>.dataDir`
+
+Defaults to the value in `defaultDataDir`.
+
+This server will be under a subdirectory named after the server name in this directory, such as `/srv/minecraft/servername`.
 
 #### `servers.<name>.autoStart`
 

--- a/modules/minecraft-servers.nix
+++ b/modules/minecraft-servers.nix
@@ -218,12 +218,19 @@ let
   mkEnableOpt = description: mkBoolOpt' false description;
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "minecraft-servers" "dataDir" ]
+      [ "services" "minecraft-servers" "defaultDataDir" ]
+    )
+  ];
+
   options.services.minecraft-servers = {
     enable = mkEnableOpt ''
       If enabled, the servers in <option>services.minecraft-servers.servers</option>
       will be created and started as applicable.
       The data for the servers will be loaded from and
-      saved to <option>services.minecraft-servers.dataDir</option>
+      saved to <option>services.minecraft-servers.servers.<server>.dataDir</option>
     '';
 
     eula = mkEnableOpt ''
@@ -238,8 +245,8 @@ in
       Sets the default for <option>services.minecraft-servers.servers.<name>.openFirewall</option>.
     '';
 
-    dataDir = mkOpt' types.path "/srv/minecraft" ''
-      Directory to store the Minecraft servers.
+    defaultDataDir = mkOpt' types.path "/srv/minecraft" ''
+      Default directory to store the Minecraft servers.
       Each server will be under a subdirectory named after
       the server name in this directory, such as <literal>/srv/minecraft/servername</literal>.
     '';
@@ -324,6 +331,13 @@ in
                 If set to <literal>false</literal>, does NOT delete any data in the data directory,
                 just does not generate the service file.
               '';
+
+              dataDir =
+                mkOpt' types.path cfg.defaultDataDir
+                  "Directory to store this minecraft server under. Defaults to the value set in <literal>defaultDataDir</literal>
+                  This server will be under a subdirectory named after the server name in this directory, such as <literal>/srv/minecraft/servername</literal>.
+
+                ";
 
               autoStart = mkBoolOpt' true ''
                 Whether to start this server on boot.
@@ -653,7 +667,7 @@ in
       users = {
         users.minecraft = mkIf (cfg.user == "minecraft") {
           description = "Minecraft server service user";
-          home = cfg.dataDir;
+          home = cfg.defaultDataDir;
           createHome = true;
           homeMode = "770";
           isSystemUser = true;
@@ -672,9 +686,13 @@ in
         }
         {
           assertion =
-            config.services.minecraft-server.enable -> cfg.dataDir != config.services.minecraft-server.dataDir;
+            let
+              dataDirs = mapAttrsToList (name: conf: conf.dataDir) servers;
+            in
+            config.services.minecraft-server.enable
+            -> lib.all (dir: dir != config.services.minecraft-server.dataDir) dataDirs;
           message =
-            "`services.minecraft-servers.dataDir` and `services.minecraft-server.dataDir` conflict."
+            "`services.minecraft-servers.dataDir` and  `services.minecraft-server.<serverName>.dataDir` conflict."
             + " Set one to use a different data directory.";
         }
         {
@@ -719,7 +737,7 @@ in
         };
 
       systemd.tmpfiles.rules = mapAttrsToList (
-        name: _: "d '${cfg.dataDir}/${name}' 0770 ${cfg.user} ${cfg.group} - -"
+        name: config: "d '${config.dataDir}/${name}' 0770 ${cfg.user} ${cfg.group} - -"
       ) servers;
 
       systemd.sockets = pipe servers [
@@ -960,7 +978,7 @@ in
               TimeoutStopSec = "1min 15s";
 
               Restart = conf.restart;
-              WorkingDirectory = "${cfg.dataDir}/${name}";
+              WorkingDirectory = "${conf.dataDir}/${name}";
               User = cfg.user;
               Group = cfg.group;
               EnvironmentFile = mkIf (cfg.environmentFile != null) (toString cfg.environmentFile);


### PR DESCRIPTION
When running multiple Minecraft servers, it can be cumbersome to have every server's data stored in the same directory/disk. The current solution is to mount each server's directory to a specified disk using symlinks or mount points. This PR provides a simpler solution by letting them set the data directory for each server.

- Added `dataDir` option for each server
- Renamed the top-level `dataDir` to `defaultDataDir` to avoid confusion 
- Deprecated the top-level `dataDir` while redirecting it to`defaultDataDir` to avoid breaking existing configurations
- Updated the README  to reflect these changes
- Modified the check against `minecraft-server.dataDir` to check against all defined servers for conflicting paths 

An example config now looks like
```nix
{ pkgs, ... }: {
  services.minecraft-servers = {
    eula = true;
    enable = true;
    defaultDataDir = "/drive1/minecraft-servers/";
    servers = {
      server1 = {
        # dataDir = defaultDataDir # Default value for dataDir if not user defined
        ...
      };
      server2 = {
        dataDir = "/drive2/minecraft-servers/";
        ...
      };
    };
  };
}
```