### PR TITLE
tools/fetchModrinthModpack: skip mods with "unknown" env value

### DIFF
--- a/pkgs/tools/fetchModrinthModpack/default.nix
+++ b/pkgs/tools/fetchModrinthModpack/default.nix
@@ -90,7 +90,7 @@ let
           while IFS= read -r file; do
             if [ "${side}" != "both" ]; then
               envState=$(echo "$file" | jq -r --arg side "${side}" '.env[$side] // "required"')
-              if [ "$envState" = "unsupported" ]; then
+              if [ "$envState" = "unsupported" ] || [ "$envState" = "unknown" ]; then
                 continue
               fi
             fi


### PR DESCRIPTION
Ran into an issue while creating a server that uses the [Create+](https://modrinth.com/modpack/create_plus?version=1.21.1&loader=neoforge) modpack from Modrinth using the `fetchModrinthModpack` function. Certain mods in this pack have both "client" and "server" set to "unknown" which this function doesn't check for. This caused my server to crash because the mods with this value were client-side only.

Not sure what the best way would be to deal with this issue. This PR simply skips any mods with a value of "unknown" which fixes the issue but maybe there's a better way of dealing with this?